### PR TITLE
Correcting location of generated html code coverage report to be in tests/framework

### DIFF
--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -91,7 +91,8 @@ cd ../PostProcessors/TopologicalPostProcessor
 coverage run $EXTRA $FRAMEWORK_DIR/Driver.py test_topology_ui.xml interactiveCheck
 cd ../DataMiningPostProcessor/Clustering/
 coverage run $EXTRA $FRAMEWORK_DIR/Driver.py hierarchical_ui.xml interactiveCheck
-cd ../../../../../
 
+## Go to the final directory and generate the html documents
+cd $SCRIPT_DIR/tests/framework
 coverage html
 

--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -94,5 +94,6 @@ coverage run $EXTRA $FRAMEWORK_DIR/Driver.py hierarchical_ui.xml interactiveChec
 
 ## Go to the final directory and generate the html documents
 cd $SCRIPT_DIR/tests/framework
+pwd
 coverage html
 


### PR DESCRIPTION

--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Follow-up to #165.

##### What are the significant changes in functionality due to this change request?

This should point the code coverage report to be generated in the appropriate directory.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code. *Done (only code coverage script is modified*
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts). *No changes*
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details. *Yes*
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass. *Yes*
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True. *No significant functionality added*
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync. *No change*
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.  *Refs an issue*
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added? *No change*
