### PR TITLE
update make file to avoid syntax error when building docs

### DIFF
--- a/doc/make_docs.sh
+++ b/doc/make_docs.sh
@@ -32,11 +32,12 @@ source ../scripts/establish_conda_env.sh --load --quiet
 #   (not the Unix-style ones used on other platforms).  This also means semi-colons need to be used
 #   to separate terms instead of the Unix colon.
 #
-if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
+if [ "$(uname)" == "Darwin" ] || [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
+then
+  export TEXINPUTS=.:$SCRIPT_DIR/tex_inputs/:$TEXINPUTS
+elif [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
 then
   export TEXINPUTS=.\;`cygpath -w $SCRIPT_DIR/tex_inputs`\;$TEXINPUTS
-else
-  export TEXINPUTS=.:$SCRIPT_DIR/tex_inputs/:$TEXINPUTS
 fi
 
 
@@ -56,7 +57,15 @@ fi
 for DIR in  user_manual user_guide theory_manual tests; do
     cd $DIR
     echo Building in $DIR...
-    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
+    if [ "$(uname)" == "Darwin" ] || [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
+    then
+      if [[ 1 -eq $VERB ]]
+      then
+        make; MADE=$?
+      else
+        make > /dev/null; MADE=$?
+      fi    
+    elif [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
     then  
       if [[ 1 -eq $VERB ]]
       then
@@ -64,13 +73,6 @@ for DIR in  user_manual user_guide theory_manual tests; do
       else
         bash.exe make_win.sh > /dev/null; MADE=$?
       fi
-    else  
-      if [[ 1 -eq $VERB ]]
-      then
-        make; MADE=$?
-      else
-        make > /dev/null; MADE=$?
-      fi    
     fi
     if [[ 0 -eq $MADE ]]; then
         echo ...Successfully made docs in $DIR

--- a/doc/sqa/make_docs.sh
+++ b/doc/sqa/make_docs.sh
@@ -32,11 +32,12 @@ source ../../scripts/establish_conda_env.sh --load --quiet
 #   (not the Unix-style ones used on other platforms).  This also means semi-colons need to be used
 #   to separate terms instead of the Unix colon.
 #
-if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
+if [ "$(uname)" == "Darwin" ] || [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
+then
+  export TEXINPUTS=.:$SCRIPT_DIR/tex_inputs/:$TEXINPUTS
+elif [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
 then
   export TEXINPUTS=.\;`cygpath -w $SCRIPT_DIR/tex_inputs`\;$TEXINPUTS
-else
-  export TEXINPUTS=.:$SCRIPT_DIR/tex_inputs/:$TEXINPUTS
 fi
 # copy files that are not built
 # SQAP
@@ -65,21 +66,22 @@ fi
 for DIR in  sdd rtr srs srs_rtr_combined; do
     cd $DIR
     echo Building in $DIR...
-    if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
-    then  
-      if [[ 1 -eq $VERB ]]
-      then
-        bash.exe make_win.sh; MADE=$?
-      else
-        bash.exe make_win.sh > /dev/null; MADE=$?
-      fi
-    else  
+    if [ "$(uname)" == "Darwin" ] || [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]
+    then
       if [[ 1 -eq $VERB ]]
       then
         make; MADE=$?
       else
         make > /dev/null; MADE=$?
       fi    
+    elif [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]  || [  "$(expr substr $(uname -s) 1 4)" == "MSYS" ]
+    then
+      if [[ 1 -eq $VERB ]]
+      then
+        bash.exe make_win.sh; MADE=$?
+      else
+        bash.exe make_win.sh > /dev/null; MADE=$?
+      fi
     fi
     if [[ 0 -eq $MADE ]]; then
         echo ...Successfully made docs in $DIR


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1013 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

