### PR TITLE
expand install script for conda 4.4 and beyond

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -30,6 +30,9 @@ try_using_raven_environment ()
     fi
 }
 
+# if conda version 4.4+, they use function definitions instead of path inclusion.
+## however, they also define the CONDA_EXE variable, which is available.
+## once loaded, command -v conda works for both versions of conda.
 if [ "${#CONDA_EXE}" -gt 0 ];
 then
   echo sourcing conda function definitions ...

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -30,7 +30,13 @@ try_using_raven_environment ()
     fi
 }
 
-if which conda 2> /dev/null;
+if [ "${#CONDA_EXE}" -gt 0 ];
+then
+  echo sourcing conda function definitions ...
+  . "$(dirname $(dirname "${CONDA_EXE}"))/etc/profile.d/conda.sh"
+fi
+
+if command -v conda 2> /dev/null;
 then
   echo conda located, checking version ...
   echo `conda -V`


### PR DESCRIPTION
Extends the "establish_conda_env.sh" script to work for conda versions after 4.3, where making conda available is a function definition process instead of a path modification.

This is necessary because:
 1. `which` doesn't find `conda` since it isn't on `$PATH`
 1. `conda` itself can't be used to install libraries without sourcing `conda.sh`, since functions are not transferred from environment to shell script.

Closes #618 