### PR TITLE
rework: getpot test

### DIFF
--- a/tests/framework/test_getpot_ext.i
+++ b/tests/framework/test_getpot_ext.i
@@ -55,6 +55,9 @@
         node = source
         xmlToLoad = ExternalXMLTest/external_printsource.xml
       [../]
+      [./what]
+        value = input,output
+      [../]
     [../]
   [../]
 


### PR DESCRIPTION
Fixes the getpot test by adding the "what" parameter to the output.