### PR TITLE
Switches to using repr instead of ET.toString

### DIFF
--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -754,7 +754,7 @@ class Simulation(MessageHandler.MessageUser):
       else:
         #tag not in whichDict, check if it's a documentation tag
         if child.tag not in ['TestInfo']:
-          self.raiseAnError(IOError,'the '+child.tag+' is not among the known simulation components '+repr(child))
+          self.raiseAnError(IOError,'<'+child.tag+'> is not among the known simulation components '+repr(child))
     # If requested, duplicate input
     # ###NOTE: All substitutions to the XML input tree should be done BEFORE this point!!
     if self.runInfoDict.get('printInput',False):

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -754,7 +754,7 @@ class Simulation(MessageHandler.MessageUser):
       else:
         #tag not in whichDict, check if it's a documentation tag
         if child.tag not in ['TestInfo']:
-          self.raiseAnError(IOError,'the '+child.tag+' is not among the known simulation components '+ET.tostring(child))
+          self.raiseAnError(IOError,'the '+child.tag+' is not among the known simulation components '+repr(child))
     # If requested, duplicate input
     # ###NOTE: All substitutions to the XML input tree should be done BEFORE this point!!
     if self.runInfoDict.get('printInput',False):

--- a/framework/utils/TreeStructure.py
+++ b/framework/utils/TreeStructure.py
@@ -428,6 +428,11 @@ class InputNode:
     return len(self.children)
 
   def __getitem__(self, index):
+    """
+      Returns a specific child node.
+      @ In, index, int, the index for the child
+      @ Out, __getitem__, InputNode, the child
+    """
     return self.children[index]
 
   def __repr__(self):
@@ -545,6 +550,11 @@ class InputNode:
     self.children.remove(node)
 
   def items(self):
+    """
+      Gets all the children in the tree.
+      @ In, None
+      @ Out, children, list, list of all the children.
+    """
     return self.children
 
 class HierarchicalNode(MessageHandler.MessageUser):

--- a/framework/utils/TreeStructure.py
+++ b/framework/utils/TreeStructure.py
@@ -406,7 +406,7 @@ class InputNode:
       @ In, None
       @ Out, hash, tuple, name and values and text
     """
-    return hash(tuple(self.tag,tuple(sorted(self.attrib.items())),self.text))
+    return hash(tuple((self.tag,tuple(sorted(self.attrib.items())),self.text)))
 
   def __iter__(self):
     """
@@ -426,6 +426,9 @@ class InputNode:
       @ Out, __len__, int, number of children
     """
     return len(self.children)
+
+  def __getitem__(self, index):
+    return self.children[index]
 
   def __repr__(self):
     """
@@ -540,6 +543,9 @@ class InputNode:
       @ Out, None
     """
     self.children.remove(node)
+
+  def items(self):
+    return self.children
 
 class HierarchicalNode(MessageHandler.MessageUser):
   """

--- a/tests/framework/ErrorChecks/badInSimulation.xml
+++ b/tests/framework/ErrorChecks/badInSimulation.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<Simulation>
+  <RunInfo>
+    <WorkingDir>.</WorkingDir>
+    <Sequence>nothere</Sequence>
+  </RunInfo>
+  <steps>
+  </steps>
+</Simulation>

--- a/tests/framework/ErrorChecks/tests
+++ b/tests/framework/ErrorChecks/tests
@@ -25,6 +25,12 @@
         expect_err = 'IOError: Invalid data in input file:'
  [../]
 
+ [./badInSimulation]
+        type = 'RavenErrors'
+        input = 'badInSimulation.xml'
+        expect_err = 'IOError: <steps> is not among the known simulation components'
+ [../]
+
  [./unsyncedTypicalHistory]
         type = 'RavenErrors'
         input = 'unsyncedTypicalHistory.xml'


### PR DESCRIPTION
The child is a InputNode, not a ElementNode.

Also, added __getitem__ and items and fixed __hash__

Closes #254

--------
Pull Request Description
--------
##### What issue does this change request address?
#254 


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
