### PR TITLE
add IOError for duplicates in Input and Output of DataObjects

### DIFF
--- a/framework/DataObjects/DataObject.py
+++ b/framework/DataObjects/DataObject.py
@@ -210,9 +210,13 @@ class DataObject(utils.metaclass_insert(abc.ABCMeta,BaseType)):
         self._inputs.remove(index)
       except ValueError:
         pass #not requested as input anyway
+    # check inputs and outputs, if there were duplicates, error out
+    dups = set(self._inputs).intersection(self._outputs)
+    if dups:
+      self.raiseAnError(IOError, 'Variables: "', ','.join(dups), '" are specified in both "Input" and "Output" Node of DataObject "', self.name,'"')
     self._orderedVars = self._inputs + self._outputs
     # check if protected vars have been violated
-    if set(self.protectedTags).issubset(set(self._orderedVars)):
+    if set(self.protectedTags).intersection(set(self._orderedVars)):
       self.raiseAnError(IOError, 'Input, Output and Index variables can not be part of RAVEN protected tags: '+','.join(self.protectedTags))
 
     # create dict var to index

--- a/plugins/ExamplePlugin/tests/ravenRunningRavenPlugin/test_example_plugin.xml
+++ b/plugins/ExamplePlugin/tests/ravenRunningRavenPlugin/test_example_plugin.xml
@@ -1,4 +1,4 @@
-<Simulation verbosity="debug">
+<Simulation verbosity="silent">
   <TestInfo>
     <name>SumOfExponential_test</name>
     <author>alfoa</author>

--- a/tests/cluster_tests/RavenRunsRaven/raven_running_raven_internal_models/test_rom_trainer.xml
+++ b/tests/cluster_tests/RavenRunsRaven/raven_running_raven_internal_models/test_rom_trainer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Simulation verbosity="debug">
+<Simulation verbosity="silent">
 
   <RunInfo>
     <WorkingDir>test_rom_trainer</WorkingDir>
@@ -92,14 +92,14 @@
     </MonteCarlo>
   </Samplers>
 
-  <Steps verbosity="debug">
-    <MultiRun name="MC_for_rom_trainer" verbosity="debug">
+  <Steps verbosity="silent">
+    <MultiRun name="MC_for_rom_trainer" verbosity="silent">
       <Input class="DataObjects" type="PointSet">inputHolder</Input>
       <Model class="Models" type="ExternalModel">PythonModule</Model>
       <Sampler class="Samplers" type="MonteCarlo">RAVENmcCode3</Sampler>
       <Output class="Databases" type="HDF5">MC_TEST_EXTRACT_STEP_FOR_ROM_TRAINER</Output>
     </MultiRun>
-    <IOStep name="test_extract_for_rom_trainer" verbosity="debug">
+    <IOStep name="test_extract_for_rom_trainer" verbosity="silent">
       <Input class="Databases" type="HDF5">MC_TEST_EXTRACT_STEP_FOR_ROM_TRAINER</Input>
       <Input class="Databases" type="HDF5">MC_TEST_EXTRACT_STEP_FOR_ROM_TRAINER</Input>
       <Output class="DataObjects" type="PointSet">Pointset_from_database_for_rom_trainer</Output>
@@ -107,11 +107,11 @@
       <Output class="OutStreams" type="Print">ciccio</Output>
       <Output class="OutStreams" type="Print">ciccioHS</Output>
     </IOStep>
-    <RomTrainer name="test_rom_trainer" verbosity="debug">
+    <RomTrainer name="test_rom_trainer" verbosity="silent">
       <Input class="DataObjects" type="PointSet">Pointset_from_database_for_rom_trainer</Input>
       <Output class="Models" type="ROM">ROM1</Output>
     </RomTrainer>
-    <RomTrainer name="test_rom_trainerHS" verbosity="debug">
+    <RomTrainer name="test_rom_trainerHS" verbosity="silent">
       <Input class="DataObjects" type="HistorySet">Historyset_from_database_for_rom_trainer</Input>
       <Output class="Models" type="ROM">ROMHS</Output>
     </RomTrainer>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #981 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

