### PR TITLE
partially addressing #733

### DIFF
--- a/framework/DataObjects/DataObject.py
+++ b/framework/DataObjects/DataObject.py
@@ -239,7 +239,11 @@ class DataObject(utils.metaclass_insert(abc.ABCMeta,BaseType)):
     # TODO typechecking, assertions
     coords = set().union(*params.values())
     for coord in coords:
-      self._pivotParams[coord] = list(var for var in params.keys() if coord in params[var])
+      if coord not in self._pivotParams:
+        self._pivotParams[coord] = list(var for var in params.keys() if coord in params[var])
+      else:
+        self._pivotParams[coord] = list(set(list(var for var in params.keys() if
+                                                 coord in params[var]) + self._pivotParams[coord]))
 
   def setSelectiveInput(self,option,value):
     """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Partially address issue #733

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
