### PR TITLE
Switches to checking for None with "is" instead of Count.

### DIFF
--- a/framework/PostProcessors/CrossValidation.py
+++ b/framework/PostProcessors/CrossValidation.py
@@ -215,7 +215,7 @@ class CrossValidation(PostProcessor):
       #here we do not make a copy since we assume that the dictionary is for just for the model usage and any changes are not impacting outside
       newInput = currentInput
 
-    if newInput.values().count(None) != 0:
+    if any(x is None for x in newInput.values()):
       varName = newInput.keys()[list(newInput.values()).index(None)]
       self.raiseAnError(IOError, "The variable: ", varName, " is not exist in the input: ", currentInput.name, " which is required for model: ", cvEstimator.name)
 


### PR DESCRIPTION
Closes #350

--------
Pull Request Description
--------
##### What issue does this change request address?
#350 

##### What are the significant changes in functionality due to this change request?
Changes one line to use "is None".

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
