### PR TITLE
unpin python 3.7 version

### DIFF
--- a/scripts/TestHarness/testers/RavenUtils.py
+++ b/scripts/TestHarness/testers/RavenUtils.py
@@ -83,10 +83,7 @@ __condaList = [("h5py", __lookup_preferred_version("h5py")),
                ("statsmodels", __lookup_preferred_version("statsmodels")),
                ("tensorflow", __lookup_preferred_version("tensorflow", optional=True)),
                ("cloudpickle", __lookup_preferred_version("cloudpickle", optional=True)),
-               ## TODO: Bad python3.7.4 build on Conda will cause module import error
-               ## (crow_modules._distribution1Dpy3.py). We will currently fix the python
-               ## versions until the issue in python3.7.4 is resolved.
-               ("python", "3.7.3"),
+               ("python", ""),
                ("hdf5", "1.10.4"),
                ("swig", ""),
                ("pylint", ""),


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1036 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

