### PR TITLE
CSV append instead of rewrite

### DIFF
--- a/framework/DataObjects/TestXDataSet.py
+++ b/framework/DataObjects/TestXDataSet.py
@@ -691,7 +691,10 @@ rlz = data.realization(index=2)
 checkFloat('load from dict rlz 2 "a"',rlz['a'],1.2)
 checkArray('load from dict rlz 2 "b"',rlz['b'].values,[1.2,1.21,1.22],float)
 
-
+print('DEBUGG')
+print(data.asDataset())
+print('')
+print(data._data.isel(**{data.sampleTag:slice(3,None,None)}))
 
 print(results)
 

--- a/framework/DataObjects/TestXDataSet.py
+++ b/framework/DataObjects/TestXDataSet.py
@@ -691,11 +691,6 @@ rlz = data.realization(index=2)
 checkFloat('load from dict rlz 2 "a"',rlz['a'],1.2)
 checkArray('load from dict rlz 2 "b"',rlz['b'].values,[1.2,1.21,1.22],float)
 
-print('DEBUGG')
-print(data.asDataset())
-print('')
-print(data._data.isel(**{data.sampleTag:slice(3,None,None)}))
-
 print(results)
 
 sys.exit(results["fail"])

--- a/framework/DataObjects/TestXHistorySet.py
+++ b/framework/DataObjects/TestXHistorySet.py
@@ -571,7 +571,8 @@ for var in data.getVars():
     checkTrue('CSV var {}'.format(var),bool((dataCSV._data[var] == data._data[var]).prod()))
 
 # clean up temp files
-os.remove(csvname+'.csv')
+# os.remove(csvname+'.csv')
+# TODO cleanup sub-files too
 os.remove(csvname+'.xml')
 
 

--- a/framework/DataObjects/TestXHistorySet.py
+++ b/framework/DataObjects/TestXHistorySet.py
@@ -571,7 +571,11 @@ for var in data.getVars():
     checkTrue('CSV var {}'.format(var),bool((dataCSV._data[var] == data._data[var]).prod()))
 
 # clean up temp files
-# os.remove(csvname+'.csv')
+os.remove(csvname+'.csv')
+os.remove(csvname+'_0.csv')
+os.remove(csvname+'_1.csv')
+os.remove(csvname+'_2.csv')
+os.remove(csvname+'_3.csv')
 # TODO cleanup sub-files too
 os.remove(csvname+'.xml')
 

--- a/framework/DataObjects/XDataSet.py
+++ b/framework/DataObjects/XDataSet.py
@@ -527,7 +527,7 @@ class DataSet(DataObject):
       @ In, fName, str, path and name of file to write
       @ In, style, str, optional, options are enumerated below
       @ In, kwargs, dict, optional, additional arguments to pass to writing function
-          Includes:  startAt, int, if included then is the realization index that writing should start from (implies appending instead of rewriting)
+          Includes:  firstIndex, int, optional, if included then is the realization index that writing should start from (implies appending instead of rewriting)
       @ Out, index, int, index of latest rlz to be written, for tracking purposes
     """
     self.asDataset() #just in case there is stuff left in the collector
@@ -542,7 +542,6 @@ class DataSet(DataObject):
       self._toCSV(fName,start=firstIndex,**kwargs)
       # then the metaxml
       self._toCSVXML(fName,**kwargs)
-      # update the counter for already-written CSV data
     # TODO dask?
     else:
       self.raiseAnError(NotImplementedError,'Unrecognized write style: "{}"'.format(style))
@@ -1128,9 +1127,6 @@ class DataSet(DataObject):
     else:
       data = self._data
       mode = 'w'
-    #for var in self._allvars:
-    #  if var not in keep:
-    #    data = data.drop(var)
     data = data.drop(toDrop)
     self.raiseADebug('Printing data to CSV: "{}"'.format(filenameLocal+'.csv'))
     # get the list of elements the user requested to write

--- a/framework/DataObjects/XHistorySet.py
+++ b/framework/DataObjects/XHistorySet.py
@@ -172,36 +172,47 @@ class HistorySet(DataSet):
     # TODO someday needs to be implemented for when ND data is collected!  For now, use base class.
     return DataSet._selectiveRealization(self,rlz)
 
-  def _toCSV(self,fname,**kwargs):
+  def _toCSV(self,fname,start=0,**kwargs):
     """
       Writes this data objcet to CSV file (for metadata see _toCSVXML)
       @ In, fname, str, path/name to write file
+      @ In, start, int, optional, starting realization to print
       @ In, kwargs, dict, optional, keywords for options
       @ Out, None
     """
     # specialized to write custom RAVEN-style history CSVs
     # TODO some overlap with DataSet implementation, but not much.
     keep = self._getRequestedElements(kwargs)
-    data = self._data
-    for var in self._allvars:
-      if var not in keep:
-        data = data.drop(var)
+    # don't rewrite everything; if we've written some already, just append (using mode)
+    if start > 0:
+      # slice data starting at "start"
+      sl = slice(start,None,None)
+      data = self._data.isel(**{self.sampleTag:sl})
+      mode = 'a'
+    else:
+      data = self._data
+      mode = 'w'
+    toDrop = list(var for var in self._allvars if var not in keep)
+    data = data.drop(toDrop)
+    #for var in self._allvars:
+    #  if var not in keep:
+    #    data = data.drop(var)
     self.raiseADebug('Printing data to CSV: "{}"'.format(fname+'.csv'))
     # specific implementation
     ## write input space CSV with pointers to history CSVs
     ### get list of input variables to keep
     ordered = list(i for i in itertools.chain(self._inputs,self._metavars) if i in keep)
     ### select input part of dataset
-    inpData = self.asDataset()[ordered]
+    inpData = data[ordered]
     ### add column for realization information, pointing to the appropriate CSV
     subFiles = np.array(list('{}_{}.csv'.format(fname,rid) for rid in data[self.sampleTag].values),dtype=object)
     ### add column to dataset
-    column = self._collapseNDtoDataArray(subFiles,'filename',labels=self._data[self.sampleTag])
+    column = self._collapseNDtoDataArray(subFiles,'filename',labels=data[self.sampleTag])
     inpData = inpData.assign(filename=column)
     ### also add column name to "ordered"
     ordered += ['filename']
     ### write CSV
-    self._usePandasWriteCSV(fname,inpData,ordered,keepSampleTag = self.sampleTag in keep)
+    self._usePandasWriteCSV(fname,inpData,ordered,keepSampleTag = self.sampleTag in keep,mode=mode)
     ### convert to dataframe, preparatory to writing to CSV
     #inpData = inpData.to_dataframe()
     ### make sure columns are in sensible order
@@ -209,9 +220,14 @@ class HistorySet(DataSet):
     ### write
     #inpData.to_csv(fname+'.csv',index = self.sampleTag in keep)
     ## obtain slices to write subset CSVs
-    slices = self.sliceByIndex(self.sampleTag)
-    for i,s in enumerate(slices):
-      filename = subFiles[i][:-4] # removing ".csv"
-      ordered = list(o for o in self.getVars('output') if o in keep)
-      dat = s[ordered].drop(self.sampleTag).dropna(self.indexes[0]) #specifically for history set, only has 1 pivot
-      self._usePandasWriteCSV(filename,dat,ordered,keepIndex=True)
+    ordered = list(o for o in self.getVars('output') if o in keep)
+    for i in range(len(data[self.sampleTag].values)):
+      rlz = data.isel(**{self.sampleTag:i})[ordered].dropna(self.indexes[0])
+      filename = subFiles[i][:-4]
+      self._usePandasWriteCSV(filename,rlz,ordered,keepIndex=True)
+    #### OLD ####
+    #slices = self.sliceByIndex(self.sampleTag)
+    #for i,s in enumerate(slices):
+    #  filename = subFiles[i][:-4] # removing ".csv"
+    #  dat = s[ordered].drop(self.sampleTag).dropna(self.indexes[0]) #specifically for history set, only has 1 pivot
+    #  self._usePandasWriteCSV(filename,dat,ordered,keepIndex=True)

--- a/framework/DataObjects/XHistorySet.py
+++ b/framework/DataObjects/XHistorySet.py
@@ -194,9 +194,6 @@ class HistorySet(DataSet):
       mode = 'w'
     toDrop = list(var for var in self._allvars if var not in keep)
     data = data.drop(toDrop)
-    #for var in self._allvars:
-    #  if var not in keep:
-    #    data = data.drop(var)
     self.raiseADebug('Printing data to CSV: "{}"'.format(fname+'.csv'))
     # specific implementation
     ## write input space CSV with pointers to history CSVs
@@ -213,21 +210,9 @@ class HistorySet(DataSet):
     ordered += ['filename']
     ### write CSV
     self._usePandasWriteCSV(fname,inpData,ordered,keepSampleTag = self.sampleTag in keep,mode=mode)
-    ### convert to dataframe, preparatory to writing to CSV
-    #inpData = inpData.to_dataframe()
-    ### make sure columns are in sensible order
-    #inpData = inpData[ordered]
-    ### write
-    #inpData.to_csv(fname+'.csv',index = self.sampleTag in keep)
     ## obtain slices to write subset CSVs
     ordered = list(o for o in self.getVars('output') if o in keep)
     for i in range(len(data[self.sampleTag].values)):
       rlz = data.isel(**{self.sampleTag:i})[ordered].dropna(self.indexes[0])
       filename = subFiles[i][:-4]
       self._usePandasWriteCSV(filename,rlz,ordered,keepIndex=True)
-    #### OLD ####
-    #slices = self.sliceByIndex(self.sampleTag)
-    #for i,s in enumerate(slices):
-    #  filename = subFiles[i][:-4] # removing ".csv"
-    #  dat = s[ordered].drop(self.sampleTag).dropna(self.indexes[0]) #specifically for history set, only has 1 pivot
-    #  self._usePandasWriteCSV(filename,dat,ordered,keepIndex=True)

--- a/framework/OutStreams/OutStreamPrint.py
+++ b/framework/OutStreams/OutStreamPrint.py
@@ -141,7 +141,7 @@ class OutStreamPrint(OutStreamManager):
       except TypeError:
         empty = False
       if not empty:
-        #try:
+        try:
           if self.options['type'] == 'csv':
             filename = dictOptions['filenameroot']
             rlzIndex = self.indexPrinted.get(filename,0)
@@ -150,8 +150,8 @@ class OutStreamPrint(OutStreamManager):
             self.indexPrinted[filename] = rlzIndex
           elif self.options['type'] == 'xml':
             self.sourceData[index].printXML(dictOptions)
-        #except AttributeError:
-        #  self.raiseAnError(IOError, 'No implementation for source type', self.sourceData[index].type, 'and output type "'+str(self.options['type'].strip())+'"!')
+        except AttributeError:
+          self.raiseAnError(IOError, 'No implementation for source type', self.sourceData[index].type, 'and output type "'+str(self.options['type'].strip())+'"!')
 
   def finalize(self):
     """

--- a/framework/OutStreams/OutStreamPrint.py
+++ b/framework/OutStreams/OutStreamPrint.py
@@ -63,6 +63,8 @@ class OutStreamPrint(OutStreamManager):
     self.sourceName = []
     self.sourceData = None
     self.what = None
+    # dictionary of what indices have already been printed, so we don't duplicate writing efforts
+    self.indexPrinted = {} # keys are filenames, which should be reset at the end of every step
 
   def localGetInitParams(self):
     """
@@ -139,11 +141,23 @@ class OutStreamPrint(OutStreamManager):
       except TypeError:
         empty = False
       if not empty:
-        try:
+        #try:
           if self.options['type'] == 'csv':
-            self.sourceData[index].write(dictOptions['filenameroot'],style='CSV',**dictOptions)
+            filename = dictOptions['filenameroot']
+            rlzIndex = self.indexPrinted.get(filename,0)
+            dictOptions['firstIndex'] = rlzIndex
+            rlzIndex = self.sourceData[index].write(filename,style='CSV',**dictOptions)
+            self.indexPrinted[filename] = rlzIndex
           elif self.options['type'] == 'xml':
             self.sourceData[index].printXML(dictOptions)
-        except AttributeError:
-          self.raiseAnError(IOError, 'No implementation for source type', self.sourceData[index].type, 'and output type "'+str(self.options['type'].strip())+'"!')
+        #except AttributeError:
+        #  self.raiseAnError(IOError, 'No implementation for source type', self.sourceData[index].type, 'and output type "'+str(self.options['type'].strip())+'"!')
 
+  def finalize(self):
+    """
+      End-of-step operations for cleanup.
+      @ In, None
+      @ Out, None
+    """
+    # clear history of printed realizations; start fresh for next step
+    self.indexPrinted = {}


### PR DESCRIPTION
Instead of rewriting CSV on multirun prints to OutStream Print, only append new entries.