### PR TITLE
temporarily enforce matplotlib backend to use Agg

### DIFF
--- a/framework/unSupervisedLearning.py
+++ b/framework/unSupervisedLearning.py
@@ -47,10 +47,16 @@ import MessageHandler
 import DataObjects
 #Internal Modules End-----------------------------------------------------------
 
-#if platform.system() == 'Windows':
-display = utils.displayAvailable()
-if not display:
-  matplotlib.use('Agg')
+# FIXME: temporarily force to use Agg backend for now, otherwise it will cause segmental fault for test:
+# test_dataMiningHierarchical.xml in tests/framework/PostProcessors/DataMiningPostProcessor/Clustering
+# For the record, when using dendrogram, we have to force matplotlib.use('Agg')
+# In the future, I think all the plots should moved to OutStreamPlots -- wangc
+#display = utils.displayAvailable()
+#if not display:
+#  matplotlib.use('Agg')
+
+matplotlib.use('Agg')
+import matplotlib.pylab as plt
 
 class unSupervisedLearning(utils.metaclass_insert(abc.ABCMeta), MessageHandler.MessageUser):
   """
@@ -1343,7 +1349,6 @@ class Scipy(unSupervisedLearning):
       @ In, None
       @ Out, None
     """
-    import matplotlib.pylab as plt
     plt.figure()
     max_d = kwargs.pop('max_d', None)
     if max_d and 'color_threshold' not in kwargs:

--- a/tests/framework/PostProcessors/DataMiningPostProcessor/Clustering/tests
+++ b/tests/framework/PostProcessors/DataMiningPostProcessor/Clustering/tests
@@ -90,8 +90,7 @@
     type   = 'RavenFramework'
     input  = 'test_dataMiningHierarchical.xml'
     csv    = 'Hierarchical/dummy.csv'
-    skip_if_OS = windows
-    skip = 'SEG FAULT... FIX ASAP'
+    #skip_if_OS = windows
   [../]
   [./agglomerativeDTW]
     type   = 'RavenFramework'


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1048 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

