### PR TITLE
increased thread safety of establish_conda_env.sh

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -41,13 +41,40 @@ function establish_OS ()
 	esac
 }
 
+function read_ravenrc ()
+{
+  # $1 should be the keyword we're looking for
+  # returns keyword argument through echo
+  ## note that "| xargs" trims leading and trailing whitespace
+  local TARGET=`echo $1 | xargs`
+  # location of the RC file
+  local RCNAME="${ECE_SCRIPT_DIR}/../.ravenrc"
+  # if the RC file exists, loop through it and read keyword arguments split by "="
+  if [ -f "$RCNAME" ]; then
+    while IFS='=' read -r KEY ARG || [[ -n "$keyarg" ]]; do
+      # trim whitespace
+      KEY=`echo $KEY | xargs`
+      ARG=`echo $ARG | xargs`
+      # check for key match
+      if [ "$KEY" = "$TARGET" ]; then
+        echo "$ARG"
+        return 0
+      fi
+    done < ${RCNAME}
+  fi
+  # if not found, return empty
+  echo ''
+}
+
 function find_conda_defs ()
 {
 	if [ -z ${CONDA_DEFS} ];
 	then
     # first check the RAVEN RC file for the key
-    CONDA_DEFS=`echo $(python ${ECE_SCRIPT_DIR}/update_install_data.py --read CONDA_DEFS)`
-    # if not setin RC, then will be empty string; next try defaults
+    CONDA_DEFS=$(read_ravenrc "CONDA_DEFS")
+    ## the following DOES NOT work if the system python is too old!
+    #CONDA_DEFS=`echo $(python ${ECE_SCRIPT_DIR}/update_install_data.py --read CONDA_DEFS)`
+    # if not set in RC, then will be empty string; next try defaults
     if [[ ${#CONDA_DEFS} == 0 ]];
     then
       # default location of conda definitions, windows is unsurprisingly an exception
@@ -74,11 +101,6 @@ function install_libraries()
   local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-install ${INSTALL_OPTIONAL} ${OSOPTION})`
   echo ... conda command: ${COMMAND}
   ${COMMAND}
-  # conda-forge
-  if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
-  local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-forge --conda-install ${OSOPTION})`
-  if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
-  ${COMMAND}
 }
 
 function create_libraries()
@@ -86,11 +108,6 @@ function create_libraries()
   if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries ...; fi
   local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-create ${INSTALL_OPTIONAL} ${OSOPTION})`
   if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda command: ${COMMAND}; fi
-  ${COMMAND}
-  # conda-forge
-  if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
-  local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-forge --conda-install ${OSOPTION})`
-  if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
   ${COMMAND}
 }
 
@@ -143,6 +160,7 @@ function set_install_settings()
   if [[ $ECE_VERBOSE == 0 ]]; then echo ... ${COMMAND}; fi
   ${COMMAND}
 }
+
 
 # main
 
@@ -208,7 +226,7 @@ if [[ $ECE_VERBOSE == 0 ]]; then echo ... Detected OS as ${OSOPTION} ...; fi
 if [ -z $RAVEN_LIBS_NAME ];
 then
   # check the RC file first
-  RAVEN_LIBS_NAME=`echo $(python ${ECE_SCRIPT_DIR}/update_install_data.py --read RAVEN_LIBS_NAME)`
+  RAVEN_LIBS_NAME=$(read_ravenrc "RAVEN_LIBS_NAME")  #FOLLOWING DOES NOT WORK on systems with old python `echo $(python ${ECE_SCRIPT_DIR}/update_install_data.py --read RAVEN_LIBS_NAME)`
   # if not found through the RC file, will be empty string, so default to raven_libraries
   if [[ ${#RAVEN_LIBS_NAME} == 0 ]];
   then
@@ -293,12 +311,13 @@ then
   else
     create_libraries
   fi
+  # since installation successful, write changed settings
+  ## store information about this creation in raven/.ravenrc text file
+  if [[ $ECE_VERBOSE == 0 ]]; then echo  ... writing settings to raven/.ravenrc ...; fi
+  set_install_settings
 fi
 
 # activate environment and write settings if successful
 activate_env
-# store information about this creation in raven/.ravenrc text file
-if [[ $ECE_VERBOSE == 0 ]]; then echo  ... writing settings to raven/.ravenrc ...; fi
-set_install_settings
 
 if [[ $ECE_VERBOSE == 0 ]]; then echo  ... done!; fi

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -72,8 +72,6 @@ function find_conda_defs ()
 	then
     # first check the RAVEN RC file for the key
     CONDA_DEFS=$(read_ravenrc "CONDA_DEFS")
-    ## the following DOES NOT work if the system python is too old!
-    #CONDA_DEFS=`echo $(python ${ECE_SCRIPT_DIR}/update_install_data.py --read CONDA_DEFS)`
     # if not set in RC, then will be empty string; next try defaults
     if [[ ${#CONDA_DEFS} == 0 ]];
     then
@@ -101,6 +99,11 @@ function install_libraries()
   local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-install ${INSTALL_OPTIONAL} ${OSOPTION})`
   echo ... conda command: ${COMMAND}
   ${COMMAND}
+  # conda-forge
+  if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
+  local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-forge --conda-install ${OSOPTION})`
+  if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
+  ${COMMAND}
 }
 
 function create_libraries()
@@ -108,6 +111,11 @@ function create_libraries()
   if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries ...; fi
   local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-create ${INSTALL_OPTIONAL} ${OSOPTION})`
   if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda command: ${COMMAND}; fi
+  ${COMMAND}
+  # conda-forge
+  if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
+  local COMMAND=`echo $(python ${RAVEN_UTILS} --conda-forge --conda-install ${OSOPTION})`
+  if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
   ${COMMAND}
 }
 

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -91,6 +91,8 @@ function find_conda_defs ()
       fi
     fi
 	fi
+  # fix Windows backslashes to be forwardslashes, compatible with all *nix
+  CONDA_DEFS="${CONDA_DEFS//\\//}"
 }
 
 function install_libraries()


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #754.

##### What are the significant changes in functionality due to this change request?
establish_conda_env.sh only writes to .ravenrc when running under "install" mode, not during "load" mode.

Also moves to using bash natively instead of python to read .ravenrc to support older python on some systems.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
