### PR TITLE
clearing old held outputs

### DIFF
--- a/framework/Models/EnsembleModel.py
+++ b/framework/Models/EnsembleModel.py
@@ -467,12 +467,20 @@ class EnsembleModel(Dummy):
         for key in exportDict['metadata']:
           output.updateMetadata(key,exportDict['metadata'][key][-1])
     # collect outputs for "holding"
-    if "holdOutputErase" in exportDict['metadata']:
-      if exportDict['metadata']['holdOutputErase'] is not None:
-        keys = self.tempOutputs['forHold'].keys()
-        for key in keys:
-          if key.startswith(exportDict['metadata']['holdOutputErase'][0]):
-            self.tempOutputs['forHold'].pop(key)
+    # first clear old outputs
+    # TODO FIXME this is a flawed implementation, since it requires that the "holdOutputErase" is of
+    # a very specific form that works with the the current SPSA optimizer.  Since we have no other optimizer right now,
+    # the problem is only extensibility, not the actual implementation.
+    if exportDict['metadata'].get('holdOutputErase',None) is not None:
+      #if exportDict['metadata']['holdOutputErase'] is not None:
+      keys = self.tempOutputs['forHold'].keys()
+      toErase = exportDict['metadata']['holdOutputErase'][0].split('_')[:2]
+      for key in keys:
+        traj,itr,pert = key.split('_')
+        if traj == toErase[0] and itr <= toErase[1]:
+          self.tempOutputs['forHold'].pop(key)
+    #then hold on to the current output
+    #TODO we shouldn't be doing this unless the user asked us to hold outputs!  FIXME
     self.tempOutputs['forHold'][finishedJob.identifier] = {'outs':optionalOutputs,'targetEvaluations':targetEvaluations}
 
   def getAdditionalInputEdits(self,inputInfo):

--- a/framework/Models/EnsembleModel.py
+++ b/framework/Models/EnsembleModel.py
@@ -472,13 +472,12 @@ class EnsembleModel(Dummy):
     # a very specific form that works with the the current SPSA optimizer.  Since we have no other optimizer right now,
     # the problem is only extensibility, not the actual implementation.
     if exportDict['metadata'].get('holdOutputErase',None) is not None:
-      #if exportDict['metadata']['holdOutputErase'] is not None:
       keys = self.tempOutputs['forHold'].keys()
       toErase = exportDict['metadata']['holdOutputErase'][0].split('_')[:2]
       for key in keys:
         traj,itr,pert = key.split('_')
         if traj == toErase[0] and itr <= toErase[1]:
-          self.tempOutputs['forHold'].pop(key)
+          del self.tempOutputs['forHold'][key]
     #then hold on to the current output
     #TODO we shouldn't be doing this unless the user asked us to hold outputs!  FIXME
     self.tempOutputs['forHold'][finishedJob.identifier] = {'outs':optionalOutputs,'targetEvaluations':targetEvaluations}

--- a/framework/Optimizers/Optimizer.py
+++ b/framework/Optimizers/Optimizer.py
@@ -792,12 +792,15 @@ class Optimizer(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
       if not model.acceptHoldOutputSpace():
         self.raiseAnError(RuntimeError,'The user requested to hold a certain output space but the model "'+model.name+'" does not allow it!')
       # try to hold this output variables (multilevel)
-      self.inputInfo['holdOutputSpace'] = [staticOutputVars,self.getPreviousIdentifierGivenCurrent(self.inputInfo['prefix'])]
-      self.inputInfo["holdOutputErase"] = None
+      #appears to be redundant code
+      #self.inputInfo['holdOutputSpace'] = [staticOutputVars,self.getPreviousIdentifierGivenCurrent(self.inputInfo['prefix'])]
+      #self.inputInfo["holdOutputErase"] = None
     #else:
-      if "holdOutputSpace" in self.inputInfo:
-        self.inputInfo.pop("holdOutputSpace")
-      self.inputInfo["holdOutputErase"] = self._createEvaluationIdentifier(traj,self.counter['varsUpdate'][traj]-1,"")
+      #if "holdOutputSpace" in self.inputInfo:
+      #  self.inputInfo.pop("holdOutputSpace")
+      # PROBLEM: rejecting samples doesn't respect the varsUpdate-1, since varsUpdate stays the same
+      ID = self._createEvaluationIdentifier(traj,self.counter['varsUpdate'][traj]-1,"")
+      self.inputInfo["holdOutputErase"] = ID
     #### CONSTANT VARIABLES ####
     if len(self.constants) > 0:
       self.values.update(self.constants)

--- a/framework/Optimizers/Optimizer.py
+++ b/framework/Optimizers/Optimizer.py
@@ -792,13 +792,6 @@ class Optimizer(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
       if not model.acceptHoldOutputSpace():
         self.raiseAnError(RuntimeError,'The user requested to hold a certain output space but the model "'+model.name+'" does not allow it!')
       # try to hold this output variables (multilevel)
-      #appears to be redundant code
-      #self.inputInfo['holdOutputSpace'] = [staticOutputVars,self.getPreviousIdentifierGivenCurrent(self.inputInfo['prefix'])]
-      #self.inputInfo["holdOutputErase"] = None
-    #else:
-      #if "holdOutputSpace" in self.inputInfo:
-      #  self.inputInfo.pop("holdOutputSpace")
-      # PROBLEM: rejecting samples doesn't respect the varsUpdate-1, since varsUpdate stays the same
       ID = self._createEvaluationIdentifier(traj,self.counter['varsUpdate'][traj]-1,"")
       self.inputInfo["holdOutputErase"] = ID
     #### CONSTANT VARIABLES ####


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #295.

##### What are the significant changes in functionality due to this change request?
Patches (not truly fixes) the storage problem mentioned in issue #295.

I discovered that when a potential new optimal point is rejected, it somehow fails to trigger old output removal until a new optimal point is accepted.  The patch is to clear all old outputs that are held once a new point is accepted.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
