### PR TITLE
Addresses issue #82

### DIFF
--- a/framework/DataObjects/HistorySet.py
+++ b/framework/DataObjects/HistorySet.py
@@ -531,18 +531,18 @@ class HistorySet(Data):
       inpValues.append(inpValues_h)
       dataFilename = mainLineList[-1]
       subCSVFilename = os.path.join(filenameRoot,dataFilename)
-      myDataFile = open(subCSVFilename, "rU")
       subCSVFile = Files.returnInstance("CSV", self)
       subCSVFile.setFilename(subCSVFilename)
       self._toLoadFromList.append(subCSVFile)
-      header = myDataFile.readline().rstrip()
-      outKeys_h = header.split(",")
-      outValues_h = [[] for a in range(len(outKeys_h))]
-      for line in myDataFile.readlines():
-        lineList = line.rstrip().split(",")
-        for i in range(len(outKeys_h)):
-          outValues_h[i].append(utils.partialEval(lineList[i]))
-      myDataFile.close()
+      with open(subCSVFilename, "rU") as myDataFile:
+        header = myDataFile.readline().rstrip()
+        outKeys_h = header.split(",")
+        outValues_h = [[] for a in range(len(outKeys_h))]
+        for line in myDataFile.readlines():
+          lineList = line.rstrip().split(",")
+          for i in range(len(outKeys_h)):
+            outValues_h[i].append(utils.partialEval(lineList[i]))
+        myDataFile.close()
       outKeys.append(outKeys_h)
       outValues.append(outValues_h)
     self._dataContainer['inputs'] = {} #XXX these are indexed by 1,2,...

--- a/framework/Files.py
+++ b/framework/Files.py
@@ -129,7 +129,8 @@ class File(BaseType):
       @ In, None
       @ Out, __file, object, file object
     """
-    self.__file.open(self.getAbsFile())
+    if not self.isOpen():
+      self.open()
     return self.__file
 
   def __exit__(self,*args):


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #82

##### What are the significant changes in functionality due to this change request?

The RAVEN FileObject could not be used with the ```with``` statement. This PR fixes it and modify a small portion of the code to use it.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code. *Done*
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts). *No changes*
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details. *Respected*
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass. *Waiting*
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True. *No significant functionality added*
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync. *No changes*
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done. *Closes*
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added? *No changes*
