### PR TITLE
buckup automatic testing machine directives 

### DIFF
--- a/scripts/AutomatiTestingRecipes/CentOS-6.cfg
+++ b/scripts/AutomatiTestingRecipes/CentOS-6.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test CentOS 6
+display_name = Test CentOS 6
+active = True
+private = True
+automatic = authorized
+build_configs = raven-centos-6
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = True
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = True
+TEST_NO_PYTHON = 1
+

--- a/scripts/AutomatiTestingRecipes/CentOS-7.cfg
+++ b/scripts/AutomatiTestingRecipes/CentOS-7.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test CentOS 7
+display_name = Test CentOS 7
+active = True
+private = True
+automatic = authorized
+build_configs = raven-centos-7
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+

--- a/scripts/AutomatiTestingRecipes/Code_Coverage.cfg
+++ b/scripts/AutomatiTestingRecipes/Code_Coverage.cfg
@@ -1,0 +1,56 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Code Coverage
+display_name = Code Coverage
+help = Generate Python code coverage
+active = True
+private = True
+allow_on_pr = True
+automatic = authorized
+build_configs = linux-gnu-coverage
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Environment]
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules boost autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+LOAD_OPTIONAL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven --coverage
+COVERAGE = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+
+[Build Python Coverage]
+script = scripts/app_python_coverage.sh
+abort_on_failure = True
+allowed_to_fail = False
+CIVET_SERVER_POST_COMMENT = 1
+CIVET_SERVER_POST_EDIT_EXISTING = 1

--- a/scripts/AutomatiTestingRecipes/Fedora-28.cfg
+++ b/scripts/AutomatiTestingRecipes/Fedora-28.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test Fedora 28
+display_name = Test Fedora 28
+active = True
+private = True
+automatic = authorized
+build_configs = raven-fedora-28
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+

--- a/scripts/AutomatiTestingRecipes/Fedora-29.cfg
+++ b/scripts/AutomatiTestingRecipes/Fedora-29.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test Fedora 29
+display_name = Test Fedora 29
+active = True
+private = True
+automatic = authorized
+build_configs = raven-fedora-29
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+

--- a/scripts/AutomatiTestingRecipes/Infrastructure.cfg
+++ b/scripts/AutomatiTestingRecipes/Infrastructure.cfg
@@ -1,0 +1,61 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Infrastructure
+display_name = Infrastructure
+active = True
+private = True
+trigger_push = True
+priority_push = 0
+trigger_push_branch = master
+automatic = authorized
+build_configs = linux-gnu-coverage
+auto_cancel_on_new_push = True
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules boost autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+COPY_PUBLIC = 0
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+LOAD_OPTIONAL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven --coverage
+COVERAGE = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+
+[Build Python Coverage]
+script = scripts/app_python_coverage.sh
+abort_on_failure = True
+allowed_to_fail = False
+CIVET_MAX_STEP_TIME = 10800
+
+[Doxygen]
+script = scripts/app_doxygen.sh
+abort_on_failure = True
+allowed_to_fail = False
+CIVET_MAX_STEP_TIME = 7200

--- a/scripts/AutomatiTestingRecipes/Merge.cfg
+++ b/scripts/AutomatiTestingRecipes/Merge.cfg
@@ -1,0 +1,33 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = devel->master merge
+display_name = Merge
+active = True
+private = True
+trigger_push = True
+priority_push = 30
+trigger_push_branch = devel
+automatic = authorized
+build_configs = linux-gnu
+
+[Push Dependencies]
+filename0 = recipes/moosebuild/raven/Test_devel.cfg
+filename1 = recipes/moosebuild/raven/Test_mac.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Merge and Commit]
+script = scripts/merge_and_commit.sh
+abort_on_failure = True
+allowed_to_fail = False

--- a/scripts/AutomatiTestingRecipes/Mingw_Test.cfg
+++ b/scripts/AutomatiTestingRecipes/Mingw_Test.cfg
@@ -1,0 +1,59 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Mingw Test
+display_name = Mingw Test
+active = True
+private = True
+trigger_pull_request = True
+priority_pull_request = 49
+automatic = authorized
+build_configs = win-mingw
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch Raven]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Show env]
+script = scripts/run_cmd.sh
+abort_on_failure = False
+allowed_to_fail = True
+RUN_CMD = env
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = False
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./run_framework_tests -j 4 -l 4

--- a/scripts/AutomatiTestingRecipes/OpenSUSE-Leap-15.cfg
+++ b/scripts/AutomatiTestingRecipes/OpenSUSE-Leap-15.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test OpenSUSE Leap 15
+display_name = Test OpenSUSE Leap 15
+active = True
+private = True
+automatic = authorized
+build_configs = raven-leap-15
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+

--- a/scripts/AutomatiTestingRecipes/Precheck.cfg
+++ b/scripts/AutomatiTestingRecipes/Precheck.cfg
@@ -1,0 +1,33 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Precheck
+display_name = Precheck
+active = True
+private = True
+automatic = automatic
+build_configs = linux-gnu
+
+trigger_pull_request = True
+priority_pull_request = 90
+
+trigger_push = True
+trigger_push_branch = devel
+priority_push = 30
+
+[Global Sources]
+filename0 = scripts/env.sh
+filename1 = scripts/env_pre_check.sh
+
+[Global Environment]
+CHECK_TICKET_REFERENCE = 0
+CHECK_STYLE = 0
+CHECK_KEYWORDS = 0
+CHECK_EOF = 0
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+
+[Pre test]
+script = scripts/pre_check.sh
+abort_on_failure = True
+allowed_to_fail = False

--- a/scripts/AutomatiTestingRecipes/README
+++ b/scripts/AutomatiTestingRecipes/README
@@ -1,0 +1,17 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+This folder containes the recipes for the automatic regression test system.
+The original recipes are stored and maintained in the CIVET repository.
+This is just a buck-up storage.

--- a/scripts/AutomatiTestingRecipes/Test.cfg
+++ b/scripts/AutomatiTestingRecipes/Test.cfg
@@ -1,0 +1,68 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test linux
+display_name = Test linux
+active = True
+private = True
+automatic = authorized
+build_configs = linux-gnu
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+
+[Update plugins submodules]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = git submodule update --init
+
+[Test plugins]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = True
+TEST_NO_PYTHON = 1
+TEST_ARGS = --re plugins

--- a/scripts/AutomatiTestingRecipes/Test_Heavy.cfg
+++ b/scripts/AutomatiTestingRecipes/Test_Heavy.cfg
@@ -1,0 +1,59 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test heavy
+display_name = Test heavy
+active = True
+private = True
+automatic = authorized
+build_configs = linux-gnu-heavy
+help = Run tests with --heavy
+
+allow_on_pr = True
+priority_pull_request = 40
+
+trigger_manual = True
+trigger_manual_branch = master
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Heavy Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+TEST_ARGS = --heavy

--- a/scripts/AutomatiTestingRecipes/Test_devel.cfg
+++ b/scripts/AutomatiTestingRecipes/Test_devel.cfg
@@ -1,0 +1,70 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test linux
+display_name = Test linux
+active = True
+private = True
+automatic = authorized
+build_configs = linux-gnu
+create_issue_on_fail = True
+
+trigger_push = True
+trigger_push_branch = devel
+priority_push = 30
+
+[Push Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+
+[Update plugins submodules]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = git submodule update --init
+
+[Test plugins]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+TEST_ARGS = --re plugins

--- a/scripts/AutomatiTestingRecipes/Test_mac.cfg
+++ b/scripts/AutomatiTestingRecipes/Test_mac.cfg
@@ -1,0 +1,62 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test mac
+display_name = Test mac
+active = True
+private = True
+automatic = authorized
+build_configs = raven-mac
+
+trigger_pull_request = True
+priority_pull_request = 55
+
+trigger_push = True
+trigger_push_branch = devel
+priority_push = 90
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Push Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1

--- a/scripts/AutomatiTestingRecipes/Test_masters.cfg
+++ b/scripts/AutomatiTestingRecipes/Test_masters.cfg
@@ -1,0 +1,56 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test master version of submodules
+display_name = Test masters
+help = Test RAVEN against master version of MOOSE
+active = True
+private = True
+trigger_push = True
+priority_push = 0
+trigger_push_branch = master
+automatic = automatic
+build_configs = linux-gnu
+auto_cancel_on_new_push = True
+allow_on_pr = True
+
+[Pullrequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+LOADED_MODULES = civet/.civet mpich-gcc-petsc_default-vtk advanced_modules autotools cmake
+APPLICATION_REPO = git@github.com:idaholab/raven
+USE_MOOSE = moose
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = True
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = True
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = True
+TEST_NO_PYTHON = 1

--- a/scripts/AutomatiTestingRecipes/Test_qsubs.cfg
+++ b/scripts/AutomatiTestingRecipes/Test_qsubs.cfg
@@ -1,0 +1,82 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test qsubs
+display_name = Test qsubs
+active = True
+private = True
+trigger_pull_request = True
+priority_pull_request = 50
+automatic = authorized
+build_configs = raven-hpc
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Pylint]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./developer_tools/pylint_check
+PYTHON_ENV = raven_falcon_libraries
+
+[Docs]
+script = scripts/run_cmd.sh
+abort_on_failure = False
+allowed_to_fail = False
+RUN_CMD = ./doc/make_docs.sh
+
+[Check test syntax]
+script = scripts/run_cmd.sh
+abort_on_failure = False
+allowed_to_fail = False
+RUN_CMD = ./developer_tools/validate_xml.sh
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = False
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+TEST_ARGS = -j6
+
+[Test qsubs]
+script = scripts/run_cmd.sh
+abort_on_failure = False
+allowed_to_fail = False
+RUN_CMD = ./test_qsubs.sh
+APP_SUBDIR = tests/cluster_tests

--- a/scripts/AutomatiTestingRecipes/Ubuntu-16.cfg
+++ b/scripts/AutomatiTestingRecipes/Ubuntu-16.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test Ubuntu 16
+display_name = Test Ubuntu 16
+active = True
+private = True
+automatic = authorized
+build_configs = raven-ubuntu-16
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+

--- a/scripts/AutomatiTestingRecipes/Ubuntu-18-2.cfg
+++ b/scripts/AutomatiTestingRecipes/Ubuntu-18-2.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test Ubuntu 18-2 Python 3
+display_name = Test Ubuntu 18-2 Python 3
+active = True
+private = True
+automatic = authorized
+build_configs = raven-ubuntu-18-2
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env_py3.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+

--- a/scripts/AutomatiTestingRecipes/Ubuntu-18.cfg
+++ b/scripts/AutomatiTestingRecipes/Ubuntu-18.cfg
@@ -1,0 +1,57 @@
+[Main]
+build_user = moosebuild
+repository = git@github.com:idaholab/raven
+name = Test Ubuntu 18
+display_name = Test Ubuntu 18
+active = True
+private = True
+automatic = authorized
+build_configs = raven-ubuntu-18
+
+trigger_pull_request = True
+priority_pull_request = 40
+
+[PullRequest Dependencies]
+filename0 = recipes/moosebuild/raven/Precheck.cfg
+
+[Global Sources]
+filename0 = scripts/env.sh
+
+[Global Environment]
+APPLICATION_REPO = git@github.com:idaholab/raven
+METHODS = opt
+METHOD = opt
+PYTHONUNBUFFERED = 1
+NO_SINGULARITY_EXEC = True
+
+[Fetch and Branch]
+script = scripts/fetch_and_branch.sh
+abort_on_failure = True
+allowed_to_fail = False
+
+[Set python environment]
+# This creates the raven_libraries conda environment
+script = scripts/raven_conda_env.sh
+abort_on_failure = True
+allowed_to_fail = False
+DEFAULT_INSTALL = 1
+
+[Build Raven]
+script = scripts/run_cmd.sh
+abort_on_failure = True
+allowed_to_fail = False
+RUN_CMD = ./build_raven
+
+[Libraries]
+script = scripts/tests.sh
+abort_on_failure = False
+allowed_to_fail = True
+TEST_ARGS = --library-report
+TEST_NO_PYTHON = 1
+
+[Test Raven]
+script = scripts/tests.sh
+abort_on_failure = True
+allowed_to_fail = False
+TEST_NO_PYTHON = 1
+


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Ref. #667

##### What are the significant changes in functionality due to this change request?
Added the CIVET recipes in RAVEN repository

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

