### PR TITLE
Independently on the verbosity level print if raven succeeded 

### DIFF
--- a/framework/MessageHandler.py
+++ b/framework/MessageHandler.py
@@ -124,11 +124,12 @@ class MessageUser(object):
                             tag, the message label (default 'Message')
       @ Out, None
     """
-    verbosity = kwargs.get('verbosity','all'    )
-    tag       = kwargs.get('tag'      ,'Message')
-    color     = kwargs.get('color'    ,None     )
+    verbosity  = kwargs.get('verbosity' ,'all'    )
+    tag        = kwargs.get('tag'       ,'Message')
+    color      = kwargs.get('color'     ,None     )
+    forcePrint = kwargs.get('forcePrint',False     )
     msg = ' '.join(str(a) for a in args)
-    self.messageHandler.message(self,msg,str(tag),verbosity,color)
+    self.messageHandler.message(self,msg,str(tag),verbosity,color,forcePrint=forcePrint)
 
   def raiseADebug(self,*args,**kwargs):
     """
@@ -313,7 +314,7 @@ class MessageHandler(object):
         sys.tracebacklimit=0
       raise etype(message)
 
-  def message(self,caller,message,tag,verbosity,color=None,writeTo=sys.stdout):
+  def message(self,caller,message,tag,verbosity,color=None,writeTo=sys.stdout, forcePrint=False):
     """
       Print a message
       @ In, caller, object, the entity desiring to print a message
@@ -321,10 +322,11 @@ class MessageHandler(object):
       @ In, tag, string, the printed message type (usually Message, Debug, or Warning, and sometimes FIXME)
       @ In, verbosity, string, the print priority of the message
       @ In, color, string, optional, color to apply to message
+      @ In, forcePrint, bool, optional, force the print independetly on the verbosity level? Defaul False
       @ Out, None
     """
     verbval = self.checkVerbosity(verbosity)
-    okay,msg = self._printMessage(caller,message,tag,verbval,color)
+    okay,msg = self._printMessage(caller,message,tag,verbval,color,forcePrint)
     if tag.lower().strip() == 'warning':
       self.addWarning(message)
     if okay:
@@ -344,7 +346,7 @@ class MessageHandler(object):
     else:
       self.warningCount[index] += 1
 
-  def _printMessage(self,caller,message,tag,verbval,color=None):
+  def _printMessage(self,caller,message,tag,verbval,color=None,forcePrint=False):
     """
       Checks verbosity to determine whether something should be printed, and formats message
       @ In, caller , object, the entity desiring to print a message
@@ -352,13 +354,14 @@ class MessageHandler(object):
       @ In, tag    , string, the printed message type (usually Message, Debug, or Warning, and sometimes FIXME)
       @ In, verbval, int   , the print priority of the message
       @ In, color, string, optional, color to apply to message
+      @ In, forcePrint, bool, optional, force the print independetly on the verbosity level? Defaul False
       @ Out, (shouldIPrint,msg), tuple, shouldIPrint -> bool, indication if the print should be allowed
                                         msg          -> string, the formatted message
     """
     #allows raising standardized messages
     shouldIPrint = False
     desired = self.getDesiredVerbosity(caller)
-    if verbval <= desired:
+    if verbval <= desired or forcePrint:
       shouldIPrint=True
     if not shouldIPrint:
       return False,''

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -837,5 +837,6 @@ class Simulation(MessageHandler.MessageUser):
           output.finalize()
       self.raiseAMessage('-'*2+' End step {0:50} '.format(stepName+' of type: '+stepInstance.type)+2*'-'+'\n')#,color='green')
     self.jobHandler.shutdown()
-    self.raiseAMessage('Run complete!')
     self.messageHandler.printWarnings()
+    self.raiseAMessage('Run complete!',forcePrint=True)
+


### PR DESCRIPTION
last message should be Run complete and the warnings should be printed before

--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Closes #375 


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?