### PR TITLE
new prefix and identifying data tracking system for adaptive sampler

### DIFF
--- a/framework/Samplers/AdaptiveSampler.py
+++ b/framework/Samplers/AdaptiveSampler.py
@@ -61,7 +61,7 @@ class AdaptiveSampler(Sampler):
   def _registerSample(self, prefix, info):
     """
       Register a sample's prefix info before submitting as job
-      @ In, prefix, str, string integer prefix
+      @ In, prefix, str, string integer (or not) prefix (aka JobId)
       @ In, info, dict, unique information to record associated with the prefix
       @ Out, None
     """

--- a/framework/Samplers/AdaptiveSampler.py
+++ b/framework/Samplers/AdaptiveSampler.py
@@ -25,12 +25,135 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 #External Modules------------------------------------------------------------------------------------
 #External Modules End--------------------------------------------------------------------------------
 
-#Internal Modules------------------------------------------------------------------------------------
+#Internal Modules
+from utils import mathUtils
 from .Sampler import Sampler
-#Internal Modules End--------------------------------------------------------------------------------
+
 
 class AdaptiveSampler(Sampler):
   """
     This is a general adaptive sampler
   """
-  pass
+  def __init__(self):
+    """
+      Constructor.
+      @ In, None
+      @ Out, None
+    """
+    Sampler.__init__(self)
+    self._registeredIdentifiers = set() # tracks job identifiers used for this adaptive sampler and its inheritors
+    self._prefixToIdentifiers = {}      # tracks the mapping of run prefixes to particular identifiers
+    self._inputIdentifiers = {}         # identifiers for a single realization
+    self._targetEvaluation = None       # data object with feedback from sample realizations
+    self._solutionExport = None         # data object for solution printing
+
+  def initialize(self, externalSeeding=None, solutionExport=None):
+    """
+      This function should be called every time a clean optimizer is needed. Called before takeAstep in <Step>
+      @ In, externalSeeding, int, optional, external seed
+      @ In, solutionExport, DataObject, optional, a PointSet to hold the solution
+      @ Out, None
+    """
+    Sampler.initialize(self, externalSeeding=externalSeeding, solutionExport=solutionExport)
+    self._targetEvaluation = self.assemblerDict['TargetEvaluation'][0][3]
+    self._solutionExport = solutionExport
+
+  def _registerSample(self, prefix, info):
+    """
+      Register a sample's prefix info before submitting as job
+      @ In, prefix, str, string integer prefix
+      @ In, info, dict, unique information to record associated with the prefix
+      @ Out, None
+    """
+    self.checkIdentifiersPresent(info)
+    self._prefixToIdentifiers[prefix] = info
+
+  def _checkSample(self):
+    """
+      Check sample consistency.
+      @ In, None
+      @ Out, None
+    """
+    Sampler._checkSample(self)
+    # make sure the prefix is registered for tracking
+    ## but if there's no identifying information, skip this check
+    if self._registeredIdentifiers:
+      prefix = self.inputInfo['prefix']
+      if not prefix in self._prefixToIdentifiers:
+        self.raiseAnError(RuntimeError, 'Prefix "{p}" has not been tracked in adaptive sampling!'.format(p=prefix))
+
+  def stillLookingForPrefix(self, prefix):
+    """
+      Checks if a prefix is still registered for collection.
+      @ In, prefix, str, job prefix
+      @ Out, looking, bool, True if still waiting for prefix else False
+    """
+    return prefix in self._prefixToIdentifiers
+
+  ##########################################
+  # Utilities for Prefix-Identifier System #
+  ##########################################
+  def registerIdentifier(self, name):
+    """
+      Establishes an identifying attribute for a job run.
+      Assures no conflicts with existing identifiers.
+      @ In, name, str, identifier to register
+      @ Out, None
+    """
+    assert mathUtils.isAString(name)
+    assert name not in self._registeredIdentifiers
+    # don't allow adding identifiers if existing jobs are already running, I think?
+    assert not self._prefixToIdentifiers
+    self._registeredIdentifiers.add(name)
+
+  def checkIdentifiersPresent(self, checkDict):
+    """
+      checks that all registered identifiers have values
+      @ In, checkDict, dict, dictionary of identifying information for a realization
+      @ Out, None
+    """
+    assert self._registeredIdentifiers.issubset(set(checkDict.keys())), 'missing identifiers: {}'.format(self._registeredIdentifiers - set(checkDict.keys()))
+
+  def getIdentifierFromPrefix(self, prefix, pop=False):
+    """
+      Obtains the identifying info dict given a prefix
+      @ In, prefix, str, identifying prefix
+      @ In, pop, bool, optional, if True then stop tracking prefix after providing it
+      @ Out, ID, dict, identifying information (or None if not present)
+    """
+    if pop:
+      return self._prefixToIdentifiers.pop(prefix, None)
+    else:
+      return self._prefixToIdentifiers.get(prefix, None)
+
+  def getPrefixFromIdentifier(self, idDict, pop=False, getAll=False):
+    """
+      Obtains a prefix given identifying information
+      @ In, idDict, dict, identifying information about a realization
+      @ In, pop, bool, optional, if True then stop tracking prefix after providing
+      @ In, getAll, bool, optional, if True then get all matching items instead of the first
+      @ Out, prefix, str, identifying prefix (or None if not found)
+    """
+    # make sure the request matches the expected form
+    if getAll:
+      found = []
+    else:
+      found = None
+    # if not collecting many, check all identifiers used
+    if not getAll:
+      self.checkIdentifiersPresent(idDict)
+    # find the match
+    toPop = []
+    for prefix, info in self._prefixToIdentifiers.items():
+      if all(list((v == info[k]) for k, v in idDict.items())):
+        if pop:
+          toPop.append(prefix)
+        if getAll:
+          found.append(prefix)
+        else:
+          found = prefix
+          break
+    for p in toPop:
+      self._prefixToIdentifiers.pop(p)
+    return found
+


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1149 

##### What are the significant changes in functionality due to this change request?
Adaptive Sampler automatically handles the TargetEvaluation through a system of prefix registration and retrieval.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

