### PR TITLE
changed the printing strategy of profiles

### DIFF
--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -33,7 +33,6 @@ import os
 import copy
 import sys
 import abc
-#import logging, logging.handlers
 import threading
 import random
 import socket

--- a/framework/Runners/Runner.py
+++ b/framework/Runners/Runner.py
@@ -28,8 +28,6 @@ import abc
 import copy
 import time
 import datetime
-import logging
-import threading
 #External Modules End--------------------------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------

--- a/framework/Runners/Runner.py
+++ b/framework/Runners/Runner.py
@@ -28,6 +28,8 @@ import abc
 import copy
 import time
 import datetime
+import logging
+import threading
 #External Modules End--------------------------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------
@@ -78,15 +80,17 @@ class Runner(MessageHandler.MessageUser):
       # print timing history
       pairs = self.timings.items()
       pairs.sort(key=lambda x:x[1])
-      self.raiseADebug('TIMINGS for job "{}":'.format(self.identifier))
+      prof = ""
+      prof += 'TIMINGS for job "{}":'.format(self.identifier)
       for e,(event,time) in enumerate(pairs):
         if e == 0:
-          self.raiseADebug('TIMINGS ... {:^20s} at {} ({})'.format(event,time,datetime.datetime.fromtimestamp(time).strftime('%Y-%m-%d %H:%M:%S')))
+          _, msg = self.messageHandler._printMessage(self,'TIMINGS ... {:^20s} at {} ({})'.format(event,time,datetime.datetime.fromtimestamp(time).strftime('%Y-%m-%d %H:%M:%S')) ,'DEBUG',3,None)
           last = time
         else:
-          self.raiseADebug('TIMINGS ... {:^20s} elapsed {:10.6f} s'.format(event,time-last))
+          _, msg = self.messageHandler._printMessage(self,'TIMINGS ... {:^20s} elapsed {:10.6f} s'.format(event,time-last),'DEBUG',3,None)
           last = time
-
+        prof +=  "\n"+msg
+      self.raiseADebug(prof)
 
   def isDone(self):
     """


### PR DESCRIPTION
The ```profile``` info in the job handler are printed by the Runners (i.e. threads/cpus). This can cause that in case of simultaneous printing, not all the information of a job are printed sequentially causing the impossibility to connect the info reported with the actual job. This PR improves this behavior creating a string a-priori and print it all in once.
