### PR TITLE
validation analysis

### DIFF
--- a/framework/MetricDistributor.py
+++ b/framework/MetricDistributor.py
@@ -161,6 +161,11 @@ class MetricDistributor(utils.metaclass_insert(abc.ABCMeta,BaseType),MessageHand
       else:
         for hist in range(featVals.shape[1]):
           out = self.estimator.evaluate(featVals[:,hist], targVals[:,hist], dataWeight)
+          if isinstance(out,np.ndarray):
+            if multiOutput != 'full':
+              out = np.average(out)
+            else:
+              out = np.average(out,axis=-1)
           dynamicOutput.append(out)
     if multiOutput == 'mean':
       output = [np.average(dynamicOutput, weights = weights)]
@@ -169,6 +174,8 @@ class MetricDistributor(utils.metaclass_insert(abc.ABCMeta,BaseType),MessageHand
     elif multiOutput == 'min':
       output = [np.amin(dynamicOutput)]
     elif multiOutput == 'raw_values':
+      output = dynamicOutput
+    elif multiOutput == 'full':
       output = dynamicOutput
     else:
       self.raiseAnError(IOError, "multiOutput: ", multiOutput, " is not acceptable! Please use 'mean', 'max', 'min' or 'full'")

--- a/framework/Metrics/DTW.py
+++ b/framework/Metrics/DTW.py
@@ -106,17 +106,18 @@ class DTW(Metric):
       @ Out, value, float, metric result
     """
     assert (isinstance(x, np.ndarray))
-    assert (isinstance(x, np.ndarray))
+    assert (isinstance(y, np.ndarray))
     tempX = copy.copy(x)
     tempY = copy.copy(y)
-    if axis == 0:
-      assert (len(x) == len(y))
-    elif axis == 1:
-      assert(x.shape[1] == y.shape[1]), self.raiseAnError(IOError, "The second dimension of first input is not \
-              the same as the second dimension of second input!")
+    #if axis == 0:
+    #  assert (len(x) == len(y))
+    #elif axis == 1:
+    #  assert(x.shape[1] == y.shape[1]), self.raiseAnError(IOError, "The second dimension of first input is not \
+    #          the same as the second dimension of second input!")
+    if axis == 1:
       tempX = tempX.T
       tempY = tempY.T
-    else:
+    elif axis != 0:
       self.raiseAnError(IOError, "Valid axis value should be '0' or '1' for the evaluate method of metric", self.name)
 
     if len(tempX.shape) == 1:
@@ -128,11 +129,22 @@ class DTW(Metric):
     for index in range(len(tempX)):
       if self.order == 1:
         X[index] = np.gradient(tempX[index])
-        Y[index] = np.gradient(tempY[index])
       else:
         X[index] = tempX[index]
+    for index in range(len(tempY)):
+      if self.order == 1:
+        Y[index] = np.gradient(tempY[index])
+      else:
         Y[index] = tempY[index]
-    value = self.dtwDistance(X, Y)
+    if len(X) == len(Y):
+      value = self.dtwDistance(X, Y)
+    else:
+      value = 0.0
+      for ix in range(len(X)):
+        for iy in range(len(Y)):
+          value += self.dtwDistance(X[ix,:].reshape(1,-1),Y[iy,:].reshape(1,-1))
+      value = value/float(len(X)+len(Y))
+
     return value
 
   def dtwDistance(self, x, y):


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

