### PR TITLE
Update user manual to clarify how plot parameters x, y, z, colorMap are specified.

### DIFF
--- a/doc/user_manual/OutStreamSystem.tex
+++ b/doc/user_manual/OutStreamSystem.tex
@@ -953,14 +953,14 @@ Independent of the plot type, some keywords are mandatory:
 \begin{itemize}
   \item \xmlNode{type}, \xmlDesc{string, required parameter}, the plot type (for
   example, line, scatter, wireframe, etc.).
-  \item \xmlNode{x}, \xmlDesc{string, required parameter}, this parameter needs
-  to be considered as the x coordinate.
-  \item \xmlNode{y}, \xmlDesc{string, required parameter}, this parameter needs
-  to be considered as the y coordinate.
-  \item \xmlNode{z}, \xmlDesc{string required parameter (3D plots only)}, this
-  parameter needs to be considered as the z coordinate.
-  %
+  \item \xmlNode{x}, \xmlDesc{string, required parameter}, specifies the DataObject parameter to be plotted as the x coordinate.   
+	This parameter must be described in a specific manner, see Section \ref{subpara:plotVariables} below for details.
+  \item \xmlNode{y}, \xmlDesc{string, required parameter}, specifies the DataObject parameter to be plotted as the y coordinate.
+	This parameter must be described in a specific manner, see Section \ref{subpara:plotVariables} below for details.
+  \item \xmlNode{z}, \xmlDesc{string, required parameter for plots with three dimensions}, specifies the DataObject parameter to be plotted as the z coordinate.
+	This parameter must be described in a specific manner, see Section \ref{subpara:plotVariables} below for details.
 \end{itemize}
+%
 In addition, other plot-dependent keywords, reported in
 Section~\ref{sec:23Dplotting}, can be provided.
 
@@ -984,19 +984,34 @@ Under the \xmlNode{plot} sub-block other optional keywords can be specified, suc
         the second integer represents the number of nodes that this subplot occupies, i.e. in the example above the
         first subplot occupies a single node at the zero node in y direction.
   \end{itemize}
-  \item \xmlNode{colorMap}, \xmlDesc{string, optional parameter}, this parameter will be used to
-  define a color map.
+  \item \xmlNode{colorMap}, \xmlDesc{string, optional parameter}, specifies a DataObject parameter whose value will be used 
+	to vary the color of plotted points.  This parameter must be described in a specific manner, see Section \ref{subpara:plotVariables} 
+	below for details.
  \end{itemize}
 
+\subparagraph{Specifying What Values to Plot \label{subpara:plotVariables}}
 As already mentioned, the Plot system accepts as input for the visual parameters
 (i.e., x, y, z, colorMap), data only from a \textbf{DataObjects} object.
 %
-Considering the structure of ``DataObjects,'' the parameters are inputted as follows:
-\texttt{DataObjectName|Input(or)Output|variableName}.
+Considering the structure of "DataObjects", the parameters are specified as three values separated by the
+vertical bar character ('\texttt{|}') as follows:
+\\* \\* \centerline{\texttt{DataObject Name|Parameter Type|Parameter Name}}
+\\ \\  Where: 
+\begin{center}
+\begin{tabular}{ll}
+Value & Description \\ \hline
+\multicolumn{1}{|l|}{\texttt{DataObject Name}} & \multicolumn{1}{l|}{Name of the DataObject that contains the parameter} \\ \hline
+\multicolumn{1}{|l|}{\texttt{Parameter Type}} & \multicolumn{1}{l|}{
+	\begin{tabular}[c]{@{}l@{}}Either \texttt{Input} or \texttt{Output} depending on whether the parameter \\
+		is defined in the \xmlNode{Input} or \xmlNode{Output} part of the DataObject \end{tabular}} \\ \hline
 
-If the ``variableName'' contains the symbol \texttt{|}, it must be surrounded by
-brackets:
-\texttt{[DataObjectName|Input(or)Output|(whatever|variableName)]}.
+\multicolumn{1}{|l|}{\texttt{Parameter Name}} & \multicolumn{1}{l|}{The name of the parameter in the DataObject to plot} \\ \hline
+\end{tabular}
+\end{center}
+\textbf{Note:}  If the \texttt{Parameter Name} part of the variable specification itself contains the vertical bar character (`\texttt{|}`) used to separate 
+the three values, it must be enclosed in parenthesis to be interpreted properly.  For example:
+\\* \\* \centerline{\texttt{DataObject Name|Parameter Type|(parameter|name)}}
+
 %%%%%%%%%%%%%
 %Predefined Plotting System block sub-sub-sub section
 %%%%%%%%%%%%%


### PR DESCRIPTION
This change clarifies how data series are specified to the plotting system in the user manual.

Closes #262 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
