### PR TITLE
fixed internal parallel test for PP

### DIFF
--- a/framework/PostProcessors/LimitSurfaceIntegral.py
+++ b/framework/PostProcessors/LimitSurfaceIntegral.py
@@ -195,6 +195,8 @@ class LimitSurfaceIntegral(PostProcessor):
         if self.variableDist[varName] == None:
           if 'lowerBound' not in self.lowerUpperDict[varName].keys() or 'upperBound' not in self.lowerUpperDict[varName].keys():
             self.raiseAnError(NameError, 'either a distribution name or lowerBound and upperBound need to be specified for variable ' + varName)
+    if self.computationPrefix == None:
+      self.raiseAnError(IOError,'The required XML node <outputName> has not been inputted!!!')
     if self.target == None:
       self.raiseAWarning('integral target has not been provided. The postprocessor is going to take the last output it finds in the provided limitsurface!!!')
 

--- a/tests/framework/InternalParallelTests/test_internal_parallel_PP_LS.xml
+++ b/tests/framework/InternalParallelTests/test_internal_parallel_PP_LS.xml
@@ -14,6 +14,7 @@
       <revision author="alfoa" date="2015-10-19">New syntax form samplerInit: from sampler_init -> samplerInit</revision>
       <revision author="maljdan" date="2016-04-06">Updating test cases to reflect the changes to the user input.</revision>
       <revision author="alfoa" date="2017-01-21">Adding this test description.</revision>
+      <revision author="alfoa" date="2018-01-09">Modified for new dataobject structure</revision>
     </revisions>
   </TestInfo>
   <RunInfo>
@@ -22,13 +23,6 @@
     <batchSize>5</batchSize>
     <internalParallel>True</internalParallel>
   </RunInfo>
-
-  <Files>
-    <Input name="limitSurfaceTestExternalModel.py" type="">limitSurfaceTestExternalModel.py</Input>
-    <Input name="goalFunctionTest.py" type="">goalFunctionTest.py</Input>
-    <Input name="LimitSurfaceUnWeightedPb_FileObj.csv" type="">LimitSurfaceUnWeightedPb_FileObj.csv</Input>
-    <Input name="LimitSurfaceWeightedPb_FileObj.csv" type="">LimitSurfaceWeightedPb_FileObj.csv</Input>
-  </Files>
 
   <Models>
     <ExternalModel ModuleToLoad="limitSurfaceTestExternalModel" name="PythonModule" subType="">
@@ -45,6 +39,7 @@
       <integralType>MonteCarlo</integralType>
       <seed>20021986</seed>
       <target>goalFunctionForLimitSurface</target>
+      <outputName>EventProbability</outputName>
       <variable name="x0">
         <distribution>x0_distrib</distribution>
       </variable>
@@ -57,6 +52,7 @@
       <integralType>MonteCarlo</integralType>
       <seed>20021986</seed>
       <target>goalFunctionForLimitSurface</target>
+      <outputName>EventProbability</outputName>
       <variable name="x0">
         <lowerBound>-2.0</lowerBound>
         <upperBound>12.0</upperBound>
@@ -130,14 +126,14 @@
       <Model class="Models" type="PostProcessor">LimitSurfaceIntegralWeighted</Model>
       <Output class="DataObjects" type="PointSet">LimitSurfaceWeightedPb</Output>
       <Output class="OutStreams" type="Print">LimitSurfaceWeightedPb_dump</Output>
-      <Output class="Files" type="">LimitSurfaceWeightedPb_FileObj.csv</Output>
+      <!-- NOT ALLOWED ANYMORE: <Output class="Files" type="">LimitSurfaceWeightedPb_FileObj.csv</Output> -->
     </PostProcess>
     <PostProcess name="ComputeLimitSurfaceIntegralUnWeighted">
       <Input class="DataObjects" type="PointSet">LimitSurfacePositiveNegative</Input>
       <Model class="Models" type="PostProcessor">LimitSurfaceIntegralUnWeightedWithBounds</Model>
       <Output class="DataObjects" type="PointSet">LimitSurfaceUnWeightedPb</Output>
       <Output class="OutStreams" type="Print">LimitSurfaceUnWeightedPb_dump</Output>
-      <Output class="Files" type="">LimitSurfaceUnWeightedPb_FileObj.csv</Output>
+      <!-- NOT ALLOWED ANYMORE: <Output class="Files" type="">LimitSurfaceUnWeightedPb_FileObj.csv</Output> -->
     </PostProcess>
   </Steps>
 
@@ -166,16 +162,16 @@
       <Output>z</Output>
     </PointSet>
     <PointSet name="LimitSurfacePositiveNegative">
-      <Input>x0,y0</Input>
+      <Input>y0,x0</Input>
       <Output>goalFunctionForLimitSurface</Output>
     </PointSet>
     <PointSet name="LimitSurfaceWeightedPb">
-      <Input>x0,y0</Input>
-      <Output>goalFunctionForLimitSurface</Output>
+      <Input>y0,x0</Input>
+      <Output>EventProbability,goalFunctionForLimitSurface</Output>
     </PointSet>
     <PointSet name="LimitSurfaceUnWeightedPb">
-      <Input>x0,y0</Input>
-      <Output>goalFunctionForLimitSurface</Output>
+      <Input>y0,x0</Input>
+      <Output>EventProbability,goalFunctionForLimitSurface</Output>
     </PointSet>
     <PointSet name="Dummy">
       <Input>x0,y0</Input>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Fix: framework/InternalParallelTests.PostProcessor


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
