### PR TITLE
added _reassignSampledVarsPbToFullyCorrVars to Sampler base class.

### DIFF
--- a/framework/Samplers/AdaptiveSobol.py
+++ b/framework/Samplers/AdaptiveSobol.py
@@ -398,7 +398,6 @@ class AdaptiveSobol(Sobol,AdaptiveSparseGrid):
         self.inputInfo['ProbabilityWeight-'+varName.replace(",","!")] = self.inputInfo['SampledVarsPb'][varName]
     self.inputInfo['PointProbability'] = reduce(mul,self.inputInfo['SampledVarsPb'].values())
     # reassign SampledVarsPb to fully correlated variables
-    self._reassignSampledVarsPbToFullyCorrVars()
     self.inputInfo['SamplerType'] = 'Adaptive Sparse Grids for Sobol'
 
   def _addPointToDataObject(self,subset,point):

--- a/framework/Samplers/AdaptiveSparseGrid.py
+++ b/framework/Samplers/AdaptiveSparseGrid.py
@@ -355,8 +355,6 @@ class AdaptiveSparseGrid(SparseGridCollocation,AdaptiveSampler):
         self.inputInfo['SampledVarsPb'][varName] = self.distDict[varName].pdf(ndCoordinates)
         self.inputInfo['ProbabilityWeight-'+varName.replace(",","!")] = self.inputInfo['SampledVarsPb'][varName]
     self.inputInfo['PointProbability'] = reduce(mul,self.inputInfo['SampledVarsPb'].values())
-    # reassign SampledVarsPb to fully correlated variables
-    self._reassignSampledVarsPbToFullyCorrVars()
     self.inputInfo['SamplerType'] = self.type
 
   def localFinalizeActualSampling(self,jobObject,model,myInput):

--- a/framework/Samplers/Grid.py
+++ b/framework/Samplers/Grid.py
@@ -276,7 +276,5 @@ class Grid(ForwardSampler):
           self.inputInfo['ProbabilityWeight-'+varName.replace(",","!")] = self.distDict[varName].cellIntegral(ndCoordinate,dxs)
           weight *= self.distDict[varName].cellIntegral(ndCoordinate,dxs)
     self.inputInfo['PointProbability' ] = reduce(mul, self.inputInfo['SampledVarsPb'].values())
-    # reassign SampledVarsPb to fully correlated variables
-    self._reassignSampledVarsPbToFullyCorrVars()
     self.inputInfo['ProbabilityWeight'] = copy.deepcopy(weight)
     self.inputInfo['SamplerType'] = 'Grid'

--- a/framework/Samplers/MonteCarlo.py
+++ b/framework/Samplers/MonteCarlo.py
@@ -180,8 +180,6 @@ class MonteCarlo(ForwardSampler):
         self.inputInfo['ProbabilityWeight'  ] = weight
       else:
         self.inputInfo['ProbabilityWeight' ] = 1.0 #MC weight is 1/N => weight is one
-    # reassign SampledVarsPb to fully correlated variables
-    self._reassignSampledVarsPbToFullyCorrVars()
     self.inputInfo['SamplerType'] = 'MonteCarlo'
 
   def _localHandleFailedRuns(self,failedRuns):

--- a/framework/Samplers/Sampler.py
+++ b/framework/Samplers/Sampler.py
@@ -662,7 +662,8 @@ class Sampler(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
     #self.inputInfo['counter'] = self.counter
     model.getAdditionalInputEdits(self.inputInfo)
     self.localGenerateInput(model,oldInput)
-
+    # split the sampled vars Pb among the different correlated variables
+    self._reassignSampledVarsPbToFullyCorrVars()
     ##### TRANSFORMATION #####
     # add latent variables and original variables to self.inputInfo
     if self.variablesTransformationDict:

--- a/framework/Samplers/Sobol.py
+++ b/framework/Samplers/Sobol.py
@@ -223,6 +223,4 @@ class Sobol(SparseGridCollocation):
         self.inputInfo['ProbabilityWeight-'+varName.replace(",","!")] = self.inputInfo['SampledVarsPb'][varName]
 
     self.inputInfo['PointProbability'] = reduce(mul,self.inputInfo['SampledVarsPb'].values())
-    # reassign SampledVarsPb to fully correlated variables
-    self._reassignSampledVarsPbToFullyCorrVars()
     self.inputInfo['SamplerType'] = 'Sparse Grids for Sobol'

--- a/framework/Samplers/SparseGridCollocation.py
+++ b/framework/Samplers/SparseGridCollocation.py
@@ -317,8 +317,6 @@ class SparseGridCollocation(Grid):
 
     self.inputInfo['ProbabilityWeight'] = weight
     self.inputInfo['PointProbability'] = reduce(mul,self.inputInfo['SampledVarsPb'].values())
-    # reassign SampledVarsPb to fully correlated variables
-    self._reassignSampledVarsPbToFullyCorrVars()
     self.inputInfo['SamplerType'] = 'Sparse Grid Collocation'
 
   def readFromROM(self):

--- a/framework/Samplers/Stratified.py
+++ b/framework/Samplers/Stratified.py
@@ -264,8 +264,5 @@ class Stratified(Grid):
             self.inputInfo['lower'][kkey] = min(upper,lower)
 
     self.inputInfo['PointProbability'] = reduce(mul, self.inputInfo['SampledVarsPb'].values())
-    # reassign SampledVarsPb to fully correlated variables
-    self._reassignSampledVarsPbToFullyCorrVars()
-
     self.inputInfo['ProbabilityWeight' ] = weight
     self.inputInfo['SamplerType'] = 'Stratified'


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Ref. #464

##### What are the significant changes in functionality due to this change request?
This PR refers to the issue #464 that has been addressed in PR #465 . It is the same thing but
the call to the ```_reassignSampledVarsPbToFullyCorrVars``` is now performed in the Sampler base class in order to avoid to call it in each Sampler (and in any new Sampler)

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
