### PR TITLE
Fixes documentation build process on Windows.

### DIFF
--- a/doc/make_docs.sh
+++ b/doc/make_docs.sh
@@ -22,8 +22,21 @@ done
 
 rm -Rvf pdfs
 
+
 # add custom, collective inputs to TEXINPUTS
-export TEXINPUTS=.:$SCRIPT_DIR/tex_inputs/:$TEXINPUTS
+#
+# Since on Windows we use MikTeX (which is a native Windows program), the TEXTINPUTS variable used i
+#   to tell the LaTeX processor where to look for .sty files must be set using Windows-style paths 
+#   (not the Unix-style ones used on other platforms).  This also means semi-colons need to be used 
+#   to separate terms instead of the Unix colon.
+#
+if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]
+then
+  export TEXINPUTS=.\;`cygpath -w $SCRIPT_DIR/tex_inputs`\;$TEXINPUTS
+else
+  export TEXINPUTS=.:$SCRIPT_DIR/tex_inputs/:$TEXINPUTS
+fi
+
 
 if git describe
 then

--- a/doc/user_guide/writeTex.py
+++ b/doc/user_guide/writeTex.py
@@ -80,8 +80,15 @@ if __name__=='__main__':
   fname = os.path.join(*fname.split('/'))
   print('reading dynamic XML from',fname)
   strNode = getNode(fname,nname)
-  outFile = file('raven_temp_tex_xml.tex','w')
-  printName = os.path.join('raven',fname.replace('../','')).replace('_','\_')
+  # In most cases, when writing text files 'w' should be used.  However, in this case the file is being fed directly to
+  #   a LaTeX processor.  On Windows, using 'w' mode will cause an extra line feed to be added which will be result in extra
+  #   line feeds when the XML is rendered into the user guide.
+  outFile = file('raven_temp_tex_xml.tex','wb')
+  # On windows the output of os.path.join will use backslashes as path separators, which gives LaTeX a problem.  Since printName is
+  #   being used to display the original file name, lets just convert it back to forward slashes.  That means we also have to 
+  #   remove '..\' as well as '../'.
+  printName = os.path.join('raven',fname.replace('../','')).replace('..\\','')
+  printName = printName.replace('\\','/').replace('_','\_')
   toWrite = '\\FloatBarrier\n'+\
             chooseSize(printName)+'\n\\texttt{'+printName+'}\n'+\
             chooseSize(strNode)+'\n'+\

--- a/doc/user_guide/writeTex.py
+++ b/doc/user_guide/writeTex.py
@@ -85,7 +85,7 @@ if __name__=='__main__':
   #   line feeds when the XML is rendered into the user guide.
   outFile = file('raven_temp_tex_xml.tex','wb')
   # On windows the output of os.path.join will use backslashes as path separators, which gives LaTeX a problem.  Since printName is
-  #   being used to display the original file name, lets just convert it back to forward slashes.  That means we also have to 
+  #   being used to display the original file name, lets just convert it back to forward slashes.  That means we also have to
   #   remove '..\' as well as '../'.
   printName = os.path.join('raven',fname.replace('../','')).replace('..\\','')
   printName = printName.replace('\\','/').replace('_','\_')
@@ -101,4 +101,3 @@ if __name__=='__main__':
              '\\normalsize'
   outFile.writelines(toWrite)
   outFile.close()
-


### PR DESCRIPTION
The manual build problem on Windows was traced to two issues in with the user guide build:

- A problem locating RAVEN.sty by the LaTeX processor due to how the value of TEXINPUTS is set by the make_docs.sh script.  This was corrected by adding a Windows-specific version that uses Windows-style paths and semicolons as separators instead of colons.

- When building XML files for inclusion in the user guide, script writeTex.py would include the path to the source file which was generated in a platform-independent manner.  However, on Windows backslashes were generated instead of forward slashes which caused problems for the LaTeX processor.  It was easiest to just change the backslashes back to forward slashes.  Also, the XML files were being generated with extra newlines.

Closes #298 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code. *Done*
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts). *No changes*
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details. *Yes*
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass. *pass*
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True. *No significant functionality (possibly we should test documentation changes on windows, but that would have other consequences*
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync. *No change*
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added? *No change*
