### PR TITLE
Correct setting of default pivots for history set

### DIFF
--- a/framework/DataObjects/XDataObject.py
+++ b/framework/DataObjects/XDataObject.py
@@ -187,6 +187,8 @@ class DataObject(utils.metaclass_insert(abc.ABCMeta,BaseType)):
           self.raiseAWarning('Multiple options were given to specify the output row to read! Using last entry:',self._selectOutput)
       # end options node
     # end input reading
+    # set default pivot parameters, if needed
+    self._setDefaultPivotParams()
     # remove index variables from input/output spaces, but silently, since we'll still have them available later
     for index in self._pivotParams.keys():
       try:
@@ -200,6 +202,14 @@ class DataObject(utils.metaclass_insert(abc.ABCMeta,BaseType)):
     self._allvars = self._inputs + self._outputs
     if self.messageHandler is None:
       self.messageHandler = MessageCourier()
+
+  def _setDefaultPivotParams(self):
+    """
+      Allows setting default pivot parameters.  In general, does nothing.
+      @ In, None
+      @ Out, None
+    """
+    pass
 
   def setPivotParams(self,params):
     """

--- a/framework/DataObjects/XHistorySet.py
+++ b/framework/DataObjects/XHistorySet.py
@@ -70,18 +70,17 @@ class HistorySet(DataSet):
     self.printTag  = self.name
     self._tempPivotParam = None
 
-  def _readMoreXML(self,xmlNode):
+  def _setDefaultPivotParams(self):
     """
-      Initializes data object based on XML input.
-      @ In, xmlNode, xml.etree.ElementTree.Element or InputData.ParameterInput, input specification
+      Sets default pivot parameters.
+      @ In, None
       @ Out, None
     """
-    DataSet._readMoreXML(self,xmlNode)
-    # propagate provided pivot parameter to all variables.
     # If not set, use "time" as default.
     if self._tempPivotParam is None:
       self.raiseAWarning('No pivot parameter provided; defaulting to \"time\".')
       self._tempPivotParam = 'time'
+    # propagate provided pivot parameter to all variables.
     # don't use setter, set directly, since there's only one var
     self._pivotParams = {self._tempPivotParam:self._outputs[:]}
 

--- a/tests/framework/test_Lorentz.xml
+++ b/tests/framework/test_Lorentz.xml
@@ -132,7 +132,7 @@
     </PointSet>
     <HistorySet name="testPrintHistorySet">
       <Input>x0,y0,z0</Input>
-      <Output>x,y,z</Output>
+      <Output>time,x,y,z</Output>
     </HistorySet>
   </DataObjects>
 


### PR DESCRIPTION
`XDataObject.DataObject._readMoreXML` calls a method to set the default pivot parameters BEFORE it adjusts the requested IO space.

As a result, if the user asks for a default `index` in the input or output of a dataobject, no errors will be thrown, and they will see the values as expected.