### PR TITLE
external models readXML, initialize, and createNewInput

### DIFF
--- a/framework/Models/Dummy.py
+++ b/framework/Models/Dummy.py
@@ -140,9 +140,9 @@ class Dummy(Model):
 
     if 'SampledVars' in kwargs.keys():
       sampledVars = self._replaceVariablesNamesWithAliasSystem(kwargs['SampledVars'],'input',False)
+      for key in kwargs['SampledVars'].keys():
+        inputDict[key] = np.atleast_1d(kwargs['SampledVars'][key])
 
-    for key in kwargs['SampledVars'].keys():
-      inputDict[key] = np.atleast_1d(kwargs['SampledVars'][key])
     for val in inputDict.values():
       if val is None:
         self.raiseAnError(IOError,'While preparing the input for the model '+self.type+' with name '+self.name+' found a None input variable '+ str(inputDict.items()))

--- a/framework/Models/ExternalModel.py
+++ b/framework/Models/ExternalModel.py
@@ -112,7 +112,7 @@ class ExternalModel(Dummy):
     if 'createNewInput' in dir(self.sim):
       if 'SampledVars' in kwargs.keys():
         sampledVars = self._replaceVariablesNamesWithAliasSystem(kwargs['SampledVars'],'input',False)
-      extCreateNewInput = self.sim.createNewInput(self,myInput,samplerType,**kwargs)
+      extCreateNewInput = self.sim.createNewInput(self.initExtSelf,myInput,samplerType,**kwargs)
       if extCreateNewInput== None:
         self.raiseAnError(AttributeError,'in external Model '+self.ModuleToLoad+' the method createNewInput must return something. Got: None')
       if type(extCreateNewInput).__name__ != "dict":
@@ -128,8 +128,9 @@ class ExternalModel(Dummy):
       newInput = ([(extCreateNewInput)],copy.deepcopy(kwargs))
     else:
       newInput =  Dummy.createNewInput(self, myInput,samplerType,**kwargs)
-    for key in kwargs['SampledVars'].keys():
-      modelVariableValues[key] = kwargs['SampledVars'][key]
+    if 'SampledVars' in kwargs.keys():
+      for key in kwargs['SampledVars'].keys():
+        modelVariableValues[key] = kwargs['SampledVars'][key]
     return newInput, copy.copy(modelVariableValues)
 
   def localInputAndChecks(self,xmlNode):

--- a/framework/Optimizers/Optimizer.py
+++ b/framework/Optimizers/Optimizer.py
@@ -634,7 +634,7 @@ class Optimizer(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
         if precond is not None:
           self.raiseADebug('Running preconditioner on batch "{}"'.format(precondBatch))
           # TODO someday this might need to be extended when other models or more complex external models are used for precond
-          precond.createNewInput([],'Optimizer')
+          precond.createNewInput([{}],'Optimizer')
           infoDict = {'SampledVars':self.denormalizeData(optPoint)}
           _,(results,_) = precond.evaluateSample([infoDict['SampledVars']],'Optimizer',infoDict)
           # flatten results #TODO breaks for multi-entry arrays

--- a/framework/Optimizers/Optimizer.py
+++ b/framework/Optimizers/Optimizer.py
@@ -423,6 +423,7 @@ class Optimizer(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
       if cls != 'Models' or typ != 'ExternalModel':
         self.raiseAnError(IOError,'Currently only "ExternalModel" models can be used as preconditioners! Got "{}.{}" for "{}".'.format(cls,typ,name))
       self.preconditioners[name] = model
+      model.initialize({},[])
 
     self.mdlEvalHist = self.assemblerDict['TargetEvaluation'][0][3]
     # check if the TargetEvaluation feature and target spaces are consistent
@@ -632,6 +633,8 @@ class Optimizer(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
         precond = self.mlPreconditioners.get(precondBatch,None)
         if precond is not None:
           self.raiseADebug('Running preconditioner on batch "{}"'.format(precondBatch))
+          # TODO someday this might need to be extended when other models or more complex external models are used for precond
+          precond.createNewInput([],'Optimizer')
           infoDict = {'SampledVars':self.denormalizeData(optPoint)}
           _,(results,_) = precond.evaluateSample([infoDict['SampledVars']],'Optimizer',infoDict)
           # flatten results #TODO breaks for multi-entry arrays


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #286 

##### What are the significant changes in functionality due to this change request?
Assures all the externalModel methods are called even when used as a preconditioner in the optimizer.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
