### PR TITLE
Alfoa/dataobject rework fix conflicts

### DIFF
--- a/scripts/TestHarness/testers/RavenUtils.py
+++ b/scripts/TestHarness/testers/RavenUtils.py
@@ -53,7 +53,6 @@ modules_to_try = [("h5py"      ,'h5py.__version__'      ,'2.4.0' ,'2.6.0' ,None 
 #                  ("netCDF4"   ,'netCDF4.__version__'   ,"1.2.3" ,"1.3.1" ,None   ),
 #                  ("matplotlib",'matplotlib.__version__',"1.3.1" ,"2.1.0" ,None   )]
 
-
 def __lookUpPreferredVersion(name):
   """
     Look up the preferred version in the modules.


### PR DESCRIPTION
--------
Pull Request Description
--------

This PR fixes all the Conflicts between ```devel``` and ```dataobject-rework``` branches 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
