### PR TITLE
Adding engine option on each random utils function 

### DIFF
--- a/framework/utils/randomUtils.py
+++ b/framework/utils/randomUtils.py
@@ -22,7 +22,7 @@ import warnings
 warnings.simplefilter('default',DeprecationWarning)
 
 import numpy as np
-from collections import deque
+from collections import deque, defaultdict
 
 from utils.utils import findCrowModule
 
@@ -34,45 +34,47 @@ class BoxMullerGenerator:
   """
     Iterator class for the Box-Muller transform
   """
-  def __init__(self):
+  def __init__(self,engine=None):
     """
       Constructor.
-      @ In, None
+      @ In, engine, instance, optional, random number generator
       @ Out, None
     """
-    self.queue = deque()
+    self.queue = defaultdict(deque)
+    self.engine = engine
 
-  def generate(self):
+  def generate(self,engine=None):
     """
       Yields a normally-distributed pseudorandom value
-      @ In, None
+      @ In, engine, instance, optional, random number generator
       @ Out, generate, float, random value
     """
-    if len(self.queue) == 0:
+    if len(self.queue[engine]) == 0:
       #calculate new values
-      self.queue.extend(self.createSamples())
-    return self.queue.pop() #no need to pop left, as they're independent and all get used
+      self.queue[engine].extend(self.createSamples(engine=engine))
+    return self.queue[engine].pop() #no need to pop left, as they're independent and all get used
 
-  def createSamples(self):
+  def createSamples(self,engine=None):
     """
       Sample calculator.  Because Box Muller does batches of 2, add them to a queue.
-      @ In, None
+      @ In, engine, instance, optional, random number generator.
       @ Out, (z1,z2), tuple, two independent random values
     """
-    u1,u2 = random(2)
+    u1,u2 = random(2,engine=engine)
     z1 = np.sqrt(-2.*np.log(u1))*np.cos(2.*np.pi*u2)
     z2 = np.sqrt(-2.*np.log(u1))*np.sin(2.*np.pi*u2)
     return z1,z2
 
-  def testSampling(self, n=1e5):
+  def testSampling(self, n=1e5,engine=None):
     """
       Tests distribution of samples over a large number.
       @ In, n, int, optional, number of samples to test with
+      @ In, engine, instance, optional, random number generator
       @ Out, mean, float, mean of sample set
       @ Out, stdev, float, standard deviation of sample set
     """
     n = int(n)
-    samples = np.array([self.generate() for _ in range(n)])
+    samples = np.array([self.generate(engine=engine) for _ in range(n)])
     mean = np.average(samples)
     stdev = np.std(samples)
     return mean,stdev
@@ -84,107 +86,156 @@ else:
   # this is needed for now since we need to split the stoch enviroments
   distStochEnv = findCrowModule('distribution1D').DistributionContainer.instance()
   boxMullerGen = BoxMullerGenerator()
+  # not sure if this boxMullerGen still needed, will be test this line after first commit
 
-def randomSeed(value,seedBoth=False):
+def randomSeed(value,seedBoth=False,engine=None):
   """
     Function to get a random seed
     @ In, value, float, the seed
+    @ In, engine, instance, optional, random number generator
     @ In, seedBoth, bool, optional, if True then seed both random environments
     @ Out, None
   """
-  if stochasticEnv == 'numpy':
-    global npStochEnv
-    npStochEnv = np.random.RandomState(value)
-  else:
-    crowStochEnv.seed(value)
-    # we must do the following now since there is no separation between the distribution (stoch eviroment) and the one here
-    ## TODO: split it in the sampler. Design needed.
-    distStochEnv.seedRandom(value)
+  replaceGlobalEnv=False
+  ## choose an engine if it is none
+  if engine is None:
+    if stochasticEnv == 'crow':
+      distStochEnv.seedRandom(value)
+      engine=crowStochEnv
+    elif stochasticEnv == 'numpy':
+      replaceGlobalEnv=True
+      global npStochEnv
+      engine = npStochEnv
+
+  if isinstance(engine, np.random.RandomState):
+    engine = np.random.RandomState(value)
+  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
+    engine.seed(value)
     if seedBoth:
       np.random.seed(value+1) # +1 just to prevent identical seed sets
+      # not sure if this loop shold one level up
+  if stochasticEnv== 'numpy' and replaceGlobalEnv:
+    #global npStochEnv
+    npStochEnv= engine
   print('randomUtils: Global random number seed has been changed to',value)
 
-def random(dim=1,samples=1,keepMatrix=False):
+def random(dim=1,samples=1,keepMatrix=False,engine=None):
   """
     Function to get a single random value, an array of random values, or a matrix of random values, on [0,1]
     @ In, dim, int, optional, dimensionality of samples
     @ In, samples, int, optional, number of arrays to deliver
     @ In, keepMatrix, bool, optional, if True then will always return np.array(np.array(float))
+    @ In, engine, instance, optional, random number generator
     @ Out, vals, float, random normal number (or np.array with size [n] if n>1, or np.array with size [n,samples] if sampels>1)
   """
+  ## choose an engine if it is none
+  if engine is None:
+    if stochasticEnv == 'numpy':
+      engine = npStochEnv
+    elif stochasticEnv == 'crow':
+      engine = crowStochEnv
   dim = int(dim)
   samples = int(samples)
-  if stochasticEnv == 'numpy':
-    vals = npStochEnv.rand(samples,dim)
-  else: #crow
+  if isinstance(engine, np.random.RandomState):
+    vals = engine.rand(samples,dim)
+  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
     vals = np.zeros([samples,dim])
     for i in range(len(vals)):
       for j in range(len(vals[0])):
-        vals[i][j] = crowStochEnv.random()
+        vals[i][j] = engine.random()
+  else:
+    raise TypeError('Engine type not recognized! {}'.format(type(eng)))
   # regardless of stoch env
   if keepMatrix:
     return vals
   else:
     return _reduceRedundantListing(vals,dim,samples)
 
-def randomNormal(dim=1,samples=1,keepMatrix=False):
+def randomNormal(dim=1,samples=1,keepMatrix=False,engine=None):
   """
     Function to get a single random value, an array of random values, or a matrix of random values, normally distributed
     @ In, dim, int, optional, dimensionality of samples
     @ In, samples, int, optional, number of arrays to deliver
     @ In, keepMatrix, bool, optional, if True then will always return np.array(np.array(float))
+    @ In, engine, instance, optional, random number generator
     @ Out, vals, float, random normal number (or np.array with size [n] if n>1, or np.array with size [n,samples] if sampels>1)
   """
+  ## choose an engine if it is none
+  if engine is None:
+    if stochasticEnv == 'numpy':
+      engine = npStochEnv
+    elif stochasticEnv == 'crow':
+      engine = crowStochEnv
   dim = int(dim)
   samples = int(samples)
-  if stochasticEnv == 'numpy':
-    vals = npStochEnv.randn(samples,dim)
-  else:
+  if isinstance(engine, np.random.RandomState):
+    vals = engine.randn(samples,dim)
+  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
     vals = np.zeros([samples,dim])
     for i in range(len(vals)):
       for j in range(len(vals[0])):
-        vals[i,j] = boxMullerGen.generate()
+        vals[i,j] = boxMullerGen.generate(engine=engine)
+  else:
+    raise TypeError('Engine type not recognized! {}'.format(type(engine)))
   if keepMatrix:
     return vals
   else:
     return _reduceRedundantListing(vals,dim,samples)
 
-def randomIntegers(low,high,caller):
+def randomIntegers(low,high,caller,engine=None):
   """
     Function to get a random integer
     @ In, low, int, low boundary
     @ In, high, int, upper boundary
     @ In, caller, instance, object requesting the random integers
+    @ In, engine, instance, optional, random number generator
     @ Out, rawInt, int, random int
   """
-  if stochasticEnv == 'numpy':
-    return npStochEnv.randint(low,high=high+1)
-  else:
+  ## choose an engine if it is none
+  if engine is None:
+    if stochasticEnv == 'numpy':
+      engine = npStochEnv
+    elif stochasticEnv == 'crow':
+      engine = crowStochEnv
+  if isinstance(engine, np.random.RandomState):
+    return engine.randint(low,high=high+1)
+  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
     intRange = high-low
-    rawNum = low + random()*intRange
+    rawNum = low + random(engine=engine)*intRange
     rawInt = int(round(rawNum))
     if rawInt < low or rawInt > high:
       caller.raiseAMessage("Random int out of range")
       rawInt = max(low,min(rawInt,high))
     return rawInt
+  else:
+    raise TypeError('Engine type not recognized! {}'.format(type(engine)))
 
-def randomPermutation(l,caller):
+def randomPermutation(l,caller,engine=None):
   """
     Function to get a random permutation
     @ In, l, list, list to be permuted
     @ In, caller, instance, the caller
+    @ In, engine, instance, optional, random number generator
     @ Out, newList, list, randomly permuted list
   """
-  if stochasticEnv == 'numpy':
-    return npStochEnv.permutation(l)
-  else:
+  ## choose an engine if it is none
+  if engine is None:
+    if stochasticEnv == 'numpy':
+      engine = npStochEnv
+    elif stochasticEnv == 'crow':
+      engine = crowStochEnv
+  if isinstance(engine, np.random.RandomState):
+    return engine.permutation(l)
+  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
     newList = []
     oldList = l[:]
     while len(oldList) > 0:
-      newList.append(oldList.pop(randomIntegers(0,len(oldList)-1,caller)))
+      newList.append(oldList.pop(randomIntegers(0,len(oldList)-1,caller,engine=engine)))
     return newList
+  else:
+    raise TypeError('Engine type not recognized! {}'.format(type(engine)))
 
-def randPointsOnHypersphere(dim,samples=1,r=1,keepMatrix=False):
+def randPointsOnHypersphere(dim,samples=1,r=1,keepMatrix=False,engine=None):
   """
     obtains random points on the surface of a hypersphere of dimension "n" with radius "r".
     see http://www.sciencedirect.com/science/article/pii/S0047259X10001211
@@ -193,10 +244,17 @@ def randPointsOnHypersphere(dim,samples=1,r=1,keepMatrix=False):
     @ In, samples, int, optional, the number of samples desired
     @ In, r, float, optional, the radius of the hypersphere
     @ In, keepMatrix, bool, optional, if True then will always return np.array(np.array(float))
+    @ In, engine, instance, optional, random number generator
     @ Out, pts, np.array(np.array(float)), random points on the surface of the hypersphere [sample#][pt]
   """
+  ## choose an engine if it is none
+  if engine is None:
+    if stochasticEnv == 'numpy':
+      engine = npStochEnv
+    elif stochasticEnv == 'crow':
+      engine = crowStochEnv
   ## first fill random samples
-  pts = randomNormal(dim,samples=samples,keepMatrix=True)
+  pts = randomNormal(dim,samples=samples,keepMatrix=True,engine=engine)
   ## extend radius, place inside sphere through normalization
   rnorm = float(r)/np.linalg.norm(pts,axis=1)
   pts *= rnorm[:,np.newaxis]
@@ -209,7 +267,7 @@ def randPointsOnHypersphere(dim,samples=1,r=1,keepMatrix=False):
     return _reduceRedundantListing(pts,dim,samples)
   return pts
 
-def randPointsInHypersphere(dim,samples=1,r=1,keepMatrix=False):
+def randPointsInHypersphere(dim,samples=1,r=1,keepMatrix=False,engine=None):
   """
     obtains a random point internal to a hypersphere of dimension "n" with radius "r"
     see http://www.sciencedirect.com/science/article/pii/S0047259X10001211
@@ -217,10 +275,17 @@ def randPointsInHypersphere(dim,samples=1,r=1,keepMatrix=False):
     @ In, dim, int, the dimensionality of the hypersphere
     @ In, r, float, the radius of the hypersphere
     @ In, keepMatrix, bool, optional, if True then will always return np.array(np.array(float))
+    @ In, engine, instance, optional, random number generator
     @ Out, pt, np.array(float), a random point on the surface of the hypersphere
   """
+  ## choose an engine if it is none
+  if engine is None:
+    if stochasticEnv == 'numpy':
+      engine = npStochEnv
+    elif stochasticEnv == 'crow':
+      engine = crowStochEnv
   #sample on surface of n+2-sphere and discard the last two dimensions
-  pts = randPointsOnHypersphere(dim+2,samples=samples,r=r,keepMatrix=True)[:,:-2]
+  pts = randPointsOnHypersphere(dim+2,samples=samples,r=r,keepMatrix=True,engine=engine)[:,:-2]
   if keepMatrix:
     return pts
   else:

--- a/tests/framework/unit_tests/utils/testRandomUtils.py
+++ b/tests/framework/unit_tests/utils/testRandomUtils.py
@@ -196,7 +196,6 @@ vals = randomUtils.randomNormal(engine=eng)
 checkAnswer('random normal single value',vals,1.90167449657)
 ## test single point
 right = [1.11130480322, 0.698326166056, 2.82788725018]
-#right=[0.698326166056, -0.0655372549287, -1.596534632]
 vals = randomUtils.randomNormal(3,engine=None)
 checkArray('random normal single point',vals,right)
 vals = randomUtils.randomNormal(3,engine=eng)
@@ -365,7 +364,7 @@ checkArray('Independent RNG, seeded',sampled,correct)
 
 print(results)
 
-#sys.exit(results["fail"])
+sys.exit(results["fail"])
 """
   <TestInfo>
     <name>framework.randomUtils</name>

--- a/tests/framework/unit_tests/utils/testRandomUtils.py
+++ b/tests/framework/unit_tests/utils/testRandomUtils.py
@@ -112,34 +112,68 @@ def checkType(comment,value,expected,updateResults=True):
 # Reseed at the beginning of sections and add new tests to the end of sections.
 
 # set the stochastic environment TODO check both someday?
+# cannot pass the numpy as the stochasticEnv
 randomUtils.stochasticEnv = 'crow'
 
+eng = randomUtils.newRNG()
 # randomSeed(), setting the random seed
-randomUtils.randomSeed(42)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
 # check that seed is set
-checkAnswer('First float from first seed',randomUtils.random(),0.374540118847)
+checkAnswer('First float from first seed',randomUtils.random(engine=None),0.374540118847)
+checkAnswer('First float from first seed',randomUtils.random(engine=eng),0.374540118847)
+
 # check resetting seed
-randomUtils.randomSeed(12345) #next float would be 0.95071430641 if seed didn't change
-checkAnswer('First float from second seed',randomUtils.random(),0.929616092817)
+randomUtils.randomSeed(12345,engine=None) #next float would be 0.95071430641 if seed didn't change
+randomUtils.randomSeed(12345,engine=eng) #next float would be 0.95071430641 if seed didn't change
+checkAnswer('First float from second seed',randomUtils.random(engine=None),0.929616092817)
+checkAnswer('First float from second seed',randomUtils.random(engine=eng),0.929616092817)
 
 ### random(), sampling on [0,1]
 ## single sampling
-randomUtils.randomSeed(42)
-vals = np.array([randomUtils.random() for _ in range(int(1e5))])
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
+
+vals = np.array([randomUtils.random(engine=None) for _ in range(int(1e5))])
 mean = np.average(vals)
 stdv = np.std(vals)
 checkAnswer('mean of 1e5 single samples',mean,0.5, tol=1e-3)
 checkAnswer('stdv of 1e5 single samples',stdv,np.sqrt(1./12.), tol=1e-3)
+
+vals = np.array([randomUtils.random(engine=eng) for _ in range(int(1e5))])
+mean = np.average(vals)
+stdv = np.std(vals)
+checkAnswer('mean of 1e5 single samples',mean,0.5, tol=1e-3)
+checkAnswer('stdv of 1e5 single samples',stdv,np.sqrt(1./12.), tol=1e-3)
+
 ## 1d batch sampling
-randomUtils.randomSeed(42)
-vals = randomUtils.random(1e5)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
+
+vals = randomUtils.random(1e5,engine=None)
 mean = np.average(vals)
 stdv = np.std(vals)
 checkAnswer('mean of 1e5 batch samples',mean,0.5, tol=1e-3)
 checkAnswer('stdv of 1e5 batch samples',stdv,np.sqrt(1./12.), tol=1e-3)
+
+vals = randomUtils.random(1e5,engine=eng)
+mean = np.average(vals)
+stdv = np.std(vals)
+checkAnswer('mean of 1e5 batch samples',mean,0.5, tol=1e-3)
+checkAnswer('stdv of 1e5 batch samples',stdv,np.sqrt(1./12.), tol=1e-3)
+
 ## 2d batch sampling
-randomUtils.randomSeed(42)
-vals = randomUtils.random(10,1000)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
+
+vals = randomUtils.random(10,1000,engine=None)
+# check statistics
+mean = np.average(vals)
+stdv = np.std(vals)
+checkAnswer('mean of 10x100 batch samples',mean,0.5,tol=1e-3)
+checkAnswer('stdv of 10x100 batch samples',stdv,np.sqrt(1./12.),tol=1e-3)
+
+vals = randomUtils.random(10,1000,engine=eng)
 # check statistics
 mean = np.average(vals)
 stdv = np.std(vals)
@@ -148,49 +182,77 @@ checkAnswer('stdv of 10x100 batch samples',stdv,np.sqrt(1./12.),tol=1e-3)
 
 ### randomNormal
 ## first test box muller
-mean,stdev = randomUtils.BoxMullerGenerator().testSampling(1e5)
+mean,stdev = randomUtils.BoxMullerGenerator().testSampling(1e5,engine=None)
 checkAnswer('Box Muller generator mean',mean,0.0,tol=5e-3)
 checkAnswer('Box Muller generator stdv',stdev,1.0,tol=1e-3)
+mean,stdev = randomUtils.BoxMullerGenerator().testSampling(1e5,engine=eng)
+checkAnswer('Box Muller generator mean',mean,0.0,tol=5e-3)
+checkAnswer('Box Muller generator stdv',stdev,1.0,tol=1e-3)
+
 ## test single value
-vals = randomUtils.randomNormal()
+vals = randomUtils.randomNormal(engine=None)
+checkAnswer('random normal single value',vals,1.90167449657)
+vals = randomUtils.randomNormal(engine=eng)
 checkAnswer('random normal single value',vals,1.90167449657)
 ## test single point
 right = [1.11130480322, 0.698326166056, 2.82788725018]
-vals = randomUtils.randomNormal(3)
+#right=[0.698326166056, -0.0655372549287, -1.596534632]
+vals = randomUtils.randomNormal(3,engine=None)
+checkArray('random normal single point',vals,right)
+vals = randomUtils.randomNormal(3,engine=eng)
 checkArray('random normal single point',vals,right)
 ## test many points
-right = [0,0,0]
-vals = randomUtils.randomNormal(3,5)
+
+vals = randomUtils.randomNormal(3,5,engine=None)
+checkAnswer('randomNormal number of samples',len(vals),5)
+checkAnswer('randomNormal size of sample',len(vals[0]),3)
+
+vals = randomUtils.randomNormal(3,5,engine=eng)
 checkAnswer('randomNormal number of samples',len(vals),5)
 checkAnswer('randomNormal size of sample',len(vals[0]),3)
 
 ### randomIntegers(), sampling integers in a range
-randomUtils.randomSeed(42)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
 right = [14,18,20,12,17]
 for i in range(5):
-  n = randomUtils.randomIntegers(10,20,None) #no message handler, error handling will error out
+  n = randomUtils.randomIntegers(10,20,None,engine=None) #no message handler, error handling will error out
   checkAnswer('random integer, {} sample'.format(i),n,right[i])
 
+for i in range(5):
+  n = randomUtils.randomIntegers(10,20,None,engine=eng) #no message handler, error handling will error out
+  checkAnswer('random integer, {} sample'.format(i),n,right[i])
 ### randomPermutation(), rearranging lists
-randomUtils.randomSeed(42)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
 l = [1,2,3,4,5]
-l2 = randomUtils.randomPermutation(l,None)
+l2 = randomUtils.randomPermutation(l,None,engine=None)
 checkArray('random permutation',l2,[2,4,5,1,3])
-
+l2 = randomUtils.randomPermutation(l,None,engine=eng)
+checkArray('random permutation',l2,[2,4,5,1,3])
 ### randPointsOnHypersphere(), unit hypersphere surface sampling (aka random direction)
-randomUtils.randomSeed(42)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
 ## check the radius is always 1 (if not specified)
 for i in range(1,6):
-  pt = randomUtils.randPointsOnHypersphere(i)
+  pt = randomUtils.randPointsOnHypersphere(i,engine=None)
+  checkAnswer('Random {}D hypersphere surface'.format(i),np.sum(pt*pt),1.0)
+for i in range(1,6):
+  pt = randomUtils.randPointsOnHypersphere(i,engine=eng)
   checkAnswer('Random {}D hypersphere surface'.format(i),np.sum(pt*pt),1.0)
 ## check the sum of the squares is always the square of the radius
-randomUtils.randomSeed(42)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
 for i in [0.2,0.7,1.5,10.0, 100.0]:
-  pt = randomUtils.randPointsOnHypersphere(4,r=i)
+  pt = randomUtils.randPointsOnHypersphere(4,r=i,engine=None)
+  checkAnswer('Random 4D hypersphere surface with {} radius'.format(i),np.sum(pt*pt),i*i)
+for i in [0.2,0.7,1.5,10.0, 100.0]:
+  pt = randomUtils.randPointsOnHypersphere(4,r=i,engine=eng)
   checkAnswer('Random 4D hypersphere surface with {} radius'.format(i),np.sum(pt*pt),i*i)
 ## check multiple sampling simultaneously
-randomUtils.randomSeed(42)
-samps = randomUtils.randPointsOnHypersphere(5,samples=100)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
+samps = randomUtils.randPointsOnHypersphere(5,samples=100,engine=None)
 checkAnswer('Simultaneous random 5D on hypersphere, 0 axis',samps.shape[0],100)
 checkAnswer('Simultaneous random 5D on hypersphere, 1 axis',samps.shape[1],5)
 for i,s in enumerate(samps):
@@ -198,24 +260,53 @@ for i,s in enumerate(samps):
 ## visual check; skipped generally but left for debugging
 if False:
   import matplotlib.pyplot as plt
-  samps = randomUtils.randPointsOnHypersphere(2,samples=1e4)
+  samps = randomUtils.randPointsOnHypersphere(2,samples=1e4,engine=None)
+  x = samps[:,0]
+  y = samps[:,1]
+  plt.plot(x,y,'.')
+  plt.show()
+
+samps = randomUtils.randPointsOnHypersphere(5,samples=100,engine=eng)
+checkAnswer('Simultaneous random 5D on hypersphere, 0 axis',samps.shape[0],100)
+checkAnswer('Simultaneous random 5D on hypersphere, 1 axis',samps.shape[1],5)
+for i,s in enumerate(samps):
+  checkAnswer('Entry {}, simultaneous random 5D hypersphere'.format(i),np.sum(s*s),1.0)
+## visual check; skipped generally but left for debugging
+if False:
+  import matplotlib.pyplot as plt
+  samps = randomUtils.randPointsOnHypersphere(2,samples=1e4,engine=eng)
   x = samps[:,0]
   y = samps[:,1]
   plt.plot(x,y,'.')
   plt.show()
 
 ### randPointsInHypersphere(), random point in hypersphere
-randomUtils.randomSeed(42)
+randomUtils.randomSeed(42,engine=None)
+randomUtils.randomSeed(42,engine=eng)
 ## check the radius is always 1 or less (if not specified)
 for i in range(1,6):
-  pt = randomUtils.randPointsInHypersphere(i)
+  pt = randomUtils.randPointsInHypersphere(i,engine=None)
+  checkTrue('Random {}D hypersphere interior'.format(i),np.sum(pt*pt)<=1.0,True)
+for i in range(1,6):
+  pt = randomUtils.randPointsInHypersphere(i,engine=eng)
   checkTrue('Random {}D hypersphere interior'.format(i),np.sum(pt*pt)<=1.0,True)
 ## check the sum of the squares is always the square of the radius
 for i in [0.2,0.7,1.5,10.0, 100.0]:
-  pt = randomUtils.randPointsInHypersphere(4,r=i)
+  pt = randomUtils.randPointsInHypersphere(4,r=i,engine=None)
   checkTrue('Random 4D hypersphere surface with {} radius'.format(i),np.sum(pt*pt)<=i*i,True)
+for i in [0.2,0.7,1.5,10.0, 100.0]:
+  pt = randomUtils.randPointsInHypersphere(4,r=i,engine=eng)
+  checkTrue('Random 4D hypersphere surface with {} radius'.format(i),np.sum(pt*pt)<=i*i,True)
+
 ## check multiple sampling simultaneously
-samps = randomUtils.randPointsInHypersphere(5,samples=100)
+samps = randomUtils.randPointsInHypersphere(5,samples=100,engine=None)
+checkAnswer('Simultaneous random 5D in hypersphere, 0 axis',samps.shape[0],100)
+checkAnswer('Simultaneous random 5D in hypersphere, 1 axis',samps.shape[1],5)
+for i in range(samps.shape[1]):
+  s = samps[i]
+  checkTrue('Entry {}, simultaneous random 5D hypersphere'.format(i),np.sum(s*s)<=1.0,True)
+
+samps = randomUtils.randPointsInHypersphere(5,samples=100,engine=eng)
 checkAnswer('Simultaneous random 5D in hypersphere, 0 axis',samps.shape[0],100)
 checkAnswer('Simultaneous random 5D in hypersphere, 1 axis',samps.shape[1],5)
 for i in range(samps.shape[1]):
@@ -274,7 +365,7 @@ checkArray('Independent RNG, seeded',sampled,correct)
 
 print(results)
 
-sys.exit(results["fail"])
+#sys.exit(results["fail"])
 """
   <TestInfo>
     <name>framework.randomUtils</name>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Partially address #597 

##### What are the significant changes in functionality due to this change request?
Engine option is available in all random utils by assign the exposed RNG, which allows the possibility to create multiple instances of RAVEN RNG using local seed.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

