### PR TITLE
More intelligent Variable Groups

### DIFF
--- a/doc/user_manual/Makefile
+++ b/doc/user_manual/Makefile
@@ -1,6 +1,6 @@
 SRCFILE = raven_user_manual
 # MANUAL_FILES = optimizer.tex rom.tex postprocessor.tex database_data.tex OutStreamSystem.tex sampler.tex existing_interfaces.tex ProbabilityDistributions.tex  step.tex functions.tex ravenStructure.tex Summary.tex introduction.tex raven_user_manual.tex model.tex runInfo.tex libraries.tex DataMining.tex HowToRun.tex metrics.tex
-MANUAL_FILES = optimizer.tex rom.tex postprocessor.tex database_data.tex OutStreamSystem.tex sampler.tex \
+MANUAL_FILES = optimizer.tex rom.tex postprocessor.tex database_data.tex OutStreamSystem.tex sampler.tex variablegroups.tex \
 existing_interfaces.tex ProbabilityDistributions.tex  step.tex functions.tex ravenStructure.tex Summary.tex \
 introduction.tex raven_user_manual.tex model.tex runInfo.tex libraries.tex DataMining.tex HowToRun.tex metrics.tex \
 Installation/clone.tex Installation/conda.tex Installation/linux.tex Installation/macosx.tex Installation/main.tex \

--- a/doc/user_manual/variablegroups.tex
+++ b/doc/user_manual/variablegroups.tex
@@ -8,8 +8,9 @@ the input file, such as DataObjects, ROMs, and ExternalModels.
 Each entry in the \xmlNode{VariableGroups} block has a distinct name and list of each constituent variable in
 the group.
 %
-Alternatively, set operations can be used to construct variable groups from other variable groups.  In this case,
-the dependent groups and the base group on which operations should be performed must be listed.  The following types of
+Additionally, set operations can be used to construct variable groups from other variable groups, by listing
+them in node text along with the operation to perform.
+The following types of
 set operations are included in RAVEN:
 \begin{itemize}
   \item \texttt{+}, Union, the combination of all variables in the \xmlString{base} set and listed set,
@@ -18,8 +19,9 @@ set operations are included in RAVEN:
   \item \texttt{\%}, Symmetric Difference, the variables in only either the \xmlString{base} or listed set,
     but not both.
 \end{itemize}
-Multiple operations can be performed by separating them with commas in the text of the group node.  In the
-event the listed set is a single variable, it will be treated like a set with a single entry.
+Multiple set operations can be performed by separating them with commas in the text of the group node, whether
+they be variable groups or single variables. In the event a circular dependency loop is detected, an error will be
+raised. VariableGroups are evaluated in the order of entries listed in their node text.
 
 When using the variable groups in a node, they can be listed alone or as part of a comma-separated list.  The
 variable group name will only be substituted in the text of nodes, not attributes or tags.
@@ -31,13 +33,6 @@ Each \xmlNode{Group} node has the following attributes:
   \item \xmlAttr{name}, \xmlDesc{required string attribute}, user-defined name
   of the group. This is the identifier that will be used elsewhere in the RAVEN input.
   %
-  \item \xmlAttr{dependencies}, \xmlDesc{optional comma-separated string attribute}, the other variable groups
-    on which this group is dependent for construction.  If listed, all entries in the text of this node must
-    be proceeded by one of the set operators above.  Defaults to an empty string.
-  \item \xmlAttr{base}, \xmlDesc{optional string attribute}, the starting set for constructing a dependent
-    variable group.  This attribute is required if any dependencies are listed.  Set operations are performed
-    by performing the chosen operation on the variable group listed in this attribute along with the listed
-    variable group.  No default.
 \end{itemize}
 \vspace{-5mm}
 
@@ -48,15 +43,15 @@ remainder are examples of other operations.
 <Simulation>
   ...
   <VariableGroups>
-    <Group name="x_odd"  >x1,x3,x5</Group>
-    <Group name="x_even" >x2,x4,x6</Group>
-    <Group name="x_first">x1,x2,x3</Group>
-    <Group name="y_group">y1,y2</Group>
-    <Group name="add_remove" dependencies="x_first"         base="x_first">-x1,+ x4,+x5</Group>
-    <Group name="union"      dependencies="x_odd,x_even"    base="x_odd">+x_even</Group>
-    <Group name="complement" dependencies="x_odd,x_first"   base="x_odd">-x_first</Group>
-    <Group name="intersect"  dependencies="x_even,x_first"  base="x_even">^x_first</Group>
-    <Group name="sym_diff"   dependencies="x_odd,x_first"   base="x_odd">% x_first</Group>
+    <Group name="x_odd"     >x1,x3,x5</Group>
+    <Group name="x_even"    >x2,x4,x6</Group>
+    <Group name="x_first"   >x1,x2,x3</Group>
+    <Group name="y_group"   >y1,y2</Group>
+    <Group name="add_remove">x_first,-x1,+ x4,+x5</Group>
+    <Group name="union"     >x_odd,+x_even</Group>
+    <Group name="complement">x_odd,-x_first</Group>
+    <Group name="intersect" >x_even,^x_first</Group>
+    <Group name="sym_diff"  >x_odd,% x_first</Group>
   </VariableGroups>
   ...
   <DataObjects>

--- a/framework/VariableGroups.py
+++ b/framework/VariableGroups.py
@@ -33,6 +33,10 @@ from collections import OrderedDict
 import BaseClasses
 #Internal Modules End--------------------------------------------------------------------------------
 
+#
+#
+#
+#
 class VariableGroup(BaseClasses.BaseType):
   """
     Allows grouping of variables for ease of access
@@ -45,113 +49,69 @@ class VariableGroup(BaseClasses.BaseType):
     """
     BaseClasses.BaseType.__init__(self)
     self.printTag       = 'VariableGroup'
-    self._dependents    = []             #name of groups this group's construction is dependent on
-    self._base          = None           #if dependent, the name of base group to start from
-    self._list          = []             #text from node
     self.variables      = []             #list of variable names
     self.initialized    = False          #true when initialized
 
-  def _readMoreXML(self,node):
+  def readXML(self, node, messageHandler, varGroups):
     """
       reads XML for more information
       @ In, node, xml.etree.ElementTree.Element, xml element to read data from
+      @ In, varGroups, dict, other variable groups including ones this depends on (if any)
       @ Out, None
     """
+    self.messageHandler = messageHandler
     #establish the name
     if 'name' not in node.attrib.keys():
       self.raiseAnError(IOError,'VariableGroups require a "name" attribute!')
     self.name = node.attrib['name']
-    #dependents
-    deps = node.attrib.get('dependencies',None)
-    if deps is not None and len(deps)>0:
-      if 'base' not in node.attrib.keys():
-        self.raiseAnError(IOError,'VariableGroups with dependencies require a "base" group to start from!')
-      self._base = node.attrib.get('base')
-      self._dependents = list(g.strip() for g in deps.split(','))
-    self._list = node.text.split(',')
+    # loop through variables and expand list
+    for dep in [s.strip() for s in node.text.split(',')]:
+      # get operator if provided
+      operator = '+'
+      if dep[0] in '+-^%':
+        operator = dep[0]
+        dep = dep[1:].strip()
+      # expand variables if a group name is given
+      if dep in varGroups:
+        dep = varGroups[dep].getVars()
+      else:
+        dep = [dep]
 
-  def initialize(self,varGroups):
-    """
-      Establish variable set.
-      @ In, varGroups, list, VariableGroup classes
-      @ Out, None
-    """
-    if len(self._dependents)==0:
-      self.variables = list(l.strip() for l in self._list) #set(l.strip() for l in self._list) #don't use sets, since they destroy order
-    else:
-      #get base
-      base = None
-      for group in varGroups:
-        if group.name==self._base:
-          base = group
-          break
-      if base is None:
-        self.raiseAnError(IOError,'Base %s not found among variable groups!' %self._base)
-      #get dependencies
-      deps=OrderedDict()
-      for depName in self._dependents:
-        dep = None
-        for group in varGroups:
-          if group.name==depName:
-            dep = group
-            break
-        if dep is None:
-          self.raiseAnError(IOError,'Dependent %s not found among variable groups!' %depName)
-        deps[depName] = dep
-      #get base set
-      baseVars = set(base.getVars())
-      #do modifiers to base
-      modifiers = list(m.strip() for m in self._list)
-      orderOps = [] #order of operations that occurred, just var names and dep lists
-      for mod in modifiers:
-        #remove internal whitespace
-        mod = mod.replace(' ','')
-        #get operator and varname
-        op = mod[0]
-        varName = mod[1:]
-        if op not in ['+','-','^','%']:
-          self.raiseAnError(IOError,'Unrecognized or missing dependency operator:',op,varName)
-        #if varName is a single variable, make it a set so it behaves like the rest
-        if varName not in deps.keys():
-          modSet = [varName]
-        else:
-          modSet = deps[varName].getVars()
-        orderOps.append(modSet[:])
-        modSet = set(modSet)
-        if   op == '+':
-          baseVars.update(modSet)
-        elif op == '-':
-          baseVars.difference_update(modSet)
-        elif op == '^':
-          baseVars.intersection_update(modSet)
-        elif op == '%':
-          baseVars.symmetric_difference_update(modSet)
-      #sort variable list into self.variables
-      #  -> first, sort through top-level vars
-      for var in base.getVars():
-        if var in baseVars:
-          self.variables.append(var)
-          baseVars.remove(var)
-      #  -> then, sort through deps/operations in order
-      for mod in orderOps:
-        for var in mod:
-          if var in baseVars:
-            self.variables.append(var)
-            baseVars.remove(var)
-      #  -> baseVars better be empty now!
-      if len(baseVars) > 0:
-        self.raiseAWarning('    End vars    :',self.variables)
-        self.raiseAWarning('    End BaseVars:',baseVars)
-        self.raiseAnError(RuntimeError, 'Not all variableGroup entries were accounted for!  The operations were not performed correctly')
-    self.initialized=True
+      # apply operators
+      toRemove = []
+      ## union
+      if operator == '+':
+        for d in dep:
+          if d not in self.variables:
+            self.variables.append(d)
+      ## difference
+      elif operator == '-':
+        for d in dep:
+          try:
+            self.variables.remove(d)
+          except ValueError:
+            self.raiseADebug('Was asked to remove "{}" from variable group "{}", but it is not present! Ignoring ...'
+                               .format(d,self.name))
+      ## intersection
+      elif operator == '^':
+        for v in self.variables:
+          if v not in dep:
+            toRemove.append(v)
+      ## symmetric difference
+      elif operator == '%':
+        for v in self.variables:
+          if v in dep:
+            toRemove.append(v)
+        for d in dep:
+          if d not in self.variables:
+            self.variables.append(d)
+      ## cleanup
+      for v in toRemove:
+        self.variables.remove(v)
 
-  def getDependencies(self):
-    """
-      Returns list object of strings containing variable group names
-      @ In, None
-      @ Out, _dependents, list(str), list of variable group names
-    """
-    return self._dependents[:]
+    # finished
+    self.raiseADebug('Variable group "{}" includes:'.format(self.name),self.getVarsString)
+
 
   def getVars(self):
     """
@@ -172,4 +132,4 @@ class VariableGroup(BaseClasses.BaseType):
 #
 #
 #
-# end
+#

--- a/framework/VariableGroups.py
+++ b/framework/VariableGroups.py
@@ -110,7 +110,7 @@ class VariableGroup(BaseClasses.BaseType):
         self.variables.remove(v)
 
     # finished
-    self.raiseADebug('Variable group "{}" includes:'.format(self.name),self.getVarsString)
+    self.raiseADebug('Variable group "{}" includes:'.format(self.name),self.getVarsString())
 
 
   def getVars(self):

--- a/framework/utils/xmlUtils.py
+++ b/framework/utils/xmlUtils.py
@@ -26,6 +26,7 @@ import xml.dom.minidom as pxml
 import re
 import os
 from .utils import isString
+from .graphStructure import graphObject
 import VariableGroups
 
 #define type checking
@@ -356,27 +357,36 @@ def readVariableGroups(xmlNode,messageHandler,caller):
     @ In, caller, MessageHandler.MessageUser instance, entity calling this method (needs to inherit from MessageHandler.MessageUser)
     @ Out, varGroups, dict, dictionary of variable groups (names to the variable lists to replace the names)
   """
-  varGroups = {}
+  # first find all the names
+  names = [node.attrib['name'] for node in xmlNode]
+
+  # find dependencies
+  deps = {}
+  nodes = {}
+  initials = []
   for child in xmlNode:
-    varGroup = VariableGroups.VariableGroup()
-    varGroup.readXML(child,messageHandler)
-    varGroups[varGroup.name]=varGroup
-  # initialize variable groups
-  while any(not vg.initialized for vg in varGroups.values()):
-    numInit = 0 #new vargroups initialized this pass
-    for vg in varGroups.values():
-      if vg.initialized:
-        continue
-      try:
-        deps = list(varGroups[dp] for dp in vg.getDependencies())
-      except KeyError as e:
-        caller.raiseAnError(IOError,'Dependency %s listed but not found in varGroups!' %e)
-      if all(varGroups[dp].initialized for dp in vg.getDependencies()):
-        vg.initialize(varGroups.values())
-        numInit+=1
-    if numInit == 0:
-      caller.raiseAWarning('variable group status:')
-      for name,vg in varGroups.items():
-        caller.raiseAWarning('   ',name,':',vg.initialized)
-      caller.raiseAnError(RuntimeError,'There was an infinite loop building variable groups!')
+    name = child.attrib['name']
+    nodes[name] = child
+    needs = [s.strip().strip('-+^%') for s in child.text.split(',')]
+    for n in needs:
+      if n not in deps and n not in names:
+        deps[n] = []
+    deps[name] = needs
+    if len(deps[name]) == 0:
+      initials.append(name)
+  graph = graphObject(deps)
+  # sanity checking
+  if graph.isALoop():
+    caller.raiseAnError(IOError,'VariableGroups have circular dependency! Order:',' -> '.join(graph.createSingleListOfVertices(alls)))
+  # ordered list (least dependencies first)
+  hierarchy = list(reversed(graph.createSingleListOfVertices(graph.findAllUniquePaths(initials))))
+
+  # build entities
+  varGroups = {}
+  for name in hierarchy:
+    if len(deps[name]):
+      varGroup = VariableGroups.VariableGroup()
+      varGroup.readXML(nodes[name], messageHandler, varGroups)
+      varGroups[name] = varGroup
+
   return varGroups

--- a/scripts/conversionScripts/vargroups_nobases.py
+++ b/scripts/conversionScripts/vargroups_nobases.py
@@ -1,0 +1,40 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import xml.etree.ElementTree as ET
+import xml.dom.minidom as pxml
+import os
+
+def convert(tree,fileName=None):
+  """
+    Removes the "base" and "dependencies" from VariableGroups and places them in the text.
+    @ In, tree, xml.etree.ElementTree.ElementTree object, the contents of a RAVEN input file
+    @ In, fileName, the name for the raven input file
+    @Out, tree, xml.etree.ElementTree.ElementTree object, the modified RAVEN input file
+  """
+  simulation = tree.getroot()
+  groupsNode = simulation.find('VariableGroups')
+  if groupsNode is not None:
+    for node in groupsNode:
+      if 'base' in node.attrib:
+        node.text = node.attrib['base'] + ',' + node.text
+        del node.attrib['base']
+        del node.attrib['dependencies']
+      elif 'dependencies' in node.attrib:
+        del node.attrib['dependencies']
+  return tree
+
+if __name__=='__main__':
+  import convert_utils
+  import sys
+  convert_utils.standardMain(sys.argv,convert)

--- a/tests/framework/VariableGroups/ExternalNodes/vargroups.xml
+++ b/tests/framework/VariableGroups/ExternalNodes/vargroups.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <VariableGroups>
-      <Group name="x_odd"                                     >x1,x3,x5</Group>
-      <Group name="x_even"     dependencies=""                >x2,x4,x6</Group>
-      <Group name="y_group"    dependencies=""                >y1,y2</Group>
-      <Group name="union"      dependencies="x_odd,x_even"    base="x_odd">+x_even</Group>
+      <Group name="x_odd"  >x1,x3,x5</Group>
+      <Group name="x_even" >x2,x4,x6</Group>
+      <Group name="y_group">y1,y2</Group>
+      <Group name="union"  >x_odd, x_even</Group>
 </VariableGroups>

--- a/tests/framework/VariableGroups/gold/Ordered/duplicated_input.xml
+++ b/tests/framework/VariableGroups/gold/Ordered/duplicated_input.xml
@@ -1,15 +1,22 @@
 <Simulation verbosity="debug">
-  
   <RunInfo>
     <WorkingDir>Ordered</WorkingDir>
     <printInput />
     <Sequence>sample,print</Sequence>
   </RunInfo>
 
+  <TestInfo>
+    <name>framework/VariableGroups/OrderedVariables</name>
+    <author>talbpaul</author>
+    <created>2016-02-08</created>
+    <classesTested>VariableGroups</classesTested>
+    <description>tests order preservation of variables in variable groups</description>
+  </TestInfo>
+
   <VariableGroups>
     <Group name="x_odd">x1,x3,x5</Group>
     <Group name="x_even">x2,x4,x6</Group>
-    <Group base="x_odd" dependencies="x_odd,x_even" name="union">+x_even</Group>
+    <Group name="union">x_odd,+x_even</Group>
   </VariableGroups>
 
   <Distributions>
@@ -92,15 +99,18 @@
     <Print name="dump_uni">
       <type>csv</type>
       <source>uni</source>
+      <what>input,output</what>
     </Print>
     <Print name="dump_odd">
       <type>csv</type>
       <source>odd</source>
+      <what>input,output</what>
     </Print>
     <Print name="dump_even">
       <type>csv</type>
       <source>even</source>
+      <what>input,output</what>
     </Print>
   </OutStreams>
-
 </Simulation>
+

--- a/tests/framework/VariableGroups/ordered.xml
+++ b/tests/framework/VariableGroups/ordered.xml
@@ -5,6 +5,7 @@
     <printInput/>
     <Sequence>sample,print</Sequence>
   </RunInfo>
+
   <TestInfo>
     <name>framework/VariableGroups/OrderedVariables</name>
     <author>talbpaul</author>
@@ -18,7 +19,7 @@
   <VariableGroups>
     <Group name="x_odd">x1,x3,x5</Group>
     <Group name="x_even">x2,x4,x6</Group>
-    <Group base="x_odd" dependencies="x_odd,x_even" name="union">+x_even</Group>
+    <Group name="union">x_odd,+x_even</Group>
   </VariableGroups>
 
   <Distributions>

--- a/tests/framework/VariableGroups/rom.xml
+++ b/tests/framework/VariableGroups/rom.xml
@@ -5,6 +5,7 @@
     <Sequence>sample,train,samprom,print</Sequence>
     <batchSize>1</batchSize>
   </RunInfo>
+
   <TestInfo>
     <name>framework/VariableGroups/ROM</name>
     <author>talbpaul</author>
@@ -17,9 +18,9 @@
 
   <VariableGroups>
     <Group name="x_odd">x1,x3,x5</Group>
-    <Group dependencies="" name="x_even">x2,x4,x6</Group>
-    <Group dependencies="" name="y_group">y1,y2</Group>
-    <Group base="x_odd" dependencies="x_odd,x_even" name="union">+x_even</Group>
+    <Group name="x_even">x2,x4,x6</Group>
+    <Group name="y_group">y1,y2</Group>
+    <Group name="union">x_odd,+x_even</Group>
   </VariableGroups>
 
   <Distributions>
@@ -110,7 +111,7 @@
     <Print name="dump_romout">
       <type>csv</type>
       <source>romout</source>
-     <what>input, output, metadata|ProbabilityWeight, metadata|prefix</what>
+      <what>input, output, metadata|ProbabilityWeight, metadata|prefix</what>
     </Print>
   </OutStreams>
 

--- a/tests/framework/VariableGroups/sets.xml
+++ b/tests/framework/VariableGroups/sets.xml
@@ -11,20 +11,29 @@
     <created>2016-02-08</created>
     <classesTested>VariableGroups</classesTested>
     <description>
-      tests set operations and data objects for using variable groups
+      Tests complex VariableGroup construction using plus, minus, intersect, and symmetric difference
+      operations. Uses these constructs in the DataObjects.
+
+      To test correct operation, check the headers of the output data objects for the right variable lists,
+      both the names themeselves and the order of the columns.
+
+      Additional unit tests for VariableGroups are in the raven/tests/framework/unit_tests/utils/testXmlUtils.py file.
     </description>
+    <revisions>
+      <revision author="talbpaul" date="2018-09-25">implicit nested group usage instead of explicit</revision>
+    </revisions>
   </TestInfo>
 
   <VariableGroups>
-    <Group name="x_odd">x1,x3,x5</Group>
-    <Group dependencies="" name="x_even">x2,x4,x6</Group>
-    <Group dependencies="" name="x_first">x1,x2,x3</Group>
-    <Group dependencies="" name="y_group">y1,y2</Group>
-    <Group base="x_first" dependencies="x_first" name="add_remove">-x1,+ x4,+x5</Group>
-    <Group base="x_odd" dependencies="x_odd,x_even" name="union">+x_even</Group>
-    <Group base="x_odd" dependencies="x_odd,x_first" name="complement">-x_first</Group>
-    <Group base="x_even" dependencies="x_even,x_first" name="intersect">^x_first</Group>
-    <Group base="x_odd" dependencies="x_odd,x_first" name="sym_diff">% x_first</Group>
+    <Group name="x_odd"  >x1,x3,x5</Group>
+    <Group name="x_even" >x2,x4,x6</Group>
+    <Group name="x_first">x1,x2,x3</Group>
+    <Group name="y_group">y1,y2</Group>
+    <Group name="add_remove">x_first, -x1, + x4, +x5</Group>
+    <Group name="union">x_odd, +x_even</Group>
+    <Group name="complement">x_odd, -x_first</Group>
+    <Group name="intersect">x_even, ^x_first</Group>
+    <Group name="sym_diff">x_odd, % x_first</Group>
   </VariableGroups>
 
   <Distributions>

--- a/tests/framework/unit_tests/utils/testXmlUtils.py
+++ b/tests/framework/unit_tests/utils/testXmlUtils.py
@@ -29,6 +29,10 @@ frameworkDir = os.path.normpath(os.path.join(os.path.dirname(__file__),os.pardir
 sys.path.append(frameworkDir)
 from utils import xmlUtils
 
+from MessageHandler import MessageHandler
+mh = MessageHandler()
+mh.initialize({})
+
 print (xmlUtils)
 
 results = {"pass":0,"fail":0}
@@ -347,7 +351,72 @@ if correct != ET.tostring(root):
 else:
   results['pass']+=1
 
+
+###################
+# Variable Groups #
+###################
+
+print('')
+# all ( a, b, d)
+# d (some a, some b)
+# ab (a, b)
+# ce (c, e)
+# f is isolated
+example = """<VariableGroups>
+  <Group name="a">a1, a2, a3</Group>
+  <Group name="b">b1, b2, b3</Group>
+  <Group name="c">c1, c2, c3</Group>
+  <Group name="d">a1, b1</Group>
+  <Group name="e">e1, e2 ,e3</Group>
+  <Group name="f">f1, f2, f3</Group>
+  <Group name="ce">c, e</Group>
+  <Group name="ab">a,b</Group>
+  <Group name="abd">a,b,d</Group>
+  <Group name="plus">a,c</Group>
+  <Group name="minus">a,-d</Group>
+  <Group name="intersect">a,^d</Group>
+  <Group name="symmdiff">a,%d</Group>
+  <Group name="symmrev">d,%a</Group>
+</VariableGroups>"""
+node = ET.fromstring(example)
+groups = xmlUtils.readVariableGroups(node,mh,None)
+
+# test contents
+def testVarGroup(groups,g,right):
+  got = groups[g].getVarsString()
+  if got == right:
+    results['pass']+=1
+  else:
+    print('ERROR: Vargroups group "{}" should be "{}" but got "{}"!'.format(g,right,got))
+    results['fail']+=1
+
+# note that order matters for these solutions!
+testVarGroup(groups,'a','a1,a2,a3')             # a and b are first basic sets
+testVarGroup(groups,'b','b1,b2,b3')             # a and b are first basic sets
+testVarGroup(groups,'c','c1,c2,c3')             # c and e are second basic sets
+testVarGroup(groups,'d','a1,b1')                # d is just a1 and b1, to test one-entry-per-variable
+testVarGroup(groups,'e','e1,e2,e3')             # c and e are second basic sets
+testVarGroup(groups,'f','f1,f2,f3')             # f is isolated; nothing else uses it
+testVarGroup(groups,'ce','c1,c2,c3,e1,e2,e3')   # ce combines c and e
+testVarGroup(groups,'ab','a1,a2,a3,b1,b2,b3')   # ab combines a and b
+testVarGroup(groups,'abd','a1,a2,a3,b1,b2,b3')  # ab combines a and b
+testVarGroup(groups,'plus','a1,a2,a3,c1,c2,c3') # plus is OR for a and c
+testVarGroup(groups,'minus','a2,a3')            # minus is a but not d
+testVarGroup(groups,'intersect','a1')           # intersect is AND for a, d
+testVarGroup(groups,'symmdiff','a2,a3,b1')      # symdiff is XOR for a, d
+testVarGroup(groups,'symmrev','b1,a2,a3')       # symmrev shows order depends on how variables are put in
+
+
+
+
+
+
+
+
 print(results)
+
+
+
 
 sys.exit(results["fail"])
 """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #801 

##### What are the significant changes in functionality due to this change request?
Removes burdensome input from user for creating variable groups and creates them intelligently using the graphStructure instead. Other behavior remains the same.

A conversion script has been added for this change, and an email explaining the changes will be important as this is prepared to merge.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
