### PR TITLE
Adding echoing the qsub return code.

### DIFF
--- a/tests/cluster_tests/test_qsubs.sh
+++ b/tests/cluster_tests/test_qsubs.sh
@@ -10,6 +10,7 @@ popd
 
 wait_lines ()
 {
+    echo Return code: $?
     LS_DATA="$1"
     COUNT="$2"
     NAME="$3"

--- a/tests/cluster_tests/test_qsubs.sh
+++ b/tests/cluster_tests/test_qsubs.sh
@@ -7,7 +7,6 @@ pushd ../../framework
 RAVEN_FRAMEWORK_DIR=$(pwd)
 popd
 
-
 wait_lines ()
 {
     echo Return code: $?
@@ -19,6 +18,11 @@ wait_lines ()
     if test $lines -ne $COUNT; then
         echo Lines not here yet, waiting longer.
         sleep 20 #Sleep in case this is just disk propagation
+        lines=`ls $LS_DATA | wc -l`
+    fi
+    if test $lines -ne $COUNT; then
+        echo Lines not here yet, waiting even longer.
+        sleep 60 #Sleep in case this is just disk propagation
         lines=`ls $LS_DATA | wc -l`
     fi
     if test $lines -eq $COUNT; then

--- a/tests/cluster_tests/torque_test.sh
+++ b/tests/cluster_tests/torque_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 num_fails=0
-failed_runs="FAILED: "
+fails=''
 
 pushd ../../framework
 RAVEN_FRAMEWORK_DIR=$(pwd)
@@ -20,12 +20,17 @@ wait_lines ()
         sleep 20 #Sleep in case this is just disk propagation
         lines=`ls $LS_DATA | wc -l`
     fi
+    if test $lines -ne $COUNT; then
+        echo Lines not here yet, waiting even longer.
+        sleep 60 #Sleep in case this is just disk propagation
+        lines=`ls $LS_DATA | wc -l`
+    fi
     if test $lines -eq $COUNT; then
         echo PASS $NAME
     else
         echo FAIL $NAME
+        fails=$fails', '$NAME
         num_fails=$(($num_fails+1))
-        failed_runs="$failed_runs $NAME"
         printf '\n\nStandard Error:\n'
         cat $RAVEN_FRAMEWORK_DIR/test_qsub.e*
         printf '\n\nStandard Output:\n'
@@ -160,7 +165,6 @@ cd ..
 if test $num_fails -eq 0; then
     echo ALL PASSED
 else
-    echo $failed_runs
-    echo FAILED: $num_fails
+    echo FAILED: $num_fails $fails
 fi
 exit $num_fails

--- a/tests/cluster_tests/torque_test.sh
+++ b/tests/cluster_tests/torque_test.sh
@@ -9,6 +9,7 @@ popd
 
 wait_lines ()
 {
+    echo Return code: $?
     LS_DATA="$1"
     COUNT="$2"
     NAME="$3"


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #125 

##### What are the significant changes in functionality due to this change request?
This just adds echoing the return code.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
