### PR TITLE
Adding `<interactive />` tag specification to the ToplogicalDecomposition PP

### DIFF
--- a/doc/user_manual/postprocessor.tex
+++ b/doc/user_manual/postprocessor.tex
@@ -919,6 +919,12 @@ The following is a list of acceptable sub-nodes:
   \item \xmlNode{weighted}, \xmlDesc{boolean, optional}, a flag that specifies
   whether the regression models should be probability weighted.
   \default{False}
+  \item \xmlNode{interactive}, if this node is present \emph{and} the user has
+  specified the keyword \texttt{interactive} at the command line, then this will
+  initiate a graphical interface for exploring the different simplification
+  levels of the topological hierarchy. Upon exit of the graphical interface, the
+  specified simplification level will be updated to use the last value of the
+  graphical interface before writing any ``output'' results.
   \item \xmlNode{persistence}, \xmlDesc{string, optional field}, specifies how
   to define the hierarchical simplification by assigning a value to each local
   minimum and maximum according to the one of the strategy options below:

--- a/framework/PostProcessors/TopologicalDecomposition.py
+++ b/framework/PostProcessors/TopologicalDecomposition.py
@@ -66,6 +66,9 @@ class TopologicalDecomposition(PostProcessor):
     TDWeightedInput = InputData.parameterInputFactory("weighted", contentType=InputData.StringType) #bool
     inputSpecification.addSub(TDWeightedInput)
 
+    TDInteractiveInput = InputData.parameterInputFactory("interactive", contentType=InputData.StringType) #bool
+    inputSpecification.addSub(TDInteractiveInput)
+
     TDPersistenceInput = InputData.parameterInputFactory("persistence", contentType=InputData.StringType)
     inputSpecification.addSub(TDPersistenceInput)
 


### PR DESCRIPTION
Closes #359.


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code. *Done*
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).  *No real change, but this does fix missing documentation*
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details. *Yes*
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass. *Yes*
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.  *No significant functionality added*
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync. *No change*
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.  *Done*
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?  *No change*

Checklist review by @joshua-cogliati-inl on 2017-Sept-18
