### PR TITLE
modified interfaces to be agnostics with respect to the sampler type

### DIFF
--- a/framework/CodeInterfaces/MAAP5/MAAP5Interface.py
+++ b/framework/CodeInterfaces/MAAP5/MAAP5Interface.py
@@ -81,7 +81,7 @@ class MAAP5(GenericCode):
       @ Out, newInputFiles, list, list of newer input files, list of the new input files (modified and not)
     """
     self.samplerType=samplerType
-    if 'DynamicEventTree' in samplerType:
+    if 'dynamiceventtree' in str(samplerType).lower():
       if Kwargs['parentID'] == 'root':
         self.oriInput(oriInputFiles) #original input files are checked only the first time
       self.stopSimulation(currentInputFiles, Kwargs)

--- a/framework/CodeInterfaces/MooseBasedApp/MooseBasedAppInterface.py
+++ b/framework/CodeInterfaces/MooseBasedApp/MooseBasedAppInterface.py
@@ -72,19 +72,12 @@ class MooseBasedApp(CodeInterfaceBase):
       @ Out, newInputFiles, list, list of newer input files, list of the new input files (modified and not)
     """
     import MOOSEparser
-    self._samplersDictionary                          = {}
-    self._samplersDictionary['MonteCarlo'           ] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['Grid'                 ] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['Stratified'           ] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['DynamicEventTree'     ] = self.dynamicEventTreeForMooseBasedApp
-    self._samplersDictionary['StochasticCollocation'] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['FactorialDesign'      ] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['ResponseSurfaceDesign'] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['LimitSurfaceSearch'   ] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['SparseGridCollocation'] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['EnsembleForward'      ] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['CustomSampler'        ] = self.pointSamplerForMooseBasedApp
-    self._samplersDictionary['None'                 ] = self.pointSamplerForMooseBasedApp #for SingleRun case
+    self._samplersDictionary                = {}
+    if 'dynamiceventtree' in samplerType.lower():
+      self._samplersDictionary[samplerType] = self.dynamicEventTreeForMooseBasedApp
+    else:
+      self._samplersDictionary[samplerType] = self.pointSamplerForMooseBasedApp
+
     found = False
     for index, inputFile in enumerate(currentInputFiles):
       inputFile = inputFile.getAbsFile()

--- a/framework/CodeInterfaces/MooseBasedApp/MooseBasedAppInterface.py
+++ b/framework/CodeInterfaces/MooseBasedApp/MooseBasedAppInterface.py
@@ -73,7 +73,7 @@ class MooseBasedApp(CodeInterfaceBase):
     """
     import MOOSEparser
     self._samplersDictionary                = {}
-    if 'dynamiceventtree' in samplerType.lower():
+    if 'dynamiceventtree' in str(samplerType).lower():
       self._samplersDictionary[samplerType] = self.dynamicEventTreeForMooseBasedApp
     else:
       self._samplersDictionary[samplerType] = self.pointSamplerForMooseBasedApp

--- a/framework/CodeInterfaces/RELAP5/Relap5Interface.py
+++ b/framework/CodeInterfaces/RELAP5/Relap5Interface.py
@@ -132,18 +132,11 @@ class Relap5(CodeInterfaceBase):
       @ Out, newInputFiles, list, list of newer input files, list of the new input files (modified and not)
     """
     import RELAPparser
-    self._samplersDictionary                          = {}
-    self._samplersDictionary['MonteCarlo'           ] = self.pointSamplerForRELAP5
-    self._samplersDictionary['Grid'                 ] = self.pointSamplerForRELAP5
-    self._samplersDictionary['Stratified'           ] = self.pointSamplerForRELAP5
-    self._samplersDictionary['Adaptive'             ] = self.pointSamplerForRELAP5
-    self._samplersDictionary['FactorialDesign'      ] = self.pointSamplerForRELAP5
-    self._samplersDictionary['ResponseSurfaceDesign'] = self.pointSamplerForRELAP5
-    self._samplersDictionary['DynamicEventTree'     ] = self.DynamicEventTreeForRELAP5
-    self._samplersDictionary['BnBDynamicEventTree'  ] = self.DynamicEventTreeForRELAP5
-    self._samplersDictionary['StochasticCollocation'] = self.pointSamplerForRELAP5
-    self._samplersDictionary['EnsembleForward'      ] = self.pointSamplerForRELAP5
-    self._samplersDictionary['CustomSampler'        ] = self.pointSamplerForRELAP5
+    self._samplersDictionary                = {}
+    if 'dynamiceventtree' in samplerType.lower():
+      self._samplersDictionary[samplerType] = self.DynamicEventTreeForRELAP5
+    else:
+      self._samplersDictionary[samplerType] = self.pointSamplerForRELAP5
 
     found = False
     for index, inputFile in enumerate(currentInputFiles):

--- a/framework/CodeInterfaces/RELAP5/Relap5Interface.py
+++ b/framework/CodeInterfaces/RELAP5/Relap5Interface.py
@@ -133,7 +133,7 @@ class Relap5(CodeInterfaceBase):
     """
     import RELAPparser
     self._samplersDictionary                = {}
-    if 'dynamiceventtree' in samplerType.lower():
+    if 'dynamiceventtree' in str(samplerType).lower():
       self._samplersDictionary[samplerType] = self.DynamicEventTreeForRELAP5
     else:
       self._samplersDictionary[samplerType] = self.pointSamplerForRELAP5

--- a/framework/CodeInterfaces/RELAP7/RELAP7Interface.py
+++ b/framework/CodeInterfaces/RELAP7/RELAP7Interface.py
@@ -73,6 +73,7 @@ class RELAP7(CodeInterfaceBase):
     """
     MOOSEparser = utils.importFromPath(os.path.join(os.path.join(uppath(os.path.dirname(__file__),1),'MooseBasedApp'),'MOOSEparser.py'),False)
     self._samplersDictionary                             = {}
+    self._samplersDictionary[samplerType]                = self.gridForRELAP7
     self._samplersDictionary['MonteCarlo'              ] = self.monteCarloForRELAP7
     self._samplersDictionary['Grid'                    ] = self.gridForRELAP7
     self._samplersDictionary['LimitSurfaceSearch'      ] = self.gridForRELAP7 # same Grid Fashion. It forces a dist to give a particular value
@@ -80,9 +81,10 @@ class RELAP7(CodeInterfaceBase):
     self._samplersDictionary['DynamicEventTree'        ] = self.dynamicEventTreeForRELAP7
     self._samplersDictionary['FactorialDesign'         ] = self.gridForRELAP7
     self._samplersDictionary['ResponseSurfaceDesign'   ] = self.gridForRELAP7
-    self._samplersDictionary['AdaptiveDynamicEventTree'] = self.adaptiveDynamicEventTreeForRELAP7
+    self._samplersDictionary['AdaptiveDynamicEventTree'] = self.dynamicEventTreeForRELAP7
     self._samplersDictionary['StochasticCollocation'   ] = self.gridForRELAP7
     self._samplersDictionary['CustomSampler'           ] = self.gridForRELAP7
+
     found = False
     for index, inputFile in enumerate(currentInputFiles):
       if inputFile.getExt() in self.getInputExtension():
@@ -126,17 +128,6 @@ class RELAP7(CodeInterfaceBase):
     RNGSeed = int(counter) + int(initSeed) - 1
     modifDict[b'RNG_seed'] = str(RNGSeed)
     listDict.append(modifDict)
-    return listDict
-
-  def adaptiveDynamicEventTreeForRELAP7(self,**Kwargs):
-    """
-      This method is used to create a list of dictionaries that can be interpreted by the input Parser
-      in order to change the input file based on the information present in the Kwargs dictionary.
-      This is specific for Adaptive DET sampler
-      @ In, **Kwargs, dict, kwared dictionary containing the values of the parameters to be changed
-      @ Out, listDict, list, list of dictionaries used by the parser to change the input file
-    """
-    listDict = self.dynamicEventTreeForRELAP7(**Kwargs)
     return listDict
 
   def dynamicEventTreeForRELAP7(self,**Kwargs):


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #180 
Closes #35
##### What are the significant changes in functionality due to this change request?
Just interface

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.  __All the changes have been reviewed and make the code more simple__
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).  __No Change__
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details. __Compliant__
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass. __Passed!__
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True. __No Change__
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync. __No Change__
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done. __Closes #180 and #35__
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added? __No Change__
