### PR TITLE
Talbpaul/dummy output

### DIFF
--- a/framework/DataObjects/XDataSet.py
+++ b/framework/DataObjects/XDataSet.py
@@ -152,7 +152,6 @@ class DataSet(DataObject):
         self._metavars = list(unrecognized)
         self._allvars += self._metavars
     # check and order data to be stored
-    print('DEBUGG dset addreal rlz:',rlz.keys())
     try:
       newData = np.asarray([list(rlz[var] for var in self._allvars)],dtype=object)
     except KeyError as e:

--- a/framework/DataObjects/XDataSet.py
+++ b/framework/DataObjects/XDataSet.py
@@ -152,6 +152,7 @@ class DataSet(DataObject):
         self._metavars = list(unrecognized)
         self._allvars += self._metavars
     # check and order data to be stored
+    print('DEBUGG dset addreal rlz:',rlz.keys())
     try:
       newData = np.asarray([list(rlz[var] for var in self._allvars)],dtype=object)
     except KeyError as e:

--- a/framework/Models/Dummy.py
+++ b/framework/Models/Dummy.py
@@ -190,30 +190,19 @@ class Dummy(Model):
     """
     # TODO START can be abstracted to base class
     # TODO apparently sometimes "options" can include 'exportDict'; what do we do for this?
-    # TODO consistency with old HDF5
+    # TODO consistency with old HDF5; fix this when HDF5 api is in place
     if output.type == 'HDF5':
       exportDict = self.createExportDictionaryFromFinishedJob(finishedJob)
       self.addOutputFromExportDictionary(exportDict, output, options, finishedJob.identifier)
 
-    result = finishedJob.getEvaluation()
+    # TODO expensive deepcopy prevents modification when sent to multiple outputs
+    result = copy.deepcopy(finishedJob.getEvaluation())
     if isinstance(result,Runners.Error):
       self.raiseAnError(AttributeError,'No available output to collect!')
     self._replaceVariablesNamesWithAliasSystem(result)
-    print('DEBUGG dummy collectout adding rlz:')
-    for k,v in result.items():
-      print('  ',k,v)
     output.addRealization(result)
     return
     # END can be abstracted to base class
-
-
-    #### OLD ####
-    # create the export dictionary
-    if options is not None and 'exportDict' in options:
-      exportDict = options['exportDict']
-    else:
-      exportDict = self.createExportDictionaryFromFinishedJob(finishedJob)
-    self.addOutputFromExportDictionary(exportDict, output, options, finishedJob.identifier)
 
   def collectOutputFromDict(self,exportDict,output,options=None):
     """

--- a/framework/Models/Dummy.py
+++ b/framework/Models/Dummy.py
@@ -175,8 +175,10 @@ class Dummy(Model):
     """
     Input = self.createNewInput(myInput, samplerType, **kwargs)
     inRun = self._manipulateInput(Input[0])
-    returnValue = (inRun,{'OutputPlaceHolder':np.atleast_1d(np.float(Input[1]['prefix']))})
-    return returnValue
+    rlz = {}
+    rlz.update(inRun)
+    rlz['OutputPlaceHolder'] = np.atleast_1d(np.float(Input[1]['prefix']))
+    return rlz
 
   def collectOutput(self,finishedJob,output,options=None):
     """
@@ -186,6 +188,17 @@ class Dummy(Model):
       @ In, options, dict, optional, dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
+    # TODO START can be abstracted to base class
+    result = finishedJob.getEvaluation()
+    if isinstance(result,Runners.Error):
+      self.raiseAnError(AttributeError,'No available output to collect!')
+    self._replaceVariablesNamesWithAliasSystem(result)
+    output.addRealization(result)
+    return
+    # END can be abstracted to base class
+
+
+    #### OLD ####
     # create the export dictionary
     if options is not None and 'exportDict' in options:
       exportDict = options['exportDict']

--- a/framework/Models/Dummy.py
+++ b/framework/Models/Dummy.py
@@ -189,10 +189,19 @@ class Dummy(Model):
       @ Out, None
     """
     # TODO START can be abstracted to base class
+    # TODO apparently sometimes "options" can include 'exportDict'; what do we do for this?
+    # TODO consistency with old HDF5
+    if output.type == 'HDF5':
+      exportDict = self.createExportDictionaryFromFinishedJob(finishedJob)
+      self.addOutputFromExportDictionary(exportDict, output, options, finishedJob.identifier)
+
     result = finishedJob.getEvaluation()
     if isinstance(result,Runners.Error):
       self.raiseAnError(AttributeError,'No available output to collect!')
     self._replaceVariablesNamesWithAliasSystem(result)
+    print('DEBUGG dummy collectout adding rlz:')
+    for k,v in result.items():
+      print('  ',k,v)
     output.addRealization(result)
     return
     # END can be abstracted to base class

--- a/framework/Models/ExternalModel.py
+++ b/framework/Models/ExternalModel.py
@@ -251,10 +251,11 @@ class ExternalModel(Dummy):
     Input = self.createNewInput(myInput, samplerType, **kwargs)
     inRun = copy.copy(self._manipulateInput(Input[0][0]))
     result,instSelf = self._externalRun(inRun,Input[1],) # TODO entry [1] is the external model object; do I need it?
-    result['RAVEN_instantiated_self'] = instSelf
+    #result['RAVEN_instantiated_self'] = instSelf
     rlz = {}
     rlz.update(inRun)
     rlz.update(result)
+    print('DEBUGG extmod evaluated:',rlz.keys())
     # OLD returnValue = (inRun,self._externalRun(inRun,Input[1],))
     return rlz
 
@@ -271,17 +272,18 @@ class ExternalModel(Dummy):
     if isinstance(evaluation, Runners.Error):
       self.raiseAnError(RuntimeError,"No available Output to collect")
 
-    instanciatedSelf = evaluation.pop('RAVEN_instantiated_self')
+    print('DEBUGG extmod collectOut:',evaluation.keys())
+    #instanciatedSelf = evaluation['RAVEN_instantiated_self']
     # OLD outcomes         = evaluatedOutput[0]
 
     # TODO move this check to the data object instead.
     if output.type in ['HistorySet']:
       outputSize = -1
-      for key in output.getParaKeys('outputs'):
-        if key in instanciatedSelf.modelVariableType.keys():
-          if outputSize == -1:
-            outputSize = len(np.atleast_1d(evaluation[key]))
-          if not utils.sizeMatch(evaluation[key],outputSize):
-            self.raiseAnError(Exception,"the time series size needs to be the same for the output space in a HistorySet! Variable:"+key+". Size in the HistorySet="+str(outputSize)+".Size outputed="+str(len(np.atleast_1d(outcomes[key]))))
+      for key in output.getVars('output'):
+        # if key in instanciatedSelf.modelVariableType.keys(): #TODO why would it not be in this dict?
+        if outputSize == -1:
+          outputSize = len(np.atleast_1d(evaluation[key]))
+        if not utils.sizeMatch(evaluation[key],outputSize):
+          self.raiseAnError(Exception,"the time series size needs to be the same for the output space in a HistorySet! Variable:"+key+". Size in the HistorySet="+str(outputSize)+".Size outputed="+str(len(np.atleast_1d(outcomes[key]))))
 
     Dummy.collectOutput(self, finishedJob, output, options)

--- a/framework/Models/ExternalModel.py
+++ b/framework/Models/ExternalModel.py
@@ -251,12 +251,9 @@ class ExternalModel(Dummy):
     Input = self.createNewInput(myInput, samplerType, **kwargs)
     inRun = copy.copy(self._manipulateInput(Input[0][0]))
     result,instSelf = self._externalRun(inRun,Input[1],) # TODO entry [1] is the external model object; do I need it?
-    #result['RAVEN_instantiated_self'] = instSelf
     rlz = {}
     rlz.update(inRun)
     rlz.update(result)
-    print('DEBUGG extmod evaluated:',rlz.keys())
-    # OLD returnValue = (inRun,self._externalRun(inRun,Input[1],))
     return rlz
 
   def collectOutput(self,finishedJob,output,options=None):
@@ -272,15 +269,14 @@ class ExternalModel(Dummy):
     if isinstance(evaluation, Runners.Error):
       self.raiseAnError(RuntimeError,"No available Output to collect")
 
-    print('DEBUGG extmod collectOut:',evaluation.keys())
-    #instanciatedSelf = evaluation['RAVEN_instantiated_self']
+    # OLD instanciatedSelf = evaluation['RAVEN_instantiated_self']
     # OLD outcomes         = evaluatedOutput[0]
 
     # TODO move this check to the data object instead.
     if output.type in ['HistorySet']:
       outputSize = -1
       for key in output.getVars('output'):
-        # if key in instanciatedSelf.modelVariableType.keys(): #TODO why would it not be in this dict?
+        # OLD ? if key in instanciatedSelf.modelVariableType.keys(): #TODO why would it not be in this dict?
         if outputSize == -1:
           outputSize = len(np.atleast_1d(evaluation[key]))
         if not utils.sizeMatch(evaluation[key],outputSize):

--- a/tests/framework/test_Lorentz.xml
+++ b/tests/framework/test_Lorentz.xml
@@ -6,7 +6,7 @@
     <created>2013-10-24</created>
     <classesTested>Models.ExternalModel</classesTested>
     <description>
-       This test is aimed to check the functionality of RAVEN to use ExternalModel entities.     
+       This test is aimed to check the functionality of RAVEN to use ExternalModel entities.
     </description>
     <revisions>
       <revision author="mandd" date="2015-04-17">conversion to Database and DataObjects</revision>
@@ -132,7 +132,7 @@
     </PointSet>
     <HistorySet name="testPrintHistorySet">
       <Input>x0,y0,z0</Input>
-      <Output>time,x,y,z</Output>
+      <Output>x,y,z</Output>
     </HistorySet>
   </DataObjects>
 

--- a/tests/framework/test_Lorentz.xml
+++ b/tests/framework/test_Lorentz.xml
@@ -30,7 +30,7 @@
       <Model class="Models" type="ExternalModel">PythonModule</Model>
       <Sampler class="Samplers" type="MonteCarlo">MC_external</Sampler>
       <Output class="DataObjects" type="HistorySet">testPrintHistorySet</Output>
-      <Output class="Databases" type="HDF5">test_external_db</Output>
+      <!-- FIXME Output class="Databases" type="HDF5">test_external_db</Output-->
       <Output class="OutStreams" type="Print">testPrintHistorySet_dump</Output>
       <Output class="DataObjects" type="PointSet">testPointSet</Output>
       <Output class="OutStreams" type="Print">testPointSet_dump</Output>


### PR DESCRIPTION
--------
Pull Request Description
--------
Fixes methods `evaluateSample` and `collectOutput` on both `Dummy` and `ExternalModel` so that they work with the new data object API.  `evaluateSample` returns the expected realization, and `collectOutput` is functionally a pass-through to the data object output collection.

Note this is being merged to a rework branch, not devel.