### PR TITLE
Alfoa/disable warnings if not debug

### DIFF
--- a/crow/scripts/find_eigen.py
+++ b/crow/scripts/find_eigen.py
@@ -1,7 +1,5 @@
 #!/bin/env python
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 import os, sys, subprocess
 

--- a/framework/Application.py
+++ b/framework/Application.py
@@ -18,8 +18,6 @@ Created on January 12, 2016
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 #External Modules---------------------------------------------------------------

--- a/framework/Assembler.py
+++ b/framework/Assembler.py
@@ -19,8 +19,6 @@ based on alfoa design
 
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #External Modules------------------------------------------------------------------------------------
 import abc
 #External Modules End--------------------------------------------------------------------------------

--- a/framework/BaseClasses.py
+++ b/framework/BaseClasses.py
@@ -16,8 +16,6 @@ Created on Mar 16, 2013
 @author: crisr
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #External Modules------------------------------------------------------------------------------------
 import inspect
 import sys

--- a/framework/CodeInterfaceBaseClass.py
+++ b/framework/CodeInterfaceBaseClass.py
@@ -17,8 +17,6 @@ Created on Jan 28, 2015
 @author: alfoa
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #External Modules------------------------------------------------------------------------------------
 import abc
 import os

--- a/framework/CodeInterfaces.py
+++ b/framework/CodeInterfaces.py
@@ -22,8 +22,6 @@ comment: The CodeInterface Module is an Handler.
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/CodeInterfaces/CobraTF/CTFinterface.py
+++ b/framework/CodeInterfaces/CobraTF/CTFinterface.py
@@ -17,8 +17,6 @@ July 2018
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 from ctfdata import ctfdata
 from CodeInterfaceBaseClass import CodeInterfaceBase
 from GenericCodeInterface import GenericParser

--- a/framework/CodeInterfaces/Dymola/DymolaInterface.py
+++ b/framework/CodeInterfaces/Dymola/DymolaInterface.py
@@ -93,8 +93,6 @@ of this is:
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import math

--- a/framework/CodeInterfaces/Generic/GenericCodeInterface.py
+++ b/framework/CodeInterfaces/Generic/GenericCodeInterface.py
@@ -17,8 +17,6 @@ Created March 17th, 2015
 @author: talbpaul
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/Generic/GenericParser.py
+++ b/framework/CodeInterfaces/Generic/GenericParser.py
@@ -17,8 +17,6 @@ Created on Mar 10, 2015
 @author: talbpaul
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import sys

--- a/framework/CodeInterfaces/MAAP5/MAAP5Interface.py
+++ b/framework/CodeInterfaces/MAAP5/MAAP5Interface.py
@@ -18,8 +18,6 @@ Created on April 14, 2016
 '''
 
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 from GenericCodeInterface import GenericCode
 import numpy as np

--- a/framework/CodeInterfaces/MAMMOTH/MAMMOTHInterface.py
+++ b/framework/CodeInterfaces/MAMMOTH/MAMMOTHInterface.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/MELCOR/MELCORdata.py
+++ b/framework/CodeInterfaces/MELCOR/MELCORdata.py
@@ -24,8 +24,6 @@
   Change Summary: Added Control Function parsing
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 import re
 import copy
 import itertools

--- a/framework/CodeInterfaces/MELCOR/melcorCombinedInterface.py
+++ b/framework/CodeInterfaces/MELCOR/melcorCombinedInterface.py
@@ -18,8 +18,6 @@
            Andrea Alfonsi (INL)
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 from CodeInterfaceBaseClass import CodeInterfaceBase
 from melcorInterface   import MelcorApp

--- a/framework/CodeInterfaces/MELCOR/melcorInterface.py
+++ b/framework/CodeInterfaces/MELCOR/melcorInterface.py
@@ -16,8 +16,6 @@
   @author: Matteo Donorio (University of Rome La Sapienza)
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/MELCOR/melgenInterface.py
+++ b/framework/CodeInterfaces/MELCOR/melgenInterface.py
@@ -18,8 +18,6 @@
   It is not an interface that can work on its own
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 from utils import utils

--- a/framework/CodeInterfaces/MooseBasedApp/BISONMESHSCRIPTparser.py
+++ b/framework/CodeInterfaces/MooseBasedApp/BISONMESHSCRIPTparser.py
@@ -17,9 +17,6 @@ Created on Jul 09, 2015
 @author: tompjame
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
-
 import os
 import re
 import collections

--- a/framework/CodeInterfaces/MooseBasedApp/BisonAndMeshInterface.py
+++ b/framework/CodeInterfaces/MooseBasedApp/BisonAndMeshInterface.py
@@ -17,8 +17,6 @@ Created July 14, 2015
 @author: talbpaul
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import copy
 from CodeInterfaceBaseClass   import CodeInterfaceBase

--- a/framework/CodeInterfaces/MooseBasedApp/BisonMeshScriptInterface.py
+++ b/framework/CodeInterfaces/MooseBasedApp/BisonMeshScriptInterface.py
@@ -17,8 +17,6 @@ created on July 13, 2015
 @author: tompjame
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/MooseBasedApp/CUBITparser.py
+++ b/framework/CodeInterfaces/MooseBasedApp/CUBITparser.py
@@ -18,8 +18,6 @@ created on Jul 15, 2015
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
 import warnings
-warnings.simplefilter('default',DeprecationWarning)
-
 import os
 import re
 import collections

--- a/framework/CodeInterfaces/MooseBasedApp/CubitInterface.py
+++ b/framework/CodeInterfaces/MooseBasedApp/CubitInterface.py
@@ -17,9 +17,6 @@ created on July 16, 2015
 @author: tompjame
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
-
 import os
 import copy
 from subprocess import Popen

--- a/framework/CodeInterfaces/MooseBasedApp/CubitMooseInterface.py
+++ b/framework/CodeInterfaces/MooseBasedApp/CubitMooseInterface.py
@@ -17,9 +17,6 @@ Created July 14, 2015
 @author: talbpaul
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
-
 import copy
 from CodeInterfaceBaseClass import CodeInterfaceBase
 from MooseBasedAppInterface import MooseBasedApp

--- a/framework/CodeInterfaces/MooseBasedApp/MOOSEparser.py
+++ b/framework/CodeInterfaces/MooseBasedApp/MOOSEparser.py
@@ -17,8 +17,6 @@ Created on Mar 25, 2013
 @author: crisr
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import xml.etree.ElementTree as ET
 import os

--- a/framework/CodeInterfaces/MooseBasedApp/MooseBasedAppInterface.py
+++ b/framework/CodeInterfaces/MooseBasedApp/MooseBasedAppInterface.py
@@ -17,8 +17,6 @@ Created on April 14, 2014
 @author: alfoa
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/Neutrino/neutrinoInterface.py
+++ b/framework/CodeInterfaces/Neutrino/neutrinoInterface.py
@@ -17,8 +17,6 @@
 """
 
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import lxml.etree as ET

--- a/framework/CodeInterfaces/OpenModelica/OpenModelicaInterface.py
+++ b/framework/CodeInterfaces/OpenModelica/OpenModelicaInterface.py
@@ -123,8 +123,6 @@ form of this is: (Where the output file will be of the type originally configure
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/PHISICS/DecayParser.py
+++ b/framework/CodeInterfaces/PHISICS/DecayParser.py
@@ -3,8 +3,6 @@ Created on June 19th, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 import os
 import re
 from decimal import Decimal

--- a/framework/CodeInterfaces/PHISICS/FissionYieldParser.py
+++ b/framework/CodeInterfaces/PHISICS/FissionYieldParser.py
@@ -3,8 +3,6 @@ Created on June 25th, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 import os
 import re
 from decimal import Decimal

--- a/framework/CodeInterfaces/PHISICS/MassParser.py
+++ b/framework/CodeInterfaces/PHISICS/MassParser.py
@@ -3,8 +3,6 @@ Created on May 10th 2018
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 import os
 import re
 from decimal import Decimal

--- a/framework/CodeInterfaces/PHISICS/MaterialParser.py
+++ b/framework/CodeInterfaces/PHISICS/MaterialParser.py
@@ -3,8 +3,6 @@ Created on July 11th, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 import os
 from decimal import Decimal
 import xml.etree.ElementTree as ET

--- a/framework/CodeInterfaces/PHISICS/PathParser.py
+++ b/framework/CodeInterfaces/PHISICS/PathParser.py
@@ -3,8 +3,6 @@ Created on July 17th, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 import os
 import re
 from decimal import Decimal

--- a/framework/CodeInterfaces/PHISICS/PhisicsInterface.py
+++ b/framework/CodeInterfaces/PHISICS/PhisicsInterface.py
@@ -16,8 +16,6 @@ Created on July 5th, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 import os
 import re
 from CodeInterfaceBaseClass import CodeInterfaceBase

--- a/framework/CodeInterfaces/PHISICS/PhisicsRelapInterface.py
+++ b/framework/CodeInterfaces/PHISICS/PhisicsRelapInterface.py
@@ -16,8 +16,6 @@ Created on February 1st 2018
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 import os
 import re
 import combine

--- a/framework/CodeInterfaces/PHISICS/QValuesParser.py
+++ b/framework/CodeInterfaces/PHISICS/QValuesParser.py
@@ -3,8 +3,6 @@ Created on June 19th, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 import os
 import re
 from decimal import Decimal

--- a/framework/CodeInterfaces/PHISICS/XSCreator.py
+++ b/framework/CodeInterfaces/PHISICS/XSCreator.py
@@ -3,8 +3,6 @@ Created on September 1st, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 import os
 from decimal import Decimal
 import xml.etree.ElementTree as ET

--- a/framework/CodeInterfaces/PHISICS/combine.py
+++ b/framework/CodeInterfaces/PHISICS/combine.py
@@ -16,8 +16,6 @@ Created on March 8th 2018
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 import os
 import re
 import csv

--- a/framework/CodeInterfaces/PHISICS/phisicsdata.py
+++ b/framework/CodeInterfaces/PHISICS/phisicsdata.py
@@ -3,8 +3,6 @@ Created on July 25th, 2017
 @author: rouxpn
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 import os
 import re
 import csv

--- a/framework/CodeInterfaces/RAVEN/RAVENInterface.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENInterface.py
@@ -17,8 +17,6 @@ Created on Sept 10, 2017
 @author: alfoa
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/RAVEN/RAVENparser.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENparser.py
@@ -17,8 +17,6 @@ Created on Sept 10, 2017
 @author: alfoa
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import xml.etree.ElementTree as ET
 import xml.dom.minidom

--- a/framework/CodeInterfaces/RELAP5/Relap5Interface.py
+++ b/framework/CodeInterfaces/RELAP5/Relap5Interface.py
@@ -17,8 +17,6 @@ Created on April 14, 2014
 @author: alfoa
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/RELAP5inssJp/Relap5inssJpInterface.py
+++ b/framework/CodeInterfaces/RELAP5inssJp/Relap5inssJpInterface.py
@@ -19,8 +19,6 @@ Created on July 20, 2016
 This is a code interface for the modified version of RELAP5 mantained by the INSS Japan
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/RELAP7/RELAP7Interface.py
+++ b/framework/CodeInterfaces/RELAP7/RELAP7Interface.py
@@ -17,8 +17,6 @@ Created on April 14, 2014
 @author: alfoa
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import sys

--- a/framework/CodeInterfaces/Rattlesnake/RattlesnakeInterface.py
+++ b/framework/CodeInterfaces/Rattlesnake/RattlesnakeInterface.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/Rattlesnake/YakInstantLibraryParser.py
+++ b/framework/CodeInterfaces/Rattlesnake/YakInstantLibraryParser.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
-
 import xml.etree.ElementTree as ET
 import xml.dom.minidom as pxml
 import os

--- a/framework/CodeInterfaces/Rattlesnake/YakMultigroupLibraryParser.py
+++ b/framework/CodeInterfaces/Rattlesnake/YakMultigroupLibraryParser.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import xml.etree.ElementTree as ET
 import xml.dom.minidom as pxml

--- a/framework/CodeInterfaces/SCALE/ScaleInterface.py
+++ b/framework/CodeInterfaces/SCALE/ScaleInterface.py
@@ -19,8 +19,6 @@ Created on April 04, 2018
 comments: Interface for Scale Simulation (current Origen and Triton)
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/Saphire/SaphireInterface.py
+++ b/framework/CodeInterfaces/Saphire/SaphireInterface.py
@@ -19,8 +19,6 @@ Created on July 12, 2018
 comments: Interface for SAPHIRE Simulation
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import copy

--- a/framework/CodeInterfaces/Utilities/csvUtilities.py
+++ b/framework/CodeInterfaces/Utilities/csvUtilities.py
@@ -19,8 +19,6 @@ Created on Jun 5, 2015
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, absolute_import
 # WARNING if you import unicode_literals here, we fail tests (e.g. framework.testFactorials).  This may be a future-proofing problem. 2015-04.
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/CodeInterfaces/WorkshopExamples/BatemanInterface.py
+++ b/framework/CodeInterfaces/WorkshopExamples/BatemanInterface.py
@@ -21,8 +21,6 @@ comments: Interface for simple Bateman code used in Workshop
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import xml.etree.ElementTree as ET

--- a/framework/CodeInterfaces/WorkshopExamples/ProjectileInterface.py
+++ b/framework/CodeInterfaces/WorkshopExamples/ProjectileInterface.py
@@ -20,8 +20,6 @@ comments: Interface for Projectile Code
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import math

--- a/framework/CrossValidations/CrossValidation.py
+++ b/framework/CrossValidations/CrossValidation.py
@@ -18,8 +18,6 @@ Created on September 2017
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/CrossValidations/Factory.py
+++ b/framework/CrossValidations/Factory.py
@@ -18,8 +18,6 @@ Created on Sept 5 2017
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/CrossValidations/SklCrossValidation.py
+++ b/framework/CrossValidations/SklCrossValidation.py
@@ -18,8 +18,6 @@ Created on September 2017
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/CsvLoader.py
+++ b/framework/CsvLoader.py
@@ -19,8 +19,6 @@ data from csv files
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/CustomCommandExecuter.py
+++ b/framework/CustomCommandExecuter.py
@@ -18,8 +18,6 @@ Created on April 10, 2014
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 import copy

--- a/framework/CustomModes/MPILegacySimulationMode.py
+++ b/framework/CustomModes/MPILegacySimulationMode.py
@@ -16,8 +16,6 @@ Module that contains a SimulationMode for PBSPro and mpiexec
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 import os

--- a/framework/CustomModes/MPISimulationMode.py
+++ b/framework/CustomModes/MPISimulationMode.py
@@ -16,8 +16,6 @@ Module that contains a SimulationMode for PBSPro and mpiexec
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 import os

--- a/framework/DataObjects/DataObject.py
+++ b/framework/DataObjects/DataObject.py
@@ -16,8 +16,6 @@
 """
 #For future compatibility with Python 3
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import sys

--- a/framework/DataObjects/DataSet.py
+++ b/framework/DataObjects/DataSet.py
@@ -18,8 +18,6 @@
   needs, depending on any combination of "index" dimensions (time, space, etc).
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import copy
 import itertools

--- a/framework/DataObjects/Factory.py
+++ b/framework/DataObjects/Factory.py
@@ -18,8 +18,6 @@ extracted from alfoa (2/16/2013) DataObjects.py
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/DataObjects/HistorySet.py
+++ b/framework/DataObjects/HistorySet.py
@@ -16,8 +16,6 @@
 """
 #For future compatibility with Python 3
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import os
 import sys

--- a/framework/DataObjects/PointSet.py
+++ b/framework/DataObjects/PointSet.py
@@ -16,8 +16,6 @@
 """
 #For future compatibility with Python 3
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import sys,os
 import functools

--- a/framework/Databases.py
+++ b/framework/Databases.py
@@ -18,8 +18,6 @@ Created on April 9, 2013
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Distributions.py
+++ b/framework/Distributions.py
@@ -18,7 +18,6 @@ Created on Mar 7, 2013
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
 #from __builtin__ import None
 #End compatibility block for Python 3----------------------------------------------------------------
 

--- a/framework/Distributions.py
+++ b/framework/Distributions.py
@@ -20,7 +20,6 @@ Created on Mar 7, 2013
 from __future__ import division, print_function, unicode_literals, absolute_import
 import warnings
 #from __builtin__ import None
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Driver.py
+++ b/framework/Driver.py
@@ -23,9 +23,11 @@ This is the Driver of RAVEN
 from __future__ import division, print_function, unicode_literals, absolute_import
 # if in debug mode, activate deprication warnings
 ## TODO does this need to be done in all modules, or just this one?
+import warnings
 if __debug__:
-  import warnings
   warnings.simplefilter('default', DeprecationWarning)
+else:
+  warnings.filterwarnings("ignore")
 
 import os
 import sys

--- a/framework/Driver.py
+++ b/framework/Driver.py
@@ -24,10 +24,12 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 # if in debug mode, activate deprication warnings
 ## TODO does this need to be done in all modules, or just this one?
 import warnings
-if __debug__:
-  warnings.simplefilter('default', DeprecationWarning)
-else:
+
+if not __debug__:
   warnings.filterwarnings("ignore")
+else:
+  warnings.simplefilter('default', DeprecationWarning)
+
 
 import os
 import sys

--- a/framework/Driver.py
+++ b/framework/Driver.py
@@ -28,8 +28,7 @@ import warnings
 if not __debug__:
   warnings.filterwarnings("ignore")
 else:
-  warnings.simplefilter('default', DeprecationWarning)
-
+  warnings.simplefilter("default", DeprecationWarning)
 
 import os
 import sys

--- a/framework/Files.py
+++ b/framework/Files.py
@@ -18,8 +18,6 @@ Created on Apr 30, 2015
 '''
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Functions.py
+++ b/framework/Functions.py
@@ -21,8 +21,6 @@ This module contains interfaces to import external functions
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, absolute_import
 # WARNING if you import unicode_literals here, we fail tests (e.g. framework.testFactorials).  This may be a future-proofing problem. 2015-04.
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/GridEntities.py
+++ b/framework/GridEntities.py
@@ -18,8 +18,6 @@ Created on Mar 30, 2015
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/IndexSets.py
+++ b/framework/IndexSets.py
@@ -19,8 +19,6 @@ that are needed to represent the original model)
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/InputTemplates/TemplateBaseClass.py
+++ b/framework/InputTemplates/TemplateBaseClass.py
@@ -20,8 +20,6 @@ template as an accelerated way to write new RAVEN workflows. Other templates
 can inherit from this base class for specific applications.
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 # standard library
 import os
 import sys

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -18,8 +18,6 @@ Created on Mar 5, 2013
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 #External Modules---------------------------------------------------------------

--- a/framework/LearningGate.py
+++ b/framework/LearningGate.py
@@ -18,8 +18,6 @@ Created on December 6, 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/MessageHandler.py
+++ b/framework/MessageHandler.py
@@ -18,8 +18,6 @@ Created on Apr 20, 2015
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/MetricDistributor.py
+++ b/framework/MetricDistributor.py
@@ -18,8 +18,6 @@ Created on Noverber 16, 2017
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Metrics/CDFAreaDifference.py
+++ b/framework/Metrics/CDFAreaDifference.py
@@ -18,8 +18,6 @@ Created on 2017 September 12
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------

--- a/framework/Metrics/DTW.py
+++ b/framework/Metrics/DTW.py
@@ -18,8 +18,6 @@ Created on August 20 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Metrics/Factory.py
+++ b/framework/Metrics/Factory.py
@@ -18,8 +18,6 @@ Created on Jul 18 2016
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/Metrics/Metric.py
+++ b/framework/Metrics/Metric.py
@@ -18,8 +18,6 @@ Created on Jul 18 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Metrics/MetricUtilities.py
+++ b/framework/Metrics/MetricUtilities.py
@@ -19,8 +19,6 @@ Created on September 18, 2017
 
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/Metrics/PDFCommonArea.py
+++ b/framework/Metrics/PDFCommonArea.py
@@ -18,8 +18,6 @@ Created on 2017 September 12
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------

--- a/framework/Metrics/PairwiseMetric.py
+++ b/framework/Metrics/PairwiseMetric.py
@@ -18,8 +18,6 @@ Created on August 20 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Metrics/ScipyMetric.py
+++ b/framework/Metrics/ScipyMetric.py
@@ -18,8 +18,6 @@ Created on Feb. 16 2018
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Metrics/SklMetric.py
+++ b/framework/Metrics/SklMetric.py
@@ -18,8 +18,6 @@ Created on August 20 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/Code.py
+++ b/framework/Models/Code.py
@@ -16,8 +16,6 @@ Module where the base class and the specialization of different type of Model ar
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/Dummy.py
+++ b/framework/Models/Dummy.py
@@ -16,8 +16,6 @@ Module where the base class and the specialization of different type of Model ar
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/EnsembleModel.py
+++ b/framework/Models/EnsembleModel.py
@@ -16,8 +16,6 @@ Module where the base class and the specialization of different type of Model ar
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/ExternalModel.py
+++ b/framework/Models/ExternalModel.py
@@ -16,8 +16,6 @@ Module where the base class and the specialization of different type of Model ar
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/Factory.py
+++ b/framework/Models/Factory.py
@@ -16,8 +16,6 @@ Factory for generating the instances of the  Models Module
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 from utils import utils

--- a/framework/Models/HybridModel.py
+++ b/framework/Models/HybridModel.py
@@ -18,8 +18,6 @@ Created on September, 2017
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/Model.py
+++ b/framework/Models/Model.py
@@ -16,8 +16,6 @@ Module where the base class and the specialization of different type of Model ar
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/ModelPlugInFactory.py
+++ b/framework/Models/ModelPlugInFactory.py
@@ -22,8 +22,6 @@ comment: The ModelPlugIn Module is an Handler.
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/PostProcessor.py
+++ b/framework/Models/PostProcessor.py
@@ -16,8 +16,6 @@ Module where the base class and the specialization of different type of Model ar
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Models/ROM.py
+++ b/framework/Models/ROM.py
@@ -16,8 +16,6 @@ Module where the base class and the specialization of different type of Model ar
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Optimizers/Conjugate.py
+++ b/framework/Optimizers/Conjugate.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Optimizers/Factory.py
+++ b/framework/Optimizers/Factory.py
@@ -17,8 +17,6 @@
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/Optimizers/FiniteDifference.py
+++ b/framework/Optimizers/FiniteDifference.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Optimizers/GradientBasedOptimizer.py
+++ b/framework/Optimizers/GradientBasedOptimizer.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Optimizers/Optimizer.py
+++ b/framework/Optimizers/Optimizer.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Optimizers/SPSA.py
+++ b/framework/Optimizers/SPSA.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/OrthoPolynomials.py
+++ b/framework/OrthoPolynomials.py
@@ -18,8 +18,6 @@ Created on Nov 24, 2014
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/OutStreams/Factory.py
+++ b/framework/OutStreams/Factory.py
@@ -18,8 +18,6 @@
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/OutStreams/OutStreamManager.py
+++ b/framework/OutStreams/OutStreamManager.py
@@ -18,8 +18,6 @@ Created on Nov 14, 2013
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 #External Modules---------------------------------------------------------------

--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -1208,7 +1208,6 @@ class OutStreamPlot(OutStreamManager):
                     if self.actcm is None:
                       self.actcm = self.fig.colorbar(cmap)
                       self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
-                      # self.actcm.set_clim(vmin = minV, vmax = maxV)
                     else:
                       self.actcm.draw_all()
                 else:
@@ -1224,7 +1223,6 @@ class OutStreamPlot(OutStreamManager):
                       if self.actcm is None:
                         self.actcm = self.fig.colorbar(cmap)
                         self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
-                        # self.actcm.set_clim(vmin = minV, vmax = maxV)
                       else:
                         self.actcm.draw_all()
                   else:

--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -1115,7 +1115,6 @@ class OutStreamPlot(OutStreamManager):
                         self.actcm = self.fig.colorbar(m)
                         self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                       else:
-                        #self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                         try:
                           self.actcm.draw_all()
                         except:
@@ -1135,7 +1134,6 @@ class OutStreamPlot(OutStreamManager):
                       else:
                         m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
                         m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
-                        #self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                         self.actcm.draw_all()
                 else:
                   if 'color' not in scatterPlotOptions:
@@ -1158,7 +1156,6 @@ class OutStreamPlot(OutStreamManager):
                           self.actcm = self.fig.colorbar(m)
                           self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                         else:
-                          #self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                           self.actcm.draw_all()
                     else:
                       scatterPlotOptions['cmap'] = plotSettings['cmap']

--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -539,7 +539,7 @@ class OutStreamPlot(OutStreamManager):
         if self.dim == 2 :
           plt.text(float(self.options[key]['position'].split(',')[0]), float(self.options[key]['position'].split(',')[1]), self.options[key]['text'], fontdict = ast.literal_eval(self.options[key]['fontdict']), **self.options[key].get('attributes', {}))
         elif self.dim == 3:
-          self.plt3D.text(float(self.options[key]['position'].split(',')[0]), float(self.options[key]['position'].split(',')[1]), float(self.options[key]['position'].split(',')[2]), self.options[key]['text'], fontdict = ast.literal_eval(self.options[key]['fontdict']), withdash = ast.literal_eval(self.options[key]['withdash']), **self.options[key].get('attributes', {}))
+          self.plt3D.text(float(self.options[key]['position'].split(',')[0]), float(self.options[key]['position'].split(',')[1]), float(self.options[key]['position'].split(',')[2]), self.options[key]['text'], fontdict = ast.literal_eval(self.options[key]['fontdict']), **self.options[key].get('attributes', {}))
       elif key == 'autoscale':
         if 'enable' not in self.options[key].keys():
           self.options[key]['enable'] = 'True'

--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -1133,7 +1133,9 @@ class OutStreamPlot(OutStreamManager):
                         self.actcm = self.fig.colorbar(m)
                         self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                       else:
-                        self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                        m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
+                        m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                        #self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                         self.actcm.draw_all()
                 else:
                   if 'color' not in scatterPlotOptions:
@@ -1168,7 +1170,8 @@ class OutStreamPlot(OutStreamManager):
                           self.actcm = self.fig.colorbar(m)
                           self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                         else:
-                          self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                          m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
+                          m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                           self.actcm.draw_all()
                   else:
                     if 'color' not in scatterPlotOptions:
@@ -1292,7 +1295,7 @@ class OutStreamPlot(OutStreamManager):
             except:
               colorss = plotSettings['color']
             if self.dim == 2:
-              plt.hist(self.xValues[pltIndex][key][xIndex], bins = ast.literal_eval(plotSettings['bins']), normed = ast.literal_eval(plotSettings['normed']), weights = ast.literal_eval(plotSettings['weights']),
+              plt.hist(self.xValues[pltIndex][key][xIndex], bins = ast.literal_eval(plotSettings['bins']), density = ast.literal_eval(plotSettings['normed']), weights = ast.literal_eval(plotSettings['weights']),
                             cumulative = ast.literal_eval(plotSettings['cumulative']), histtype = plotSettings['histtype'], align = plotSettings['align'],
                             orientation = plotSettings['orientation'], rwidth = ast.literal_eval(plotSettings['rwidth']), log = ast.literal_eval(plotSettings['log']),
                             color = colorss, stacked = ast.literal_eval(plotSettings['stacked']), **plotSettings.get('attributes', {}))
@@ -1332,7 +1335,9 @@ class OutStreamPlot(OutStreamManager):
           for xIndex in range(len(self.xValues[pltIndex][key])):
             for yIndex in range(len(self.yValues[pltIndex][key])):
               if self.dim == 2:
-                self.actPlot = plt.stem(self.xValues[pltIndex][key][xIndex], self.yValues[pltIndex][key][yIndex], linefmt = plotSettings['linefmt'], markerfmt = plotSettings['markerfmt'], basefmt = plotSettings['linefmt'], **plotSettings.get('attributes', {}))
+                self.actPlot = plt.stem(self.xValues[pltIndex][key][xIndex], self.yValues[pltIndex][key][yIndex], linefmt = plotSettings['linefmt'],
+                                        markerfmt = plotSettings['markerfmt'], basefmt = plotSettings['linefmt'],
+                                        use_line_collection=True, **plotSettings.get('attributes', {}))
               elif self.dim == 3:
                 # it is a basic stem plot constructed using a standard line plot. For now we do not use the previous defined keywords...
                 for zIndex in range(len(self.zValues[pltIndex][key])):
@@ -1443,7 +1448,8 @@ class OutStreamPlot(OutStreamManager):
                         self.actcm = self.fig.colorbar(m)
                         self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                       else:
-                        self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                        m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
+                        m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                         self.actcm.draw_all()
                   else:
                     if plotSettings['cmap'] == 'None':
@@ -1508,7 +1514,8 @@ class OutStreamPlot(OutStreamManager):
                         self.actcm = self.fig.colorbar(m)
                         self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                       else:
-                        self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                        m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
+                        m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                         self.actcm.draw_all()
                   else:
                     if plotSettings['cmap'] != 'None':
@@ -1559,7 +1566,8 @@ class OutStreamPlot(OutStreamManager):
                         self.actcm = self.fig.colorbar(m)
                         self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                       else:
-                        self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                        m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
+                        m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                         self.actcm.draw_all()
                   else:
                     if plotSettings['cmap'] == 'None':
@@ -1618,7 +1626,8 @@ class OutStreamPlot(OutStreamManager):
                       self.actcm = plt.colorbar(self.actPlot, shrink = 0.8, extend = 'both')
                       self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                     else:
-                      self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                      m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
+                      m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                       self.actcm.draw_all()
         elif self.dim == 3:
           self.raiseAWarning('contour/filledContour is a 2-D plot, where x,y are the surface coordinates and colorMap vector is the array to visualize!\n               contour3D/filledContour3D are 3-D! ')
@@ -1665,14 +1674,15 @@ class OutStreamPlot(OutStreamManager):
                   else:
                     if plotSettings['cmap'] == 'None':
                       plotSettings['cmap'] = 'jet'
-                    self.actPlot = self.plt3D.contourf3D(xig, yig, ma.masked_where(np.isnan(Ci), Ci), nbins, extend3d = ext3D, cmap = matplotlib.cm.get_cmap(name = plotSettings['cmap']), **plotSettings.get('attributes', {}))
+                    self.actPlot = self.plt3D.contourf3D(xig, yig, ma.masked_where(np.isnan(Ci), Ci), nbins, cmap = matplotlib.cm.get_cmap(name = plotSettings['cmap']), **plotSettings.get('attributes', {}))
                   plt.clabel(self.actPlot, inline = 1, fontsize = 10)
                   if 'colorbar' not in self.options.keys() or self.options['colorbar']['colorbar'] != 'off':
                     if first:
                       self.actcm = plt.colorbar(self.actPlot, shrink = 0.8, extend = 'both')
                       self.actcm.set_label(self.colorMapCoordinates[pltIndex][0].split('|')[-1].replace(')', ''))
                     else:
-                      self.actcm.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
+                      m = matplotlib.cm.ScalarMappable(cmap = self.actPlot.cmap, norm = self.actPlot.norm)
+                      m.set_clim(vmin = min(self.colorMapValues[pltIndex][key][-1]), vmax = max(self.colorMapValues[pltIndex][key][-1]))
                       self.actcm.draw_all()
       ########################
       #   DataMining PLOT    #

--- a/framework/OutStreams/OutStreamPlot.py
+++ b/framework/OutStreams/OutStreamPlot.py
@@ -18,8 +18,6 @@ Created on Nov 14, 2013
 """
 ## for future compatibility with Python 3---------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 ## End compatibility block for Python 3-----------------------------------------
 
 ## External Modules-------------------------------------------------------------

--- a/framework/OutStreams/OutStreamPrint.py
+++ b/framework/OutStreams/OutStreamPrint.py
@@ -18,8 +18,6 @@ Created on Nov 14, 2013
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 #External Modules---------------------------------------------------------------
 import os

--- a/framework/PluginFactory.py
+++ b/framework/PluginFactory.py
@@ -32,7 +32,6 @@ from collections import defaultdict
 from PluginsBaseClasses import PluginBase
 from utils import xmlUtils
 
-warnings.simplefilter('default', DeprecationWarning)
 
 # Design Note: This module is meant to be loaded BEFORE any other entities are loaded!
 #              It is critical that factories can inquire the plugin list to populate their modules.

--- a/framework/PluginsBaseClasses/ExternalModelPluginBase.py
+++ b/framework/PluginsBaseClasses/ExternalModelPluginBase.py
@@ -17,8 +17,6 @@ Created on November 6, 2017
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 #External Modules End-----------------------------------------------------------

--- a/framework/PluginsBaseClasses/PluginBase.py
+++ b/framework/PluginsBaseClasses/PluginBase.py
@@ -17,8 +17,6 @@ Created on November 6, 2017
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 #External Modules End-----------------------------------------------------------

--- a/framework/PostProcessorFunctions/HS2PS.py
+++ b/framework/PostProcessorFunctions/HS2PS.py
@@ -14,8 +14,6 @@
 
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/PostProcessorFunctions/HStoPSOperator.py
+++ b/framework/PostProcessorFunctions/HStoPSOperator.py
@@ -18,8 +18,6 @@ Created on Feb 02, 2018
 
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/PostProcessorFunctions/HistorySetSampling.py
+++ b/framework/PostProcessorFunctions/HistorySetSampling.py
@@ -18,8 +18,6 @@ Created on October 28, 2015
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
 
 

--- a/framework/PostProcessorFunctions/HistorySetSnapShot.py
+++ b/framework/PostProcessorFunctions/HistorySetSnapShot.py
@@ -17,8 +17,6 @@ Created on October 28, 2015
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
 

--- a/framework/PostProcessorFunctions/HistorySetSync.py
+++ b/framework/PostProcessorFunctions/HistorySetSync.py
@@ -17,8 +17,6 @@ Created on October 28, 2015
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
+++ b/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
@@ -16,8 +16,6 @@
 
 '''
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
 import numpy as np

--- a/framework/PostProcessorFunctions/dataObjectLabelFilter.py
+++ b/framework/PostProcessorFunctions/dataObjectLabelFilter.py
@@ -17,11 +17,7 @@ Created on October 28, 2015
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
-
-
 import os
 import numpy as np
 from scipy import interpolate

--- a/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
+++ b/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
@@ -18,8 +18,6 @@ Created on November 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/PostProcessorFunctions/testInterfacedPP.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP.py
@@ -16,8 +16,6 @@ Created on December 1, 2015
 
 '''
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import copy
 import itertools

--- a/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
@@ -16,8 +16,6 @@ Created on December 1, 2015
 
 '''
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import copy
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase

--- a/framework/PostProcessorInterfaceBaseClass.py
+++ b/framework/PostProcessorInterfaceBaseClass.py
@@ -16,8 +16,6 @@ Created on December 1st, 2015
 
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import abc

--- a/framework/PostProcessorInterfaces.py
+++ b/framework/PostProcessorInterfaces.py
@@ -19,8 +19,6 @@ Created on December 1, 2015
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/PostProcessors/BasicStatistics.py
+++ b/framework/PostProcessors/BasicStatistics.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa, wangc
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/ComparisonStatisticsModule.py
+++ b/framework/PostProcessors/ComparisonStatisticsModule.py
@@ -17,9 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
-
 #External Modules------------------------------------------------------------------------------------
 import numpy as np
 import math

--- a/framework/PostProcessors/CrossValidation.py
+++ b/framework/PostProcessors/CrossValidation.py
@@ -17,9 +17,6 @@ Created on August 30, 2017
 @author: wangc
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
-
 #External Modules------------------------------------------------------------------------------------
 import numpy as np
 import os

--- a/framework/PostProcessors/DataClassifier.py
+++ b/framework/PostProcessors/DataClassifier.py
@@ -17,8 +17,6 @@ Created on Jan 29, 2018
 @author: Congjian Wang
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import copy

--- a/framework/PostProcessors/DataMining.py
+++ b/framework/PostProcessors/DataMining.py
@@ -16,9 +16,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
-
 #External Modules---------------------------------------------------------------
 import numpy as np
 import copy

--- a/framework/PostProcessors/ETImporter.py
+++ b/framework/PostProcessors/ETImporter.py
@@ -18,8 +18,6 @@ Created on Nov 1, 2017
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/ETStructure.py
+++ b/framework/PostProcessors/ETStructure.py
@@ -18,8 +18,6 @@ Created on April 30, 2018
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #Internal Modules---------------------------------------------------------------
 import MessageHandler

--- a/framework/PostProcessors/ExternalPostProcessor.py
+++ b/framework/PostProcessors/ExternalPostProcessor.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/FTGate.py
+++ b/framework/PostProcessors/FTGate.py
@@ -18,8 +18,6 @@ Created on April 30, 2018
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #Internal Modules---------------------------------------------------------------
 import MessageHandler

--- a/framework/PostProcessors/FTImporter.py
+++ b/framework/PostProcessors/FTImporter.py
@@ -18,8 +18,6 @@ Created on Dec 21, 2017
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/FTStructure.py
+++ b/framework/PostProcessors/FTStructure.py
@@ -18,8 +18,6 @@ Created on April 30, 2018
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #Internal Modules---------------------------------------------------------------
 import MessageHandler

--- a/framework/PostProcessors/Factory.py
+++ b/framework/PostProcessors/Factory.py
@@ -19,8 +19,6 @@ Created on July 10, 2013
 
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/PostProcessors/FastFourierTransform.py
+++ b/framework/PostProcessors/FastFourierTransform.py
@@ -17,8 +17,6 @@ Created on September 11, 2018
 @author: talbpaul
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/ImportanceRank.py
+++ b/framework/PostProcessors/ImportanceRank.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/InterfacedPostProcessor.py
+++ b/framework/PostProcessors/InterfacedPostProcessor.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/LimitSurface.py
+++ b/framework/PostProcessors/LimitSurface.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/LimitSurfaceIntegral.py
+++ b/framework/PostProcessors/LimitSurfaceIntegral.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/Metric.py
+++ b/framework/PostProcessors/Metric.py
@@ -17,8 +17,6 @@ Created on August 23, 2017
 @author: wangc
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/PostProcessor.py
+++ b/framework/PostProcessors/PostProcessor.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import copy

--- a/framework/PostProcessors/RealizationAverager.py
+++ b/framework/PostProcessors/RealizationAverager.py
@@ -17,8 +17,6 @@ Created on July 2, 2019
 @author: talbpw
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/SafestPoint.py
+++ b/framework/PostProcessors/SafestPoint.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/SampleSelector.py
+++ b/framework/PostProcessors/SampleSelector.py
@@ -17,8 +17,6 @@ Created on August 28, 2018
 @author: giovannimaronati
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/TopologicalDecomposition.py
+++ b/framework/PostProcessors/TopologicalDecomposition.py
@@ -17,8 +17,6 @@ Created on July 10, 2013
 @author: alfoa
 """
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/PostProcessors/ValueDuration.py
+++ b/framework/PostProcessors/ValueDuration.py
@@ -17,8 +17,6 @@ Created on August 28, 2018
 @author: talbpaul
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/framework/Quadratures.py
+++ b/framework/Quadratures.py
@@ -18,8 +18,6 @@ Created on Dec 2, 2014
 """
 #for future compatibility with Python 3-----------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------------
 
 #External Modules---------------------------------------------------------------------

--- a/framework/Runners/DistributedMemoryRunner.py
+++ b/framework/Runners/DistributedMemoryRunner.py
@@ -18,8 +18,6 @@ Created on Mar 5, 2013
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Runners/Factory.py
+++ b/framework/Runners/Factory.py
@@ -18,8 +18,6 @@
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/Runners/InternalRunner.py
+++ b/framework/Runners/InternalRunner.py
@@ -18,8 +18,6 @@ Created on Mar 5, 2013
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Runners/Runner.py
+++ b/framework/Runners/Runner.py
@@ -16,8 +16,6 @@ Created on September 12, 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Runners/SharedMemoryRunner.py
+++ b/framework/Runners/SharedMemoryRunner.py
@@ -16,8 +16,6 @@ Created on September 12, 2016
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/AdaptiveDynamicEventTree.py
+++ b/framework/Samplers/AdaptiveDynamicEventTree.py
@@ -21,8 +21,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/AdaptiveSampler.py
+++ b/framework/Samplers/AdaptiveSampler.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/AdaptiveSobol.py
+++ b/framework/Samplers/AdaptiveSobol.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/AdaptiveSparseGrid.py
+++ b/framework/Samplers/AdaptiveSparseGrid.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/CustomSampler.py
+++ b/framework/Samplers/CustomSampler.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/DynamicEventTree.py
+++ b/framework/Samplers/DynamicEventTree.py
@@ -21,8 +21,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/EnsembleForward.py
+++ b/framework/Samplers/EnsembleForward.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/FactorialDesign.py
+++ b/framework/Samplers/FactorialDesign.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/Factory.py
+++ b/framework/Samplers/Factory.py
@@ -18,8 +18,6 @@
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/Samplers/ForwardSampler.py
+++ b/framework/Samplers/ForwardSampler.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/Grid.py
+++ b/framework/Samplers/Grid.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/LimitSurfaceSearch.py
+++ b/framework/Samplers/LimitSurfaceSearch.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/MonteCarlo.py
+++ b/framework/Samplers/MonteCarlo.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/ResponseSurfaceDesign.py
+++ b/framework/Samplers/ResponseSurfaceDesign.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/Sampler.py
+++ b/framework/Samplers/Sampler.py
@@ -18,8 +18,6 @@ Created on Feb 16, 2013
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/Sobol.py
+++ b/framework/Samplers/Sobol.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/SparseGridCollocation.py
+++ b/framework/Samplers/SparseGridCollocation.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Samplers/Stratified.py
+++ b/framework/Samplers/Stratified.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -16,8 +16,6 @@ Module that contains the driver for the whole the simulation flow (Simulation Cl
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/Steps.py
+++ b/framework/Steps.py
@@ -17,8 +17,6 @@ Step is called by simulation
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/DynamicModeDecomposition.py
+++ b/framework/SupervisedLearning/DynamicModeDecomposition.py
@@ -21,8 +21,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/Factory.py
+++ b/framework/SupervisedLearning/Factory.py
@@ -18,8 +18,6 @@
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 ################################################################################

--- a/framework/SupervisedLearning/GaussPolynomialRom.py
+++ b/framework/SupervisedLearning/GaussPolynomialRom.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 from numpy import average

--- a/framework/SupervisedLearning/HDMRRom.py
+++ b/framework/SupervisedLearning/HDMRRom.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/KerasClassifier.py
+++ b/framework/SupervisedLearning/KerasClassifier.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/KerasConvNetClassifier.py
+++ b/framework/SupervisedLearning/KerasConvNetClassifier.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/SupervisedLearning/KerasLSTMClassifier.py
+++ b/framework/SupervisedLearning/KerasLSTMClassifier.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 #External Modules------------------------------------------------------------------------------------
 import numpy as np

--- a/framework/SupervisedLearning/KerasMLPClassifier.py
+++ b/framework/SupervisedLearning/KerasMLPClassifier.py
@@ -19,8 +19,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/MSR.py
+++ b/framework/SupervisedLearning/MSR.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/NDinterpolatorRom.py
+++ b/framework/SupervisedLearning/NDinterpolatorRom.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/NDinvDistWeight.py
+++ b/framework/SupervisedLearning/NDinvDistWeight.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/NDsplineRom.py
+++ b/framework/SupervisedLearning/NDsplineRom.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/PolyExponential.py
+++ b/framework/SupervisedLearning/PolyExponential.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/ROMCollection.py
+++ b/framework/SupervisedLearning/ROMCollection.py
@@ -34,7 +34,6 @@ from utils import utils, mathUtils, xmlUtils, randomUtils
 from .SupervisedLearning import supervisedLearning
 # import pickle as pk # TODO remove me!
 import os
-warnings.simplefilter('default', DeprecationWarning)
 
 
 #

--- a/framework/SupervisedLearning/SciKitLearn.py
+++ b/framework/SupervisedLearning/SciKitLearn.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #Internal Modules (Lazy Importer)--------------------------------------------------------------------

--- a/framework/SupervisedLearning/SupervisedLearning.py
+++ b/framework/SupervisedLearning/SupervisedLearning.py
@@ -25,8 +25,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 import sys

--- a/framework/SupervisedLearning/pickledROM.py
+++ b/framework/SupervisedLearning/pickledROM.py
@@ -20,8 +20,6 @@
 """
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 

--- a/framework/UI/BaseHierarchicalView.py
+++ b/framework/UI/BaseHierarchicalView.py
@@ -18,8 +18,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 try:
   from PySide.QtCore import QSize

--- a/framework/UI/BaseTopologicalView.py
+++ b/framework/UI/BaseTopologicalView.py
@@ -18,8 +18,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/DendrogramView.py
+++ b/framework/UI/DendrogramView.py
@@ -18,8 +18,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 import numpy as np

--- a/framework/UI/FitnessView.py
+++ b/framework/UI/FitnessView.py
@@ -19,8 +19,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/HierarchyWindow.py
+++ b/framework/UI/HierarchyWindow.py
@@ -19,8 +19,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/ScatterView.py
+++ b/framework/UI/ScatterView.py
@@ -18,8 +18,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 import matplotlib

--- a/framework/UI/ScatterView2D.py
+++ b/framework/UI/ScatterView2D.py
@@ -18,8 +18,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 import matplotlib

--- a/framework/UI/ScatterView3D.py
+++ b/framework/UI/ScatterView3D.py
@@ -18,8 +18,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/SensitivityView.py
+++ b/framework/UI/SensitivityView.py
@@ -19,8 +19,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/TopologyMapView.py
+++ b/framework/UI/TopologyMapView.py
@@ -26,8 +26,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/TopologyWindow.py
+++ b/framework/UI/TopologyWindow.py
@@ -20,8 +20,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/Tree.py
+++ b/framework/UI/Tree.py
@@ -19,8 +19,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 import numpy as np

--- a/framework/UI/ZoomableGraphicsView.py
+++ b/framework/UI/ZoomableGraphicsView.py
@@ -20,8 +20,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 try:

--- a/framework/UI/colors.py
+++ b/framework/UI/colors.py
@@ -19,8 +19,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 from matplotlib import cm, colors

--- a/framework/VariableGroups.py
+++ b/framework/VariableGroups.py
@@ -19,8 +19,6 @@ Module aimed to define the methods to group variables in the RAVEN frameworl
 
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/h5py_interface_creator.py
+++ b/framework/h5py_interface_creator.py
@@ -20,7 +20,6 @@ Created on Mar 25, 2013
 from __future__ import division, print_function, unicode_literals, absolute_import
 import warnings
 from datetime import datetime
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/raven_qsub_command.py
+++ b/framework/raven_qsub_command.py
@@ -21,8 +21,6 @@ Created on November 13, 2013
 This module is used to employ QSUB commands when the PBS protocol is available
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules------------------------------------------------------------------------------------
 import os,subprocess,sys

--- a/framework/unSupervisedLearning.py
+++ b/framework/unSupervisedLearning.py
@@ -24,8 +24,6 @@
 
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 #External Modules---------------------------------------------------------------

--- a/framework/utils/RAVENiterators.py
+++ b/framework/utils/RAVENiterators.py
@@ -17,8 +17,6 @@ Created on Oct 13, 2015
 @author: alfoa
 """
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #External Modules------------------------------------------------------------------------------------
 import numpy as np
 #External Modules End--------------------------------------------------------------------------------

--- a/framework/utils/TreeStructure.py
+++ b/framework/utils/TreeStructure.py
@@ -18,8 +18,6 @@ Created on Jan 28, 2014
 
 #for future compatibility with Python 3--------------------------------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3----------------------------------------------------------------
 
 import xml.etree.ElementTree as ET

--- a/framework/utils/cached_ndarray.py
+++ b/framework/utils/cached_ndarray.py
@@ -18,8 +18,6 @@ Created on Feb 4, 2015
 """
 #----- python 2 - 3 compatibility
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #----- end python 2 - 3 compatibility
 #External Modules------------------------------------------------------------------------------------
 import sys

--- a/framework/utils/graphStructure.py
+++ b/framework/utils/graphStructure.py
@@ -18,8 +18,6 @@ Created on Oct 27, 2016
 """
 #----- python 2 - 3 compatibility
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #----- end python 2 - 3 compatibility
 #External Modules------------------------------------------------------------------------------------
 import sys

--- a/framework/utils/lazyImporterUtils.py
+++ b/framework/utils/lazyImporterUtils.py
@@ -20,8 +20,6 @@
 """
 #----- python 2 - 3 compatibility
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #----- end python 2 - 3 compatibility
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/utils/mathUtils.py
+++ b/framework/utils/mathUtils.py
@@ -19,8 +19,6 @@
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 import sys
 import math

--- a/framework/utils/randomUtils.py
+++ b/framework/utils/randomUtils.py
@@ -18,9 +18,6 @@
 '''
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
-
 import threading
 import numpy as np
 from collections import deque, defaultdict

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -17,8 +17,6 @@
 
 from __future__ import division, print_function, absolute_import
 # WARNING if you import unicode_literals here, we fail tests (e.g. framework.testFactorials).  This may be a future-proofing problem. 2015-04.
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 
 # *************************** NOTE FOR DEVELOPERS ***************************
 # Do not import numpy or scipy or other libraries that are not              *

--- a/framework/utils/xmlUtils.py
+++ b/framework/utils/xmlUtils.py
@@ -17,10 +17,11 @@ talbpaul, 2016-05
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-from utils.utils import toString
+from utils.utils import toString, getRelativeSortedListEntry
 import xml.etree.ElementTree as ET
 import re
 import os
+
 #define type checking
 def isComment(node):
   """

--- a/framework/utils/xmlUtils.py
+++ b/framework/utils/xmlUtils.py
@@ -21,9 +21,6 @@ import warnings
 import xml.etree.ElementTree as ET
 import re
 import os
-from .utils import toString, getRelativeSortedListEntry
-warnings.simplefilter('default', DeprecationWarning)
-
 #define type checking
 def isComment(node):
   """

--- a/framework/utils/xmlUtils.py
+++ b/framework/utils/xmlUtils.py
@@ -17,7 +17,7 @@ talbpaul, 2016-05
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
+from utils.utils import toString
 import xml.etree.ElementTree as ET
 import re
 import os

--- a/plugins/ExamplePlugin/src/SumOfExponential.py
+++ b/plugins/ExamplePlugin/src/SumOfExponential.py
@@ -3,8 +3,6 @@
   Date  :  11/17/2017
 """
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/plugins/PRAplugin/src/ETModel.py
+++ b/plugins/PRAplugin/src/ETModel.py
@@ -18,8 +18,6 @@ Created on April 30, 2018
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 #External Modules End-----------------------------------------------------------

--- a/plugins/PRAplugin/src/FTModel.py
+++ b/plugins/PRAplugin/src/FTModel.py
@@ -18,8 +18,6 @@ Created on April 30, 2018
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/plugins/PRAplugin/src/GraphModel.py
+++ b/plugins/PRAplugin/src/GraphModel.py
@@ -18,8 +18,6 @@ Created on April 30, 2018
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/plugins/PRAplugin/src/MarkovModel.py
+++ b/plugins/PRAplugin/src/MarkovModel.py
@@ -18,8 +18,6 @@ Created on April 30, 2018
 """
 
 from __future__ import division, print_function , unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
 
 #External Modules---------------------------------------------------------------
 import numpy as np

--- a/scripts/TestHarness/testers/TestUnorderedCSV.py
+++ b/scripts/TestHarness/testers/TestUnorderedCSV.py
@@ -20,7 +20,6 @@ import warnings
 import sys
 from UnorderedCSVDiffer import UnorderedCSVDiffer as UCSV
 
-warnings.simplefilter('default', DeprecationWarning)
 
 def check_same(comment, first, second, localMsg, localResults):
   """

--- a/scripts/conversionScripts/conversion_from_old_hdf5_to_new/reader_old_HDF5_format.py
+++ b/scripts/conversionScripts/conversion_from_old_hdf5_to_new/reader_old_HDF5_format.py
@@ -22,7 +22,6 @@ This module is a stripped version of the h5py_interface_creator.py module presen
 from __future__ import division, print_function, unicode_literals, absolute_import
 import warnings
 from datetime import datetime
-warnings.simplefilter('default',DeprecationWarning)
 if not 'xrange' in dir(__builtins__):
   xrange = range
 #End compatibility block for Python 3----------------------------------------------------------------

--- a/scripts/externalROMloader.py
+++ b/scripts/externalROMloader.py
@@ -43,8 +43,6 @@ External Loader for serialized surrogate model (ROM) for external usage
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3
 
 #External Modules--------------------begin

--- a/scripts/update_install_data.py
+++ b/scripts/update_install_data.py
@@ -18,8 +18,6 @@ Created on June 18, 2018
 """
 #for future compatibility with Python 3-----------------------------------------
 from __future__ import division, print_function, unicode_literals, absolute_import
-import warnings
-warnings.simplefilter('default',DeprecationWarning)
 #End compatibility block for Python 3-------------------------------------------
 
 import os


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1117

##### What are the significant changes in functionality due to this change request?
Removed some warnings and reduced verbosity if not in debug

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

