### PR TITLE
fix issue in basic statistics 

### DIFF
--- a/framework/PostProcessors/BasicStatistics.py
+++ b/framework/PostProcessors/BasicStatistics.py
@@ -923,7 +923,7 @@ class BasicStatistics(PostProcessor):
         # construct target and feature matrices
         dataSet = dataSet.to_array().transpose(self.sampleTag,'variable')
         featSet = dataSet.sel(**{'variable':features}).values
-        targSet = dataSet.sel(**{'variable':targets}).values
+        targSet = dataSet.sel(**{'variable':targets}).values 
         da = self.sensitivityCalculation(features,targets,featSet,targSet,intersectionSet)
       calculations[metric] = da
     #
@@ -990,7 +990,7 @@ class BasicStatistics(PostProcessor):
         pivotCoords = reducedCovar.coords[self.pivotParameter].values
         ds = None
         for label, group in reducedCovar.groupby(self.pivotParameter):
-          corrMatrix = self.corrCoeff(group.values)
+          corrMatrix = self.corrCoeff(group.values if len(group.values.shape) == 2 else group.values[0])
           da = xr.DataArray(corrMatrix, dims=('targets','features'), coords={'targets':targCoords,'features':targCoords})
           ds = da if ds is None else xr.concat([ds,da], dim=self.pivotParameter)
         ds.coords[self.pivotParameter] = pivotCoords

--- a/framework/h5py_interface_creator.py
+++ b/framework/h5py_interface_creator.py
@@ -58,7 +58,10 @@ def _loads(val):
     @ Out, _loads, any, data decoded
   """
   if hasattr(val,'tostring'):
-    return pk.loads(val.tostring())
+    try:
+      return pk.loads(val.tostring())
+    except UnicodeDecodeError:
+      return pk.loads(val.tostring(),errors='backslashreplace')
   else:
     try:
       return pk.loads(val)

--- a/plugins/ExamplePlugin/tests/tests
+++ b/plugins/ExamplePlugin/tests/tests
@@ -10,7 +10,7 @@
   type = 'RavenFramework'
   input = 'test_raven_running_raven_plugin.xml'
   csv = 'ravenRunningRavenPlugin/testPointSet_dump.csv'
-  max_time = 100
+  max_time = 120
   rel_err = 0.0001
  [../]
 []

--- a/tests/framework/Optimizers/RavenRunningRaven/inner_opt.xml
+++ b/tests/framework/Optimizers/RavenRunningRaven/inner_opt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Simulation verbosity="debug">
+<Simulation verbosity="silent">
   <RunInfo>
     <WorkingDir>innerRun</WorkingDir>
     <Sequence>optimize,print</Sequence>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1011 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.
