### PR TITLE
Cogljj/close fix

### DIFF
--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -1898,18 +1898,15 @@ class OutStreamPlot(OutStreamManager):
     # self.plt3D.draw(self.fig.canvas.renderer)
 
     if 'screen' in self.destinations and display:
-      if platform.system() in ['Linux','Windows']:
-        # XXX For some reason, this is required on Linux, but causes
-        # OSX to fail.  Which is correct for windows has not been determined.
-        def handle_close(event):
-          """
-            This method is aimed to handle the closing of figures (overall when in interactive mode)
-            @ In, event, instance, the event to close
-            @ Out, None
-          """
-          self.fig.canvas.stop_event_loop()
-          self.raiseAMessage('Closed Figure')
-        self.fig.canvas.mpl_connect('close_event', handle_close)
+      def handle_close(event):
+        """
+        This method is aimed to handle the closing of figures (overall when in interactive mode)
+        @ In, event, instance, the event to close
+        @ Out, None
+        """
+        self.fig.canvas.stop_event_loop()
+        self.raiseAMessage('Closed Figure')
+      self.fig.canvas.mpl_connect('close_event', handle_close)
       # self.plt.pause(1e-6)
       ## The following code is extracted from pyplot.pause without actually
       ## needing to force the code to sleep, according to MPL's documentation,

--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -673,18 +673,18 @@ class OutStreamPlot(OutStreamManager):
       @ In, instructionString, string, the instruction to execute
       @ Out, None
     """
-    if instructionString == 'interactive' and 'screen' in self.destinations and displayAvailable:
+    if instructionString == 'interactive' and 'screen' in self.destinations and display:
       self.fig = plt.figure(self.name)
       ## This seems a bit hacky, but we need the ginput in order to block
       ## execution of raven until this is over, however closing the window can
       ## cause this thing to fail.
-      try:
-        self.fig.ginput(n = -1, timeout = -1, show_clicks = False)
-      except:
+      #try:
+      self.fig.ginput(n = -1, timeout = 0, show_clicks = False)
+      #except:
         ## I know this is bad, but it is a single line of code outside our
         ## control, if it fails for any reason it should not be a huge deal, we
         ## just want RAVEN to continue on its merry way when a figure closes.
-        pass
+      #  pass
       ## We may want to catch a more generic exception since this may be depedent
       ## on the backend used, hence the code replacement above
       # except _tkinter.TclError:
@@ -724,7 +724,7 @@ class OutStreamPlot(OutStreamManager):
     else:
       self.fig = plt.figure(self.name)
 
-    if 'screen' in self.destinations and displayAvailable:
+    if 'screen' in self.destinations and display:
       self.fig.show()
 
     if self.dim == 3:
@@ -1897,7 +1897,7 @@ class OutStreamPlot(OutStreamManager):
     plt.draw()
     # self.plt3D.draw(self.fig.canvas.renderer)
 
-    if 'screen' in self.destinations and displayAvailable:
+    if 'screen' in self.destinations and display:
       if platform.system() in ['Linux','Windows']:
         # XXX For some reason, this is required on Linux, but causes
         # OSX to fail.  Which is correct for windows has not been determined.

--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -678,13 +678,13 @@ class OutStreamPlot(OutStreamManager):
       ## This seems a bit hacky, but we need the ginput in order to block
       ## execution of raven until this is over, however closing the window can
       ## cause this thing to fail.
-      #try:
-      self.fig.ginput(n = -1, timeout = 0, show_clicks = False)
-      #except:
+      try:
+        self.fig.ginput(n = -1, timeout = 0, show_clicks = False)
+      except:
         ## I know this is bad, but it is a single line of code outside our
         ## control, if it fails for any reason it should not be a huge deal, we
         ## just want RAVEN to continue on its merry way when a figure closes.
-      #  pass
+        pass
       ## We may want to catch a more generic exception since this may be depedent
       ## on the backend used, hence the code replacement above
       # except _tkinter.TclError:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #1043 

##### What are the significant changes in functionality due to this change request?
Removes special case in OSX that was no-longer needed.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

