### PR TITLE
Coverage issue

### DIFF
--- a/framework/UI/ScatterView.py
+++ b/framework/UI/ScatterView.py
@@ -34,7 +34,7 @@ except ImportError as e:
 from .BaseHierarchicalView import BaseHierarchicalView
 
 from mpl_toolkits.mplot3d import Axes3D
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 import mpl_toolkits

--- a/framework/UI/ScatterView.py
+++ b/framework/UI/ScatterView.py
@@ -69,8 +69,6 @@ class ScatterView(BaseHierarchicalView):
     self.mplCanvas = FigureCanvas(self.fig)
     self.mplCanvas.axes = self.fig.add_subplot(111)
 
-    # We want the axes cleared every time plot() is called
-    self.mplCanvas.axes.hold(False)
     self.colorbar = None
 
     mySplitter.addWidget(self.mplCanvas)
@@ -172,9 +170,6 @@ class ScatterView(BaseHierarchicalView):
       dimensionality = 3
       self.mplCanvas.axes = self.fig.add_subplot(111, projection='3d')
 
-    # We want the axes cleared every time plot() is called
-    self.mplCanvas.axes.hold(False)
-
     myColormap = colors.cm.get_cmap(self.cmbColorMaps.currentText())
 
     if len(rows) == 0:
@@ -210,8 +205,6 @@ class ScatterView(BaseHierarchicalView):
         self.lblColorMaps.setVisible(True)
         self.cmbColorMaps.setVisible(True)
 
-      self.mplCanvas.axes.hold(True)
-
     kwargs = {'edgecolors': 'none', 'c': values['Color']}
 
     if dimensionality == 2:
@@ -229,7 +222,6 @@ class ScatterView(BaseHierarchicalView):
       kwargs['vmax'] = maxs['Color']
 
     myPlot = self.mplCanvas.axes.scatter(**kwargs)
-    self.mplCanvas.axes.hold(True)
 
     if self.axesLabelAction.isChecked():
       self.mplCanvas.axes.set_xlabel(self.cmbVars['X'].currentText(),size=fontSize,labelpad=10)
@@ -258,7 +250,6 @@ class ScatterView(BaseHierarchicalView):
     for label in  (self.mplCanvas.axes.get_xticklabels()+self.mplCanvas.axes.get_yticklabels()):
       label.set_fontsize(smallFontSize)
 
-    self.mplCanvas.axes.hold(False)
     self.mplCanvas.draw()
 
   def test(self):

--- a/framework/UI/ScatterView2D.py
+++ b/framework/UI/ScatterView2D.py
@@ -37,7 +37,7 @@ except ImportError as e:
 from .BaseTopologicalView import BaseTopologicalView
 
 from matplotlib.collections import LineCollection
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 import matplotlib.pyplot

--- a/framework/UI/ScatterView2D.py
+++ b/framework/UI/ScatterView2D.py
@@ -83,8 +83,8 @@ class ScatterView2D(BaseTopologicalView):
     self.fig = Figure(facecolor='white')
     self.mplCanvas = FigureCanvas(self.fig)
     self.mplCanvas.axes = self.fig.add_subplot(111)
-    # We want the axes cleared every time plot() is called
-    self.mplCanvas.axes.hold(False)
+    # We want the axes cleared every time plot() is called,
+    # so axes.hold used to be called, but that has been removed.
     self.colorbar = None
 
     mySplitter.addWidget(self.mplCanvas)
@@ -334,7 +334,6 @@ class ScatterView2D(BaseTopologicalView):
             else:
               lineColors.append('#CCCCCC')
 
-      self.mplCanvas.axes.hold(True)
       lc = LineCollection(lines,colors=lineColors,linewidths=1)
       self.mplCanvas.axes.add_collection(lc)
 
@@ -346,7 +345,6 @@ class ScatterView2D(BaseTopologicalView):
                                            vmax=maxs['Color'],
                                            edgecolors='none')
 
-      self.mplCanvas.axes.hold(True)
       if self.chkExts.checkState() == qtc.Qt.PartiallyChecked:
         maxValues['Color'] = colors.maxBrushColor.name()
         minValues['Color'] = colors.minBrushColor.name()
@@ -371,7 +369,6 @@ class ScatterView2D(BaseTopologicalView):
                                            c=values['Color'],
                                            edgecolors='none')
 
-      self.mplCanvas.axes.hold(True)
       if self.chkExts.checkState() == qtc.Qt.PartiallyChecked:
         maxValues['Color'] = colors.maxBrushColor.name()
         minValues['Color'] = colors.minBrushColor.name()
@@ -404,7 +401,6 @@ class ScatterView2D(BaseTopologicalView):
     for label in  (self.mplCanvas.axes.get_xticklabels()+self.mplCanvas.axes.get_yticklabels()):
       label.set_fontsize(smallFontSize)
 
-    self.mplCanvas.axes.hold(False)
     self.mplCanvas.draw()
 
   def test(self):

--- a/framework/UI/ScatterView3D.py
+++ b/framework/UI/ScatterView3D.py
@@ -35,10 +35,11 @@ except ImportError as e:
 from .BaseTopologicalView import BaseTopologicalView
 
 import matplotlib
-matplotlib.use('Qt5Agg')
+#Is the below needed?
+#matplotlib.use('Qt5Agg')
 
 from mpl_toolkits.mplot3d import Axes3D
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 import mpl_toolkits
 import matplotlib.pyplot

--- a/framework/UI/ScatterView3D.py
+++ b/framework/UI/ScatterView3D.py
@@ -84,8 +84,8 @@ class ScatterView3D(BaseTopologicalView):
     self.fig = Figure(facecolor='white')
     self.mplCanvas = FigureCanvas(self.fig)
     self.mplCanvas.axes = self.fig.add_subplot(111, projection='3d')
-    # We want the axes cleared every time plot() is called
-    self.mplCanvas.axes.hold(False)
+    # We want the axes cleared every time plot() is called,
+    # so axes.hold used to be called, but now that has been removed.
     self.colorbar = None
 
     mySplitter.addWidget(self.mplCanvas)
@@ -351,7 +351,6 @@ class ScatterView3D(BaseTopologicalView):
 
       lc = mpl_toolkits.mplot3d.art3d.Line3DCollection(lines,colors=lineColors,linewidths=1)
       self.mplCanvas.axes.add_collection(lc)
-      self.mplCanvas.axes.hold(True)
 
     if self.cmbVars['Color'].currentText() not in specialColorKeywords:
       myPlot = self.mplCanvas.axes.scatter(values['X'], values['Y'],
@@ -372,7 +371,6 @@ class ScatterView3D(BaseTopologicalView):
       self.colorbar.set_label(self.cmbVars['Color'].currentText(),size=fontSize,labelpad=10)
       self.colorbar.set_ticks(np.linspace(mins['Color'],maxs['Color'],5))
       self.colorbar.ax.tick_params(labelsize=smallFontSize)
-      self.mplCanvas.axes.hold(True)
       if self.chkExts.checkState() == qtc.Qt.PartiallyChecked:
         maxValues['Color'] = colors.maxBrushColor.name()
         minValues['Color'] = colors.minBrushColor.name()
@@ -397,7 +395,6 @@ class ScatterView3D(BaseTopologicalView):
                                            values['Z'], c=values['Color'],
                                            edgecolors='none')
 
-      self.mplCanvas.axes.hold(True)
       if self.chkExts.checkState() == qtc.Qt.PartiallyChecked:
         maxValues['Color'] = colors.maxBrushColor.name()
         minValues['Color'] = colors.minBrushColor.name()
@@ -440,7 +437,6 @@ class ScatterView3D(BaseTopologicalView):
     for label in  (self.mplCanvas.axes.get_xticklabels()+self.mplCanvas.axes.get_yticklabels()+self.mplCanvas.axes.get_zticklabels()):
       label.set_fontsize(smallFontSize)
 
-    self.mplCanvas.axes.hold(False)
     self.mplCanvas.draw()
 
   def test(self):

--- a/framework/unSupervisedLearning.py
+++ b/framework/unSupervisedLearning.py
@@ -56,7 +56,7 @@ import DataObjects
 #  matplotlib.use('Agg')
 
 
-if utils.displayAvailable():
+if utils.displayAvailable() and platform.system() != 'Windows':
   matplotlib.use('TkAgg')
 import matplotlib.pylab as plt
 

--- a/framework/unSupervisedLearning.py
+++ b/framework/unSupervisedLearning.py
@@ -55,7 +55,9 @@ import DataObjects
 #if not display:
 #  matplotlib.use('Agg')
 
-matplotlib.use('Agg')
+
+if utils.displayAvailable():
+  matplotlib.use('TkAgg')
 import matplotlib.pylab as plt
 
 class unSupervisedLearning(utils.metaclass_insert(abc.ABCMeta), MessageHandler.MessageUser):

--- a/framework/unSupervisedLearning.py
+++ b/framework/unSupervisedLearning.py
@@ -55,6 +55,7 @@ import DataObjects
 #if not display:
 #  matplotlib.use('Agg')
 
+matplotlib.use('Agg')
 import matplotlib.pylab as plt
 
 class unSupervisedLearning(utils.metaclass_insert(abc.ABCMeta), MessageHandler.MessageUser):

--- a/scripts/TestHarness/testers/RavenFramework.py
+++ b/scripts/TestHarness/testers/RavenFramework.py
@@ -138,7 +138,7 @@ class RavenFramework(Tester):
     self.__make_differ('xml', XMLDiff.XML, {"unordered":False})
     self.__make_differ('UnorderedXml', XMLDiff.XML, {"unordered":True})
     self.__make_differ('text', TextDiff.Text)
-    self.__make_differ('image', RAVENImageDiff.ImageDiff)
+    self.__make_differ('image', RAVENImageDiff.ImageDiffer)
     self.required_executable = self.specs['required_executable']
     self.required_libraries = self.specs['required_libraries'].split(' ')\
       if len(self.specs['required_libraries']) > 0 else []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #1085 

##### What are the significant changes in functionality due to this change request?
Fixes problem with running the Topology and the Hierarchical UI. 

Besides the main issue, this also allows working with newer matplotlib versions that don't have axes.hold and fixes a minor issue with doing image diffs with the RavenFramework tester.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

