### PR TITLE
print date to today

### DIFF
--- a/developer_tools/createRegressionTestDocumentation.py
+++ b/developer_tools/createRegressionTestDocumentation.py
@@ -267,31 +267,34 @@ class testDescription(object):
     tupleOut = verificationDict, analyticalDict, requirementDict
     return tupleOut
 
-  def createLatexFile(self, fileName, documentClass = "article", latexPackages=['']):
+  def createLatexFile(self, fileName, documentClass = "article", latexPackages=[''], bodyOnly=False):
     """
       This method is aimed to create a latex file containing all the information
       found in the described tests
       @ In, fileName, string, filename (absolute path)
+      @ In, documentClass, string, latex class document
+      @ In, latexPackages, list, list of latex packages
+      @ In, bodyOnly, bool, create a full document or just the document body (\begin{document} to \end{document})
       @ Out, None
     """
     fileObject = open(fileName,"w+")
-    fileObject.write(" \\documentclass{"+documentClass+"}\n")
-    for packageLatex in latexPackages: fileObject.write(" \\usepackage{"+packageLatex.strip()+"} \n")
-    fileObject.write(" \\usepackage{hyperref} \n \\usepackage[automark,nouppercase]{scrpage2} \n")
-    fileObject.write(" \\usepackage[obeyspaces,dvipsnames,svgnames,x11names,table,hyperref]{xcolor} \n")
-    fileObject.write(" \\usepackage{times} \n \\usepackage[FIGBOTCAP,normal,bf,tight]{subfigure} \n")
-    fileObject.write(" \\usepackage{amsmath} \n \\usepackage{amssymb} \n")
-    fileObject.write(" \\usepackage{soul} \n \\usepackage{pifont} \n \\usepackage{enumerate} \n")
-    fileObject.write(" \\usepackage{listings}  \n \\usepackage{fullpage} \n \\usepackage{xcolor} \n")
-    fileObject.write(" \\usepackage{ifthen}  \n \\usepackage{textcomp}  \n  \\usepackage{mathtools} \n")
-    fileObject.write(" \\usepackage{relsize}  \n \\usepackage{lscape}  \n \\usepackage[toc,page]{appendix} \n")
-    fileObject.write("\n")
-    fileObject.write(' \\lstdefinestyle{XML} {\n language=XML, \n extendedchars=true, \n breaklines=true, \n breakatwhitespace=true, \n')
-    fileObject.write(' emphstyle=\color{red}, \n basicstyle=\\ttfamily, \n commentstyle=\\color{gray}\\upshape, \n ')
-    fileObject.write(' morestring=[b]", \n morecomment=[s]{<?}{?>}, \n morecomment=[s][\color{forestgreen}]{<!--}{-->},')
-    fileObject.write(' keywordstyle=\\color{cyan}, \n stringstyle=\\ttfamily\color{black}, tagstyle=\color{blue}\\bf \\ttfamily \n }')
-
-    fileObject.write(" \\title{RAVEN regression tests' description}\n")
+    if not bodyOnly:
+      fileObject.write(" \\documentclass{"+documentClass+"}\n")
+      for packageLatex in latexPackages: fileObject.write(" \\usepackage{"+packageLatex.strip()+"} \n")
+      fileObject.write(" \\usepackage{hyperref} \n \\usepackage[automark,nouppercase]{scrpage2} \n")
+      fileObject.write(" \\usepackage[obeyspaces,dvipsnames,svgnames,x11names,table,hyperref]{xcolor} \n")
+      fileObject.write(" \\usepackage{times} \n \\usepackage[FIGBOTCAP,normal,bf,tight]{subfigure} \n")
+      fileObject.write(" \\usepackage{amsmath} \n \\usepackage{amssymb} \n")
+      fileObject.write(" \\usepackage{soul} \n \\usepackage{pifont} \n \\usepackage{enumerate} \n")
+      fileObject.write(" \\usepackage{listings}  \n \\usepackage{fullpage} \n \\usepackage{xcolor} \n")
+      fileObject.write(" \\usepackage{ifthen}  \n \\usepackage{textcomp}  \n  \\usepackage{mathtools} \n")
+      fileObject.write(" \\usepackage{relsize}  \n \\usepackage{lscape}  \n \\usepackage[toc,page]{appendix} \n")
+      fileObject.write("\n")
+      fileObject.write(' \\lstdefinestyle{XML} {\n language=XML, \n extendedchars=true, \n breaklines=true, \n breakatwhitespace=true, \n')
+      fileObject.write(' emphstyle=\color{red}, \n basicstyle=\\ttfamily, \n commentstyle=\\color{gray}\\upshape, \n ')
+      fileObject.write(' morestring=[b]", \n morecomment=[s]{<?}{?>}, \n morecomment=[s][\color{forestgreen}]{<!--}{-->},')
+      fileObject.write(' keywordstyle=\\color{cyan}, \n stringstyle=\\ttfamily\color{black}, tagstyle=\color{blue}\\bf \\ttfamily \n }')
+      fileObject.write(" \\title{RAVEN regression tests' description}\n")
     fileObject.write(" \\begin{document} \n \\maketitle \n")
     # Introduction
     fileObject.write(" \\section{Introduction} \n")
@@ -415,7 +418,7 @@ if __name__ == '__main__':
   print("\n% of tests that got commented is : "+str(descriptionClass.getDescriptionCoverage())+" %")
   print("\nFolders that contain undocumented tests are:\n")
   for folderName in descriptionClass.getFoldersOfUndocumentedTests(): print(folderName)
-  descriptionClass.createLatexFile("regression_tests_documentation.tex")
+  descriptionClass.createLatexFile("regression_tests_documentation_body.tex",bodyOnly=True)
 
 
 

--- a/doc/make_docs.sh
+++ b/doc/make_docs.sh
@@ -32,7 +32,7 @@ source ../scripts/establish_conda_env.sh --load --quiet
 #   (not the Unix-style ones used on other platforms).  This also means semi-colons need to be used
 #   to separate terms instead of the Unix colon.
 #
-if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]
+if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
 then
   export TEXINPUTS=.\;`cygpath -w $SCRIPT_DIR/tex_inputs`\;$TEXINPUTS
 else
@@ -56,11 +56,21 @@ fi
 for DIR in  user_manual user_guide theory_manual tests; do
     cd $DIR
     echo Building in $DIR...
-    if [[ 1 -eq $VERB ]]
-    then
-      make; MADE=$?
-    else
-      make > /dev/null; MADE=$?
+    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
+    then  
+      if [[ 1 -eq $VERB ]]
+      then
+        bash.exe make_win.sh; MADE=$?
+      else
+        bash.exe make_win.sh > /dev/null; MADE=$?
+      fi
+    else  
+      if [[ 1 -eq $VERB ]]
+      then
+        make; MADE=$?
+      else
+        make > /dev/null; MADE=$?
+      fi    
     fi
     if [[ 0 -eq $MADE ]]; then
         echo ...Successfully made docs in $DIR

--- a/doc/sqa/make_docs.sh
+++ b/doc/sqa/make_docs.sh
@@ -23,7 +23,7 @@ done
 rm -Rvf sqa_built_documents
 mkdir sqa_built_documents
 # load raven libraries
-source ../scripts/establish_conda_env.sh --load --quiet
+source ../../scripts/establish_conda_env.sh --load --quiet
 
 # add custom, collective inputs to TEXINPUTS
 #
@@ -32,7 +32,7 @@ source ../scripts/establish_conda_env.sh --load --quiet
 #   (not the Unix-style ones used on other platforms).  This also means semi-colons need to be used
 #   to separate terms instead of the Unix colon.
 #
-if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]
+if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
 then
   export TEXINPUTS=.\;`cygpath -w $SCRIPT_DIR/tex_inputs`\;$TEXINPUTS
 else
@@ -43,7 +43,6 @@ fi
 cp sqap/*.pdf sqa_built_documents/
 cp sqap/*.docx sqa_built_documents/
 # Configuration Item list
-cp CIlist/*.pdf sqa_built_documents/
 cp CIlist/*.docx sqa_built_documents/
 # CR_scheme
 cp CR_scheme.pptx sqa_built_documents/
@@ -66,11 +65,21 @@ fi
 for DIR in  sdd rtr srs srs_rtr_combined; do
     cd $DIR
     echo Building in $DIR...
-    if [[ 1 -eq $VERB ]]
-    then
-      make; MADE=$?
-    else
-      make > /dev/null; MADE=$?
+    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
+    then  
+      if [[ 1 -eq $VERB ]]
+      then
+        bash.exe make_win.sh; MADE=$?
+      else
+        bash.exe make_win.sh > /dev/null; MADE=$?
+      fi
+    else  
+      if [[ 1 -eq $VERB ]]
+      then
+        make; MADE=$?
+      else
+        make > /dev/null; MADE=$?
+      fi    
     fi
     if [[ 0 -eq $MADE ]]; then
         echo ...Successfully made docs in $DIR

--- a/doc/sqa/rtr/make_win.sh
+++ b/doc/sqa/rtr/make_win.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Local variable definition ----------------------------------------------------
 # list of files to run.
-declare -a files=(raven_user_guide)
+declare -a files=(raven_requirements_traceability_matrix)
 # extension to be removed.
 declare -a exts=(txt ps ds)
 
@@ -20,23 +20,16 @@ clean_files () {
 
 # Subroutine to generate files.
 gen_files () { 
-
-        if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
-        then
-          export TEXINPUTS=.\;`cygpath -w ../tex_inputs`\;$TEXINPUTS
-        else
-          export TEXINPUTS=../tex_inputs/:$TEXINPUTS
-        fi
-
-        git log -1 --format="%H %an %aD" .. > ../version.tex
-        python ../../scripts/TestHarness/testers/RavenUtils.py --manual-list > libraries.tex
+        git log -1 --format="%H %an %aD" .. > ../../version.tex
+        python ../../../scripts/TestHarness/testers/RavenUtils.py --manual-list > dependencies.tex
+	python ../../../developer_tools/createSQAtracebilityMatrix.py -i ../srs/requirements_list.xml -o traceability_matrix.tex 
 	for file in "${files[@]}"
 	do
 		# Generate files.
-        pdflatex -shell-escape $file.tex
+        pdflatex -interaction=nonstopmode $file.tex
         bibtex $file.tex
-	pdflatex -shell-escape $file.tex
-	pdflatex -shell-escape $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
 
 	done
 }

--- a/doc/sqa/sdd/make_win.sh
+++ b/doc/sqa/sdd/make_win.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Local variable definition ----------------------------------------------------
 # list of files to run.
-declare -a files=(raven_user_guide)
+declare -a files=(raven_software_design_description)
 # extension to be removed.
 declare -a exts=(txt ps ds)
 
@@ -20,23 +20,15 @@ clean_files () {
 
 # Subroutine to generate files.
 gen_files () { 
-
-        if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
-        then
-          export TEXINPUTS=.\;`cygpath -w ../tex_inputs`\;$TEXINPUTS
-        else
-          export TEXINPUTS=../tex_inputs/:$TEXINPUTS
-        fi
-
-        git log -1 --format="%H %an %aD" .. > ../version.tex
-        python ../../scripts/TestHarness/testers/RavenUtils.py --manual-list > libraries.tex
+        git log -1 --format="%H %an %aD" .. > ../../version.tex
+        python ../../../scripts/TestHarness/testers/RavenUtils.py --manual-list > dependencies.tex
 	for file in "${files[@]}"
 	do
 		# Generate files.
-        pdflatex -shell-escape $file.tex
+        pdflatex -interaction=nonstopmode $file.tex
         bibtex $file.tex
-	pdflatex -shell-escape $file.tex
-	pdflatex -shell-escape $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
 
 	done
 }

--- a/doc/sqa/srs/make_win.sh
+++ b/doc/sqa/srs/make_win.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Local variable definition ----------------------------------------------------
 # list of files to run.
-declare -a files=(raven_user_guide)
+declare -a files=(raven_software_requirements_specifications)
 # extension to be removed.
 declare -a exts=(txt ps ds)
 
@@ -20,23 +20,16 @@ clean_files () {
 
 # Subroutine to generate files.
 gen_files () { 
-
-        if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
-        then
-          export TEXINPUTS=.\;`cygpath -w ../tex_inputs`\;$TEXINPUTS
-        else
-          export TEXINPUTS=../tex_inputs/:$TEXINPUTS
-        fi
-
-        git log -1 --format="%H %an %aD" .. > ../version.tex
-        python ../../scripts/TestHarness/testers/RavenUtils.py --manual-list > libraries.tex
+        git log -1 --format="%H %an %aD" .. > ../../version.tex
+        python ../../../scripts/TestHarness/testers/RavenUtils.py --manual-list > dependencies.tex
+	python ../../../developer_tools/readRequirementsAndCreateLatex.py -i requirements_list.xml -o requirements.tex 
 	for file in "${files[@]}"
 	do
 		# Generate files.
-        pdflatex -shell-escape $file.tex
+        pdflatex -interaction=nonstopmode $file.tex
         bibtex $file.tex
-	pdflatex -shell-escape $file.tex
-	pdflatex -shell-escape $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
 
 	done
 }

--- a/doc/sqa/srs_rtr_combined/make_win.sh
+++ b/doc/sqa/srs_rtr_combined/make_win.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Local variable definition ----------------------------------------------------
 # list of files to run.
-declare -a files=(raven_user_guide)
+declare -a files=(raven_software_requirements_specifications_and_traceability)
 # extension to be removed.
 declare -a exts=(txt ps ds)
 
@@ -20,23 +20,17 @@ clean_files () {
 
 # Subroutine to generate files.
 gen_files () { 
-
-        if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
-        then
-          export TEXINPUTS=.\;`cygpath -w ../tex_inputs`\;$TEXINPUTS
-        else
-          export TEXINPUTS=../tex_inputs/:$TEXINPUTS
-        fi
-
-        git log -1 --format="%H %an %aD" .. > ../version.tex
-        python ../../scripts/TestHarness/testers/RavenUtils.py --manual-list > libraries.tex
+        git log -1 --format="%H %an %aD" .. > ../../version.tex
+        python ../../../scripts/TestHarness/testers/RavenUtils.py --manual-list > dependencies.tex
+	python ../../../developer_tools/readRequirementsAndCreateLatex.py -i ../srs/requirements_list.xml -o ../srs/requirements.tex 
+	python ../../../developer_tools/createSQAtracebilityMatrix.py -i ../srs/requirements_list.xml -o ../rtr/traceability_matrix.tex 
 	for file in "${files[@]}"
 	do
 		# Generate files.
-        pdflatex -shell-escape $file.tex
+        pdflatex -interaction=nonstopmode $file.tex
         bibtex $file.tex
-	pdflatex -shell-escape $file.tex
-	pdflatex -shell-escape $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
 
 	done
 }

--- a/doc/tests/analytic_tests.tex
+++ b/doc/tests/analytic_tests.tex
@@ -244,16 +244,12 @@ showstringspaces=false            %
 \title{RAVEN Analytic Test Documentation}
 
 \author{
-\textbf{\textit{Principal Investigator (PI):}}
- \\Cristian Rabiti\\
-\textbf{\textit{Main Developers:}}
 \\Andrea Alfonsi
-\\Joshua Cogliati
-\\Diego Mandelli
-\\Robert Kinoshita
-\\Congjian Wang
-\\Daniel P. Maljovec
 \\Paul W. Talbot
+\\Congjian Wang
+\\Diego Mandelli
+\\Joshua Cogliati
+\\Cristian Rabiti
 }
 
 % There is a "Printed" date on the title page of a SAND report, so
@@ -264,11 +260,10 @@ showstringspaces=false            %
 % ---------------------------------------------------------------------------- %
 % Set some things we need for SAND reports. These are mandatory
 %
-%TODO someone help me know what goes here?  - Paul
-\SANDnum{todo}
-\SANDprintDate{todo}
-\SANDauthor{todo}
-\SANDreleaseType{todo}
+\SANDnum{INL/EXT-19-53843}
+\SANDprintDate{\today}
+\SANDauthor{Andrea Alfonsi, Paul W. Talbot, Diego Mandelli, Congjian Wang, Joshua Cogliati, Cristian Rabiti}
+\SANDreleaseType{Revision 0}
 
 
 % ---------------------------------------------------------------------------- %

--- a/doc/tests/make_win.sh
+++ b/doc/tests/make_win.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Local variable definition ----------------------------------------------------
+# list of files to run.
+declare -a files=(analytic_tests regression_tests_documentation)
+# extension to be removed.
+declare -a exts=(txt ps ds)
+
+# Functions definition ---------------------------------------------------------
+# Subroutine to remove files.
+clean_files () { 
+	# Remove ald the files with the selected suffixes.
+	for ext in "${exts[@]}"
+	do
+		for file in `ls *.$ext 2> /dev/null`
+		do
+			rm -rf *.aux *.bbl *.blg *.log *.out *.toc *.lot *.lof raven_user_manual.pdf
+		done
+	done
+}
+
+# Subroutine to generate files.
+gen_files () { 
+        git log -1 --format="%H %an %aD" .. > ../version.tex
+        python ../../developer_tools/createRegressionTestDocumentation.py
+	for file in "${files[@]}"
+	do
+		# Generate files.
+        pdflatex -interaction=nonstopmode $file.tex
+        bibtex $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+
+	done
+}
+
+# Clean and run ----------------------------------------------------------------
+if [[ $1 = 'clean' ]]
+then
+    # Remove al the files with the selected extension.
+    clean_files
+else
+    # Generate all the selected files.
+    gen_files
+fi

--- a/doc/tests/regression_tests_documentation.tex
+++ b/doc/tests/regression_tests_documentation.tex
@@ -21,11 +21,10 @@
 % If you just want to change the text font, you should just \usepackage{times}.
 % \usepackage{pslatex}
 \usepackage{times}
-\usepackage{longtable}
 \usepackage[FIGBOTCAP,normal,bf,tight]{subfigure}
 \usepackage{amsmath}
 \usepackage{amssymb}
-\usepackage[labelfont=bf]{caption}
+\usepackage{soul}
 \usepackage{pifont}
 \usepackage{enumerate}
 \usepackage{listings}
@@ -33,6 +32,15 @@
 \usepackage{xcolor}          % Using xcolor for more robust color specification
 \usepackage{ifthen}          % For simple checking in newcommand blocks
 \usepackage{textcomp}
+\usepackage{mathtools}
+\usepackage{relsize}
+\usepackage{lscape}
+\usepackage[toc,page]{appendix}
+%\usepackage{RAVEN}
+
+\newtheorem{mydef}{Definition}
+\newcommand{\norm}[1]{\lVert#1\rVert}
+%\usepackage[table,xcdraw]{xcolor}
 %\usepackage{authblk}         % For making the author list look prettier
 %\renewcommand\Authsep{,~\,}
 
@@ -49,6 +57,7 @@
   basicstyle=\ttfamily,
   frame=single
 }
+
 
 \setcounter{secnumdepth}{5}
 \lstdefinestyle{XML} {
@@ -164,6 +173,7 @@ showstringspaces=false            %
 \newcommand{\default}[1]{~\\*\textit{Default: #1}}
 \newcommand{\nb} {\textcolor{deepgreen}{\textbf{~Note:}}~}
 
+
 %%%%%%%% End comands definition to input python code into document
 
 %\usepackage[dvips,light,first,bottomafter]{draftcopy}
@@ -175,6 +185,7 @@ showstringspaces=false            %
 % obsolete.  Also, \boldsymbol doesn't even seem to work with
 % the fonts used in this particular document...
 \usepackage{bm}
+
 
 % Define tensors to be in bold math font.
 \newcommand{\tensor}[1]{{\bm{#1}}}
@@ -206,8 +217,6 @@ showstringspaces=false            %
     urlcolor=black
 }
 
-\newcommand{\wiki}{\href{https://github.com/idaholab/raven/wiki}{RAVEN wiki}}
-
 % Compress lists of citations like [33,34,35,36,37] to [33-37]
 \usepackage{cite}
 
@@ -237,7 +246,7 @@ showstringspaces=false            %
 %
 % Set the title, author, and date
 %
-\title{RAVEN User Manual}
+\title{RAVEN regression tests' description}
 %\author{%
 %\begin{tabular}{c} Author 1 \\ University1 \\ Mail1 \\ \\
 %Author 3 \\ University3 \\ Mail3 \end{tabular} \and
@@ -247,43 +256,13 @@ showstringspaces=false            %
 
 
 \author{
-\textbf{\textit{Project Manager:}}
- \\Cristian Rabiti\\
- \textbf{\textit{Principal Investigator and Technical Leader:}}
- \\Andrea Alfonsi\\
-\textbf{\textit{Main Developers:}}
 \\Andrea Alfonsi
-\\Diego Mandelli
-\\Joshua Cogliati
-\\Congjian Wang
 \\Paul W. Talbot
-\\Daniel P. Maljovec
-\\Robert Kinoshita\\
-\textbf{\textit{Former Developers:}} \\Sonat Sen
-\\Jun Chen\\
-\textbf{\textit{Contributors:}}
-\\Alessandro Bandini (Post-Processor)
-\\Ivan Rinaldi (documentation)
-\\Claudia Picoco (new external code interface)
-\\James B. Tompkins (new external code interface)
-\\Matteo Donorio (new external code interface)
-\\Fabio Giannetti (new external code interface)
+\\Diego Mandelli
+\\Congjian Wang
+\\Joshua Cogliati
+\\Cristian Rabiti
 }
-% \\James B. Tompkins}   Just people who actually ``developed'' a significant capability in the code should be placed here. Andrea
-%\author{\textbf{\textit{Main Developers:}}  \\Andrea Alfonsi}
-%\author{\\Joshua Cogliati}
-%\author{\\Diego Mandelli}
-%\author{\\Robert Kinoshita}
-%\author{\\Sonat Sen}
-%
-%\author{Cristian Rabiti}
-%\author{Andrea Alfonsi}
-%\author{Joshua Cogliati}
-%\author{Diego Mandelli}
-%\author{Robert Kinoshita}
-%\author{Sonat Sen}
-%\affil{Idaho National Laboratory, Idaho Falls, ID 83402}
-%\\\{cristian.rabiti, andrea.alfonsi, joshua.cogliati, diego.mandelli, robert.kinoshita, ramazan.sen\}@inl.gov}
 
 % There is a "Printed" date on the title page of a SAND report, so
 % the generic \date should [WorkingDir:]generally be empty.
@@ -293,25 +272,15 @@ showstringspaces=false            %
 % ---------------------------------------------------------------------------- %
 % Set some things we need for SAND reports. These are mandatory
 %
-\SANDnum{INL/EXT-15-34123}
+\SANDnum{INL/EXT-19-53844}
 \SANDprintDate{\today}
-\SANDauthor{Cristian Rabiti, Andrea Alfonsi, Joshua Cogliati, Diego Mandelli,
-Robert Kinoshita, Sonat Sen, Congjian Wang, Paul W. Talbot, Daniel P. Maljovec}
-\SANDreleaseType{Revision 7}
-
-% ---------------------------------------------------------------------------- %
-% Include the markings required for your SAND report. The default is "Unlimited
-% Release". You may have to edit the file included here, or create your own
-% (see the examples provided).
-%
-% \include{MarkOUO} % Not needed for unlimted release reports
-
+\SANDauthor{Andrea Alfonsi, Paul W. Talbot, Diego Mandelli, Congjian Wang, Joshua Cogliati, Cristian Rabiti}
+\SANDreleaseType{Revision 0}
 \def\component#1{\texttt{#1}}
 
 % ---------------------------------------------------------------------------- %
 \newcommand{\systemtau}{\tensor{\tau}_{\!\text{SUPG}}}
 
-% Added by Sonat
 \usepackage{placeins}
 \usepackage{array}
 
@@ -319,141 +288,13 @@ Robert Kinoshita, Sonat Sen, Congjian Wang, Paul W. Talbot, Daniel P. Maljovec}
 \newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
 \newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
 
-% end added by Sonat
 % ---------------------------------------------------------------------------- %
 %
 % Start the document
 %
-
-\begin{document}
-    \maketitle
-
-    % ------------------------------------------------------------------------ %
-    % An Abstract is required for SAND reports
-    %
-%    \begin{abstract}
-%    \input abstract
-%    \end{abstract}
-
-
-    % ------------------------------------------------------------------------ %
-    % An Acknowledgement section is optional but important, if someone made
-    % contributions or helped beyond the normal part of a work assignment.
-    % Use \section* since we don't want it in the table of context
-    %
-%    \clearpage
-%    \section*{Acknowledgment}
-
-
-
-%	The format of this report is based on information found
-%	in~\cite{Sand98-0730}.
-
-
-    % ------------------------------------------------------------------------ %
-    % The table of contents and list of figures and tables
-    % Comment out \listoffigures and \listoftables if there are no
-    % figures or tables. Make sure this starts on an odd numbered page
-    %
-    \cleardoublepage		% TOC needs to start on an odd page
-    \tableofcontents
-    %\listoffigures
-    %\listoftables
-
-
-    % ---------------------------------------------------------------------- %
-    % An optional preface or Foreword
-%    \clearpage
-%    \section*{Preface}
-%    \addcontentsline{toc}{section}{Preface}
-%	Although muggles usually have only limited experience with
-%	magic, and many even dispute its existence, it is worthwhile
-%	to be open minded and explore the possibilities.
-
-
-    % ---------------------------------------------------------------------- %
-    % An optional executive summary
-    %\clearpage
-    %\section*{Summary}
-    %\addcontentsline{toc}{section}{Summary}
-    %\input{Summary.tex}
-%	Once a certain level of mistrust and skepticism has
-%	been overcome, magic finds many uses in todays science
-
-
-
-%	and engineering. In this report we explain some of the
-%	fundamental spells and instruments of magic and wizardry. We
-%	then conclude with a few examples on how they can be used
-%	in daily activities at national Laboratories.
-
-
-    % ---------------------------------------------------------------------- %
-    % An optional glossary. We don't want it to be numbered
-%    \clearpage
-%    \section*{Nomenclature}
-%    \addcontentsline{toc}{section}{Nomenclature}
-%    \begin{description}
-%          \item[alohomoral]
-%           spell to open locked doors and containers
-%          \item[leviosa]
-%           spell to levitate objects
-%    \item[remembrall]
-%           device to alert you that you have forgotten something
-%    \item[wand]
-%           device to execute spells
-%    \end{description}
-
-
-    % ---------------------------------------------------------------------- %
-    % This is where the body of the report begins; usually with an Introduction
-    %
-    \SANDmain		% Start the main part of the report
-
-\input{introduction.tex}
-\input{nomenclature.tex}
-\input{Installation/main.tex}
-\input{HowToRun.tex}
-\input{ravenStructure.tex}
-\input{runInfo.tex}
-\input{files.tex}
-\input{variablegroups.tex}
-\input{ProbabilityDistributions.tex}
-\input{sampler.tex}
-\input{optimizer.tex}
-\input{database_data.tex}
-\input{OutStreamSystem.tex}
-\input{model.tex}
-\input{functions.tex}
-\input{metrics.tex}
-\input{step.tex}
-\input{existing_interfaces.tex}
-\input{couplingAcode.tex}
-\input{advanced_users_plugins.tex}
-\input{advanced_users_templates.tex}
-\input{examplesPrimer.tex}
-\section*{Document Version Information}
-\input{../version.tex}
-
-
-    % ---------------------------------------------------------------------- %
-    % References
-    %
-    \clearpage
-    % If hyperref is included, then \phantomsection is already defined.
-    % If not, we need to define it.
-    \providecommand*{\phantomsection}{}
-    \phantomsection
-    \addcontentsline{toc}{section}{References}
-    \bibliographystyle{ieeetr}
-    \bibliography{raven_user_manual}
-
-
-    % ---------------------------------------------------------------------- %
-    %
-
-    % \printindex
-
-    %\include{distribution}
-
-\end{document}
+\SANDmain 
+ \input{regression_tests_documentation_body.tex}
+% ---------------------------------------------------------------------------- %
+%
+% End the document
+%

--- a/doc/theory_manual/make_win.sh
+++ b/doc/theory_manual/make_win.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Local variable definition ----------------------------------------------------
+# list of files to run.
+declare -a files=(raven_theory_manual)
+# extension to be removed.
+declare -a exts=(txt ps ds)
+
+# Functions definition ---------------------------------------------------------
+# Subroutine to remove files.
+clean_files () { 
+	# Remove ald the files with the selected suffixes.
+	for ext in "${exts[@]}"
+	do
+		for file in `ls *.$ext 2> /dev/null`
+		do
+			rm -rf *.aux *.bbl *.blg *.log *.out *.toc *.lot *.lof raven_user_manual.pdf
+		done
+	done
+}
+
+# Subroutine to generate files.
+gen_files () { 
+        git log -1 --format="%H %an %aD" .. > ../version.tex
+        python ../../scripts/TestHarness/testers/RavenUtils.py --manual-list > libraries.tex
+	for file in "${files[@]}"
+	do
+		# Generate files.
+        pdflatex -interaction=nonstopmode $file.tex
+        bibtex $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+
+	done
+}
+
+# Clean and run ----------------------------------------------------------------
+if [[ $1 = 'clean' ]]
+then
+    # Remove al the files with the selected extension.
+    clean_files
+else
+    # Generate all the selected files.
+    gen_files
+fi

--- a/doc/theory_manual/raven_theory_manual.tex
+++ b/doc/theory_manual/raven_theory_manual.tex
@@ -281,7 +281,7 @@ showstringspaces=false            %
 \SANDnum{INL/EXT-16-38178}
 \SANDprintDate{\today}
 \SANDauthor{Andrea Alfonsi, Cristian Rabiti, Diego Mandelli, Joshua Cogliati, Congjian Wang, Paul W. Talbot, Daniel P. Maljovec, Curtis Smith}
-\SANDreleaseType{Revision 2}
+\SANDreleaseType{Revision 3}
 
 
 % ---------------------------------------------------------------------------- %

--- a/doc/theory_manual/raven_theory_manual.tex
+++ b/doc/theory_manual/raven_theory_manual.tex
@@ -246,7 +246,7 @@ showstringspaces=false            %
 %
 % Set the title, author, and date
 %
-\title{RAVEN Theory Manual and User Guide}
+\title{RAVEN Theory Manual}
 %\author{%
 %\begin{tabular}{c} Author 1 \\ University1 \\ Mail1 \\ \\
 %Author 3 \\ University3 \\ Mail3 \end{tabular} \and
@@ -279,9 +279,9 @@ showstringspaces=false            %
 % Set some things we need for SAND reports. These are mandatory
 %
 \SANDnum{INL/EXT-16-38178}
-\SANDprintDate{March 2017}
+\SANDprintDate{\today}
 \SANDauthor{Andrea Alfonsi, Cristian Rabiti, Diego Mandelli, Joshua Cogliati, Congjian Wang, Paul W. Talbot, Daniel P. Maljovec, Curtis Smith}
-\SANDreleaseType{Revision 1 draft}
+\SANDreleaseType{Revision 2}
 
 
 % ---------------------------------------------------------------------------- %

--- a/doc/user_guide/make_win.sh
+++ b/doc/user_guide/make_win.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Local variable definition ----------------------------------------------------
+# list of files to run.
+declare -a files=(raven_user_guide)
+# extension to be removed.
+declare -a exts=(txt ps ds)
+
+# Functions definition ---------------------------------------------------------
+# Subroutine to remove files.
+clean_files () { 
+	# Remove ald the files with the selected suffixes.
+	for ext in "${exts[@]}"
+	do
+		for file in `ls *.$ext 2> /dev/null`
+		do
+			rm -rf *.aux *.bbl *.blg *.log *.out *.toc *.lot *.lof raven_user_manual.pdf
+		done
+	done
+}
+
+# Subroutine to generate files.
+gen_files () { 
+        git log -1 --format="%H %an %aD" .. > ../version.tex
+        python ../../scripts/TestHarness/testers/RavenUtils.py --manual-list > libraries.tex
+	for file in "${files[@]}"
+	do
+		# Generate files.
+        pdflatex -interaction=nonstopmode $file.tex
+        bibtex $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+
+	done
+}
+
+# Clean and run ----------------------------------------------------------------
+if [[ $1 = 'clean' ]]
+then
+    # Remove al the files with the selected extension.
+    clean_files
+else
+    # Generate all the selected files.
+    gen_files
+fi

--- a/doc/user_guide/raven_user_guide.tex
+++ b/doc/user_guide/raven_user_guide.tex
@@ -280,7 +280,7 @@ showstringspaces=false            %
 % Set some things we need for SAND reports. These are mandatory
 %
 \SANDnum{INL/EXT-18-44465}
-\SANDprintDate{March 2017}
+\SANDprintDate{\today}
 \SANDauthor{Andrea Alfonsi, Cristian Rabiti, Diego Mandelli, Joshua Cogliati, Congjian Wang, Paul W. Talbot, Daniel P. Maljovec, Curtis Smith, Jia Zhou}
 \SANDreleaseType{Revision 0 draft}
 

--- a/doc/user_manual/HowToRun.tex
+++ b/doc/user_manual/HowToRun.tex
@@ -13,12 +13,26 @@ The \texttt{raven\_framework} script is in the raven folder.
 %
 To run RAVEN, open a terminal and use the following command (replace \texttt{<inputFileName.xml>} with your RAVEN input file):
 
+\begin{itemize}
+
+  \item \textbf{Any unix-based systems (e.g. Macintosh, Linux, etc.)}:
 \begin{lstlisting}[language=bash]
 raven_framework <inputFileName.xml>
 \end{lstlisting}
+  \item \textbf{Windows}:
+  \begin{lstlisting}[language=bash]
+bash.exe raven_framework <inputFileName.xml>
+\end{lstlisting}
+  
+\end{itemize}
 
 Using \texttt{raven\_framework} is the recommended way to run RAVEN.  In the event bypassing the typical
 environment loading and checks is desired, it can also be run via
 the \texttt{Driver.py} script using python, with the input file as argument.  However, this is not
 recommended, as it will use whatever default versions of Python and other libraries are discovered, rather
 than the matching libraries set up during installation.
+
+\nb For Windows systems, we provided a convienient Batch script ( \texttt{raven\_framework.bat} ) for running RAVEN 
+avoiding to interact with the Windows command line terminal. More info on how to use it can be found in the RAVEN
+\wiki , section \textit{Running RAVEN} (\url{https://github.com/idaholab/raven/wiki/runningRAVEN}).
+

--- a/doc/user_manual/Installation/clone.tex
+++ b/doc/user_manual/Installation/clone.tex
@@ -38,41 +38,83 @@ RAVEN depends heavily on Python, and uses conda to maintain a separate environme
 other Python library installations.  This separate environment is called \texttt{raven\_libraries}.
 
 In order to establish this environment, navigate to \texttt{raven}, then
+\begin{itemize}
+
+  \item \textbf{Any unix-based systems (e.g. Macintosh, Linux, etc.)}:
 \begin{lstlisting}[language=bash]
 cd scripts
 ./establish_conda_env.sh --install
 \end{lstlisting}
+  \item \textbf{Windows}:
+  \begin{lstlisting}[language=bash]
+cd scripts
+bash.exe establish_conda_env.sh --install
+\end{lstlisting}
+  
+\end{itemize}
 Assure that there are no errors in this process, then continue to compiling RAVEN.
 
 \nb If \texttt{conda} is not installed in the default location, then the path to the conda definitions
 needs to be provided, for example
+
+\begin{itemize}
+
+  \item \textbf{Any unix-based systems (e.g. Macintosh, Linux, etc.)}:
 \begin{lstlisting}[language=bash]
 cd scripts
-./establish_conda_env.sh --install --conda-defs /path/to/miniconda3/etc/profile.d/conda.sh
+./establish_conda_env.sh --install
+   --conda-defs /path/to/miniconda3/etc/profile.d/conda.sh
 \end{lstlisting}
+  \item \textbf{Windows}:
+  \begin{lstlisting}[language=bash]
+cd scripts
+bash.exe establish_conda_env.sh --install
+  --conda-defs \path/\to\miniconda3\etc\profile.d\conda.sh
+\end{lstlisting}
+  
+\end{itemize}
+
 replacing \texttt{/path/to} with the install path for \texttt{conda}.
-
-
-
 
 \subsubsection{Compiling RAVEN}
 Once Python libraries are established and the source code present, navigate to \texttt{raven} and run
+
+
+\begin{itemize}
+
+  \item \textbf{Any unix-based systems (e.g. Macintosh, Linux, etc.)}:
 \begin{lstlisting}[language=bash]
 ./build_raven
 \end{lstlisting}
+  \item \textbf{Windows}:
+  \begin{lstlisting}[language=bash]
+bash.exe build_raven
+\end{lstlisting}
+  
+\end{itemize}
+
 This will compile several dependent libraries.  This step has the highest potential for revealing problems in
 the operating system setup, particularly for Windows.  See troubleshooting on the \wiki for help sorting out
 difficulties.
 
 
-
-
 \subsubsection{Testing RAVEN}
 \label{sec:testing raven}
 To test the installation of RAVEN, navigate to \texttt{raven}, then run the command
+
+\begin{itemize}
+
+  \item \textbf{Any unix-based systems (e.g. Macintosh, Linux, etc.)}:
 \begin{lstlisting}[language=bash]
-./run_tests -j2
+../run_tests -j2
 \end{lstlisting}
+  \item \textbf{Windows}:
+  \begin{lstlisting}[language=bash]
+bash.exe ./run_tests -j2
+\end{lstlisting}
+  
+\end{itemize}
+
 where \texttt{-j2} signifies running with 2 processors.  If more processors are available, this can be
 increased, but using all or more than all of the available processes can slow down the testing dramatically.
 This command runs RAVEN's regression tests, analytic tests, and unit tests.  The number of tests changes
@@ -88,12 +130,22 @@ the \wiki.
 \subsubsection{Updating RAVEN}
 RAVEN updates frequently, and new features are added while bugs are fixed on a regular basis.  To update
 RAVEN, navigate to \texttt{raven}, then run the commands
+\begin{itemize}
+
+  \item \textbf{Any unix-based systems (e.g. Macintosh, Linux, etc.)}:
 \begin{lstlisting}[language=bash]
 git pull
 ./scripts/establish_conda_env.sh --install
 ./build_raven
 \end{lstlisting}
-
+  \item \textbf{Windows}:
+  \begin{lstlisting}[language=bash]
+git pull
+bash.exe scripts/establish_conda_env.sh --install
+bash.exe build_raven
+\end{lstlisting}
+  
+\end{itemize}
 
 \subsubsection{In-use Testing}
 

--- a/doc/user_manual/Installation/windows.tex
+++ b/doc/user_manual/Installation/windows.tex
@@ -9,9 +9,9 @@ systems; however, it is straightforward.  First, RAVEN has the following prerequ
         has been verified on Windows 7, 10, and Windows Server 2012 R2 Standard.
     \item At least 9 Gigabytes of available disk space:
     \begin{itemize}
-        \item 0.5 GB for MSYS2, including supporting tools and git source code control
+        \item 0.5 GB for GIT SCM, including supporting tools and git source code control
         \item 1.5 GB for Python language and supporting packages
-        \item 1.5 GB for RAVEN and the MOOSE framework
+        \item 1 GB for RAVEN framework
         \item 5.0 GB for the Visual Studio compiler needed to build RAVEN
     \end{itemize}
 \end{itemize}
@@ -19,35 +19,15 @@ systems; however, it is straightforward.  First, RAVEN has the following prerequ
 \subsubsection{A Visual Guide}
 Note: An illustrated version of this procedure may be found on the \wiki.
 
-\subsubsection{MSYS2 environment}
-Since RAVEN requires a UNIX-like shell to function, the freely-available software package called MSYS2 is
-used to
-provide this functionality.  More information about MSYS2 is available at
-\url{https://sourceforge.net/p/msys2/wiki/MSYS2%20introduction/}.
-\nb While there is also a 32-bit version of MSYS2 available, the RAVEN installation described here will not work with it.
-
+\subsubsection{GIT SCM for Windows}
+RAVEN currently works on Windows using basic tools freely available online. 
+The first software to be downloaded and installed is \textbf{Git SCM} available at \url{https://gitforwindows.org/}.
 \begin{enumerate}
-    \item Obtain and run the latest basic 64-bit MSYS2 installer from \url{ https://msys2.github.io/} (As of this writing it is named
-	msys2-x86\_64-20161025.exe and is approximately 67 Megabytes in size).
-    \item The page with the download also contains installation instructions. Perform the steps described there up to
-	step 6 to install a minimal MSYS2 system and bring it up to date. Make sure that you install to path
-        C:\textbackslash{}msys64.  This installation will create shortcuts in the Windows start menu that may be used
-        to start UNIX-Like shells:
-		\begin{itemize}
-	    		\item MSYS2 Shell
-	    		\item MinGW-w64 Win32 Shell
-	    		\item MinGW-w64 Win64 Shell
-		\end{itemize}
-        When working with RAVEN, it is recommended to use "MinGW-w64 Win64 Shell", although any of them should work.
-    \item Use the MSYS2 package manager {\it pacman} to install a few tools that will be needed later.  Enter the following command in an MSYS shell window:
-
-\begin{lstlisting}[language=bash]
-USER@HOSTNAME MINGW64 ~
-$ pacman -S git winpty make
-\end{lstlisting}
-	The package manager will then download and install those packages (and their dependencies) from the MSYS2
-	repository.
-\end{enumerate}
+    \item Obtain the latest Git SCM for Windows installer from  \url{https://gitforwindows.org/} and install it. 
+    Install Git Bash and have 
+    the installer add Git Bash to your Windows \textit{PATH} environment variables. 
+    The \textit{PATH} can be updated either automatically (allowing the Git SCM installer to update it for you) or manually 
+    (Systems Properties - Environment Variables - Edit Environment Variables).
 
 \subsubsection{Install Python Language and Package Support}
 \begin{enumerate}
@@ -55,7 +35,11 @@ $ pacman -S git winpty make
 		\url{https://conda.io/miniconda.html} and install it.  \item The installer
 		will ask whether Python should be installed for only the logged in user or
 		for all users.  Either option will work for RAVEN.
-	\item Locate and test the Python installation.   Open a Windows command prompt and enter the
+	\item 	have  the installer add \textit{conda} to your Windows \textit{PATH} environment variables.   
+	The \textit{PATH} can be updated either automatically (allowing the  \textit{conda} installer to update it for you) 
+	or manually (Systems Properties - Environment Variables - Edit Environment Variables).
+	\item Check the installation of Python and coda locating and testing the Python installation.   
+	Open a Windows command prompt and enter the
 		command "{\it where python}", which attempts to locate a the Python language interpreter
 		in the current system path.  This looks like:
 
@@ -64,98 +48,8 @@ $ pacman -S git winpty make
     C:\Users\USERID\AppData\Local\Continuum\Miniconda3\python.exe
     \end{lstlisting}
 
-	\item Setup MSYS2 to find Python.  MSYS2 has its own separate PATH which must also be adjusted
-		so that Python and its associated tools may be found. This is done by converting the
-		file system location of Python determined in the previous step to its MSYS2-compatible
-		equivalent and using the result to setup MSYS2 so that it too can find it in the future.
-		\newline \newline
-		This is done by turning all backslashes ('\textbackslash') in the path to be converted to
-		forward slashes ('/'), and changing the drive letter from its '\textless letter\textgreater:'
-		form to '/ \textless letter\textgreater'. In addition, any spaces in the path must
-		be escaped using a backslash ('\textbackslash') when converted.
-		\newline \newline
-		For example:
-
-\begin{lstlisting}[language=bash]
-C:\Users\USERID\AppData\Local\Continuum\Miniconda3
-\end{lstlisting}
-		becomes
-\begin{lstlisting}[language=bash]
-/c/Users/USERID/AppData/Local/Continuum/Miniconda3
-\end{lstlisting}
-		for MSYS2. Here is an example with spaces that need to be escaped:
-\begin{lstlisting}[language=bash]
-C:\Program Files\Common Files
-\end{lstlisting}
-		converted to MSYS2 form would become
-\begin{lstlisting}[language=bash]
-/c/Program\ Files/Common\ Files
-\end{lstlisting}
-		\medskip
-		Three separate paths must be added to MSYS2 to enable all of the Python tools needed
-		to be found.  These are:
-
-		\smallskip
-\begin{tabular}{| l | l |}
-	\hline
-	{\bf Path} & {\bf Purpose} \\\hline
-	\textless Converted path from above\textgreater	& Python executable \\\hline
-	\textless Converted path from above\textgreater /Scripts &	Conda (Needed to manage Python packages) \\\hline
-	\textless Converted path from above\textgreater /Library/bin &	Swig (Needed to build RAVEN) \\\hline
-\end{tabular}
-
-		\medskip
-		These paths are added using shell commands that append new entries to the existing PATH
-		variable without overwriting it.  These commands take the following form:
-
-\begin{lstlisting}[language=bash, basicstyle=\tiny]
-export PATH=/c/Users/USERID/AppData/Local/Continuum/Miniconda3:$PATH
-export PATH=/c/Users/USERID/AppData/Local/Continuum/Miniconda3/Scripts:$PATH
-export PATH=/c/Users/USERID/AppData/Local/Continuum/Miniconda3/Library/bin:$PATH
-\end{lstlisting}
-
-		To configure these needed paths in MSYS2 so that they persist, file "~/.bashrc" will need
-		to be edited.  This may be done either using an MSYS2-based editor such as {\it vim}
-		(VI-iMproved, which is included in the installation) or a Windows-based editor like
-		{\it Wordpad} (included with Windows).  Another excellent open source editor for
-		Windows is {\it Notepad++} \url{https://notepad-plus-plus.org/}, which is also good
-		for editing RAVEN input files.
-
-	\item Test Python in MSYS2.  At this point open a new MSYS2 shell window and see if Python is
-		now found in the PATH:
-		\newline
-		Note: Due to the way that Python interacts with the MSYS2 shell, when using Python by
-		itself in MSYS2 the {\it winpty} utility is provided. (If Python is run without winpty,
-		it may appear to sit there and do nothing. Pressing \textless Ctrl\textgreater -C will
-		interrupt it.)
-
-
-\begin{lstlisting}[language=bash, basicstyle=\tiny]
-USER@HOSTNAME MINGW64 ~
-$ winpty python
-Python 3.6.7 |Anaconda 4.0.0 (64-bit)| (default, Dec 19 2016, 13:29:36) [MSC v.1500 64 bit (AMD64)] on win32
-Type "help", "copyright", "credits" or "license" for more information.
-Anaconda is brought to you by Continuum Analytics.
-Please check out: http://continuum.io/thanks and https://anaconda.org
->>>
->>> quit()
-
-\end{lstlisting}
-
-% Windows should use establish_conda_env.sh like everyone else
-%	\item Install needed Python packages.  RAVEN requires several Python packages to function properly.
-%		Now the {\it conda} command will be used to download and install them in an automated manner. The
-%		following asks {\it conda} to obtain the specified versions of the listed packages, as well as all
-%		of their dependencies.
-%		\smallskip
-%
-%    \begin{lstlisting}[language=bash]
-%    conda install numpy=1.11.0 h5py=2.6.0 scipy=0.17.1 \
-%      scikit-learn=0.17.1 matplotlib=1.5.1 python=3 \
-%      hdf5 swig pylint lxml
-%    \end{lstlisting}
-
 \end{enumerate}
+
 
 \subsubsection{Compiler Installation and Configuration}
 \begin{enumerate}
@@ -167,114 +61,13 @@ Please check out: http://continuum.io/thanks and https://anaconda.org
 		successfully used to build RAVEN. Professional and Enterprise versions of these will
 		also work. If one of these is already present on your system, it is not necessary to
 		obtain another one. Note that because C++11 language features are required, the
-		"Microsoft Visual C++ Compiler for Python 2.7" often used for building Python
+		"Microsoft Visual C++ Compiler for Python 2.7 or 3.x" often used for building Python
 		add-ons will {\bf not} work.
 
 		After downloading and running the Visual Studio installer, it will ask what features
 		to install. For building RAVEN, "Desktop development with C++" is needed at a minimum.
 		Installation of other Visual Studio features should be fine.
-
-	\item Let the build system know where to find the compiler.  When the build system attempts
-		to search for an installed compiler, this process often fails with the error message
-		"Unable to find vcvarsall.bat".  This happens because Python version 2.7 has not been
-		updated to automatically locate modern Visual Studio installations. To solve this it
-		is necessary to help the Python build system find the C++ compiler on the system.
-		The easiest way to do this is create a Windows batch (.BAT) file that will redirect
-		the build system to the information it needs. First, locate the file VCVARSALL.BAT
-		file installed as part of Visual Studio on your system. This location will usually
-		be something like the following:
-		\smallskip
-
-\begin{tabular}{| l | l |}
-	\hline
-	{\bf Visual Studio Version} & {\bf Directory containing VCVARSALL.BAT} \\\hline
-	2015 & C:\textbackslash Program Files (x86)\textbackslash Microsoft Visual Studio 14.0\textbackslash VC \\\hline
-	2017 & C:\textbackslash Program Files (x86)\textbackslash Microsoft Visual \\
-               & Studio\textbackslash 2017\textbackslash Community\textbackslash VC\textbackslash
-                Auxiliary\textbackslash Build \\\hline
-\end{tabular}
-
-		\medskip
-		Once the target file has been located it is necessary to create a couple of directories
-		and one file. The first directory created must be named "VC" and should be created
-		somewhere outside of the RAVEN source tree (such as your MinGW home directory):
-
-\begin{lstlisting}[language=bash]
-USER@HOSTNAME MINGW64 ~
-$ mkdir VC
-\end{lstlisting}
-
-		The next directory to be created must be inside the one just created. It is suggested
-		to name it "target", because it is there that we will point the Python build system:
-
-\begin{lstlisting}[language=bash]
-USER@HOSTNAME MINGW64 ~
-$ cd VC
-
-USER@HOSTNAME MINGW64 ~/VC
-$ mkdir target
-
-USER@HOSTNAME MINGW64 ~/VC
-$ ls
-target
-
-\end{lstlisting}
-
-		The file to be created is named "VCVARSALL.BAT", and it must be written in the VC
-		directory that was just made. The Python build system will be configured to find this
-		file, which then redirects it to the actual file. Use a text editor (such as
-		{\it vim} or {\it notepad} as described above) to create the file VCVARSALL.BAT:
-
-\begin{lstlisting}[language=bash]
-USER@HOSTNAME MINGW64 ~/VC
-$ vim VCVARSALL.BAT
-\end{lstlisting}
-
-		or
-
-\begin{lstlisting}[language=bash]
-USER@HOSTNAME MINGW64 ~/VC
-$ notepad VCVARSALL.BAT
-\end{lstlisting}
-
-		One line will need to be added to the new file VCVARSALL.BAT:
-
-\begin{lstlisting}[language=bash, basicstyle=\tiny]
-CALL "<Full Path To VCVARSALL.BAT File Installed by Visual Studio>" %1 %2 %3 %4 %5
-\end{lstlisting}
-
-		For example, in the case of Visual Studio 2017 Community installed in the default
-		location this would be:
-
-\begin{lstlisting}[language=bash, basicstyle=\tiny]
-CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\VCVARSALL.BAT" %1 %2 %3 %4 %5
-\end{lstlisting}
-
-		Note the double quotes around the path and file name. These are necessary because
-		there are spaces in some of the directory names that make up the full location of
-		VCVARSALL.BAT.
-
-		After creating the new {\it VCVARSALL.BAT} in the directory {\it VC}, one more thing
-		needs to be done to inform the Python build system where this file just created is.
-		During the build process, an {\it environment variable} "VS90COMNTOOLS" will be checked.
-		The value of VS90COMNTOOLS will need to be set to the {\it target} directory just below
-		the location of VCVARSALL.BAT file just created.
-
-		For example, if VCVARSALL.BAT was created in directory VC under your MinGW home
-		directory, the variable VS90COMNTOOLS should point to \textasciitilde /VC/target.
-
-\begin{lstlisting}[language=bash]
-USER@HOSTNAME MINGW64 ~
-$ export VS90COMNTOOLS=~/VC/target
-
-USER@HOSTNAME MINGW64 ~
-$ echo $VS90COMNTOOLS
-/home/user/VC/target
-\end{lstlisting}
-
 \end{enumerate}
-
-
 
 Once the compiler installation and configuration is complete, you are prepared to install the RAVEN libraries
 (see section \ref{sec:install conda}).

--- a/doc/user_manual/Installation/windows.tex
+++ b/doc/user_manual/Installation/windows.tex
@@ -28,6 +28,7 @@ The first software to be downloaded and installed is \textbf{Git SCM} available 
     the installer add Git Bash to your Windows \textit{PATH} environment variables. 
     The \textit{PATH} can be updated either automatically (allowing the Git SCM installer to update it for you) or manually 
     (Systems Properties - Environment Variables - Edit Environment Variables).
+\end{enumerate}
 
 \subsubsection{Install Python Language and Package Support}
 \begin{enumerate}

--- a/doc/user_manual/make_win.sh
+++ b/doc/user_manual/make_win.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Local variable definition ----------------------------------------------------
+# list of files to run.
+declare -a files=(raven_user_manual)
+# extension to be removed.
+declare -a exts=(txt ps ds)
+
+# Functions definition ---------------------------------------------------------
+# Subroutine to remove files.
+clean_files () { 
+	# Remove ald the files with the selected suffixes.
+	for ext in "${exts[@]}"
+	do
+		for file in `ls *.$ext 2> /dev/null`
+		do
+			rm -rf *.aux *.bbl *.blg *.log *.out *.toc *.lot *.lof raven_user_manual.pdf
+		done
+	done
+}
+
+# Subroutine to generate files.
+gen_files () { 
+        git log -1 --format="%H %an %aD" .. > ../version.tex
+        python ../../scripts/TestHarness/testers/RavenUtils.py --manual-list > libraries.tex
+        bash.exe ./create_command.sh
+        bash.exe ./create_pip_commands.sh
+	for file in "${files[@]}"
+	do
+		# Generate files.
+        pdflatex -interaction=nonstopmode $file.tex
+        bibtex $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+	pdflatex -interaction=nonstopmode $file.tex
+
+	done
+}
+
+# Clean and run ----------------------------------------------------------------
+if [[ $1 = 'clean' ]]
+then
+    # Remove al the files with the selected extension.
+    clean_files
+else
+    # Generate all the selected files.
+    gen_files
+fi

--- a/raven_framework.bat
+++ b/raven_framework.bat
@@ -1,0 +1,32 @@
+@echo off
+ECHO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ECHO[
+ECHO       .---.        .------######       #####     ###   ###  ########  ###    ###
+ECHO      /     \  __  /    --###  ###    ###  ###   ###   ###  ###       #####  ###
+ECHO     / /     \(  )/    --###  ###    ###   ###  ###   ###  ######    ### ######
+ECHO    //////   ' \/ `   --#######     #########  ###   ###  ###       ###  #####
+ECHO   //// / // :    :   -###   ###   ###   ###    ######   ####      ###   ####
+ECHO  // /   /  /`    '---###    ###  ###   ###      ###    ########  ###    ###
+ECHO //          //..\\
+ECHO ===========UU====UU=============================================================
+ECHO            '//||\\`
+ECHO              ''``
+ECHO[
+ECHO[
+set /p input_file="Enter input file: "
+ECHO[
+FOR %%i IN ("%input_file%") DO (
+ECHO *** INPUT FILE LOCATION ***
+ECHO     filedrive=%%~di
+ECHO     filepath=%%~pi
+ECHO     filename=%%~ni
+ECHO     fileextension=%%~xi
+)
+ECHO[
+ECHO *** RUNNING ***:
+ECHO[
+Pushd %filepath%
+bash.exe raven_framework %input_file%
+ECHO[
+ECHO[
+pause


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #974 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

