### PR TITLE
conda env script

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#Similar to setup_raven_libs.sh, but installs libraries, not just opens environment
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+conda_install_or_create ()
+{
+  if conda env list | grep -q raven_libraries;
+  then
+    echo ... RAVEN environment located, checking packages ...
+    `python $SCRIPT_DIR/TestHarness/testers/RavenUtils.py --conda-install`
+  else
+    echo ... No RAVEN environment located, creating it ...
+    try_using_raven_environment
+    `python $SCRIPT_DIR/TestHarness/testers/RavenUtils.py --conda-create`
+  fi
+}
+
+try_using_raven_environment ()
+{
+  #First check home directory for a script, then /opt/raven_libs
+  if test -e $HOME/.raven/environments/raven_libs_profile;
+    then
+  source $HOME/.raven/environments/raven_libs_profile
+    else
+  if test -e /opt/raven_libs/environments/raven_libs_profile;
+  then
+      source /opt/raven_libs/environments/raven_libs_profile
+  fi
+    fi
+}
+
+if which conda 2> /dev/null;
+then
+  echo conda located, checking environments ...
+  conda_install_or_create
+else
+  echo conda not initially located, checking for RAVEN conda ...
+  try_using_raven_environment
+  if which conda 2> /dev/null;
+  then
+    echo conda located, checking environments ...
+    conda_install_or_create
+  else
+    echo No conda found!  Unable to ensure RAVEN environment and libraries exist.
+  fi
+fi


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Working towards #182.  This script is needed to enable RAVEN to use pandas and xarrays.

##### What are the significant changes in functionality due to this change request?
Script sets up the raven_libraries conda environment preparatory to running raven.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code. *Done*
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts). *No changes to input syntax*
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details. *Yes*
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass. *Waiting*
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True. *Will be covered by regular tests when this is added*
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync. *No changes*
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done. *Refs an issue*
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
*No change*

When the automated tests pass, this passes.