### PR TITLE
Misc Image Differ fixes

### DIFF
--- a/scripts/TestHarness/testers/RAVENImageDiff.py
+++ b/scripts/TestHarness/testers/RAVENImageDiff.py
@@ -76,15 +76,18 @@ class ImageDiff:
       except IOError as e:
         self.__messages += 'Unrecognized file type for test image in scipy.imread: '+testFilename
         filesRead = False
+        return (False, self.__messages)
       try:
         goldImage = imread(open(goldFilename,'r'))
       except IOError as e:
         filesRead = False
         self.__messages += 'Unrecognized file type for test image in scipy.imread: '+goldFilename
+        return (False, self.__messages)
       #first check dimensionality
       if goldImage.shape != testImage.shape:
-        self.__messages += 'Gold and test image are not the same shape: '+str(goldImage.shape)+', '+testImage.shape
+        self.__messages += 'Gold and test image are not the same shape: '+str(goldImage.shape)+', '+str(testImage.shape)
         self.__same = False
+        return (self.__same, self.__messages)
       #set default options
       DU.setDefaultOptions(self.__options)
       #pixelwise comparison


### PR DESCRIPTION
return from some failure conditions, instead of trying to continue executing.

Closes #166

--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., )
#166

##### What are the significant changes in functionality due to this change request?
Fixes some issues with the image differ.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
