### PR TITLE
List of software added in wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,25 @@ RAVEN provides a set of basic and advanced capabilities that ranges from data ge
 ## Model capabilities
 
 - Generic interface with external codes
-- Custom code interfaces (third-party software(s) currently available: Any generic MOOSE based application, MAAP, DYMOLA, etc.)
+- Custom code interfaces (third-party software(s) currently available:
+    - [RELAP5-3D](https://relap53d.inl.gov/SitePages/Home.aspx)  
+    - [MELCOR](https://melcor.sandia.gov/about.html) 
+    - [MAAP5](https://www.fauske.com/nuclear/maap-modular-accident-analysis-program) 
+    - [MOOSE-BASED Apps](https://mooseframework.inl.gov/) 
+    - [SCALE](https://www.ornl.gov/onramp/scale-code-system) 
+    - [SERPENT](http://montecarlo.vtt.fi/) 
+    - [CTF - COBRA TF](https://www.ne.ncsu.edu/rdfmg/cobra-tf/) 
+    - [SAPHIRE](https://saphire.inl.gov/) 
+    - [MODELICA](https://www.modelica.org/modelicalanguage) 
+    - [DYMOLA](https://www.3ds.com/products-services/catia/products/dymola/) 
+    - [BISON](https://bison.inl.gov/SitePages/Home.aspx) 
+    - [RATTLESNAKE](https://rattlesnake.inl.gov/SitePages/Home.aspx)
+    - [MAMMOTH](https://moose.inl.gov/mammoth/SitePages/Home.aspx) 
+    - [GOTHIC](http://www.numerical.com/products/gothic/gothic_all.php) 
+    - [PHISICS](https://modsimcode.inl.gov/SitePages/Home.aspx)
+    - [NEUTRINO](http://www.neutrinodynamics.com/) 
+    - [RAVEN running itself](https://raven.inl.gov/SitePages/Overview.aspx)
+
 - Custom ad-hoc external models (build in python internally to RAVEN)
 
 ## Data Post-Processing capabilities


### PR DESCRIPTION
Added list of software we are currently coupled  to

--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Ref. #1096

##### What are the significant changes in functionality due to this change request?
Added the software list

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

