### PR TITLE
Adding lock to pickled file

### DIFF
--- a/framework/CodeInterfaces/RAVEN/RAVENparser.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENparser.py
@@ -142,6 +142,8 @@ class RAVENparser():
           moduleToLoad = extModel.attrib['ModuleToLoad']
           if not moduleToLoad.endswith("py"):
             moduleToLoad += ".py"
+          if os.path.isabs(moduleToLoad):
+            continue
           if self.workingDir not in moduleToLoad:
             absPath = os.path.abspath(os.path.expanduser(os.path.join(workingDir, moduleToLoad)))
           else:

--- a/framework/Steps.py
+++ b/framework/Steps.py
@@ -27,6 +27,7 @@ import time
 import abc
 import os
 import sys
+import threading
 import itertools
 if sys.version_info.major > 2:
   import pickle
@@ -990,6 +991,9 @@ class IOStep(Step):
         ## unpickle the ROM
         fileobj = inDictionary['Input'][i]
         unpickledObj = pickle.load(open(fileobj.getAbsFile(),'rb+'))
+        pickleLock = threading.RLock()
+        with pickleLock:
+          unpickledObj = pickle.load(open(fileobj.getAbsFile(),'rb+'))
         if not isinstance(unpickledObj,Models.ROM):
           self.raiseAnError(RuntimeError,'Pickled object in "%s" is not a ROM.  Exiting ...' %str(fileobj))
         if not unpickledObj.amITrained:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1092 

##### What are the significant changes in functionality due to this change request?
Adding a threading lock to pickled file to avoid pickle data was truncated problem, adding a check if  the path is absolute inside RAVEN parser to avoid the copying same file error.


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

