### PR TITLE
Fixing Windows problems

### DIFF
--- a/dependencies.ini
+++ b/dependencies.ini
@@ -30,7 +30,7 @@
 # main libraries from main conda
 [core]
 h5py = 2.9.0
-numpy = 1.16.4
+numpy = 1.18.1
 scipy = 1.2.1
 scikit-learn = 0.21.2
 pandas = 0.24.2

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -321,7 +321,7 @@ fi
 if [ -z $RAVEN_LIBS_NAME ];
 then
   # check the RC file first
-  RAVEN_LIBS_NAME=$(read_ravenrc "RAVEN_LIBS_NAME")
+  export RAVEN_LIBS_NAME=$(read_ravenrc "RAVEN_LIBS_NAME")
   # if not found through the RC file, will be empty string, so default to raven_libraries
   if [[ ${#RAVEN_LIBS_NAME} == 0 ]];
   then

--- a/tests/framework/unit_tests/Distributions/TestDistributions.py
+++ b/tests/framework/unit_tests/Distributions/TestDistributions.py
@@ -101,7 +101,7 @@ def checkIntegral(name,dist,low,high,numpts=1e4,tol=1e-3):
     @ In, tol, float, optional, the tolerance
     @ Out, None
   """
-  xs=np.linspace(low,high,numpts)
+  xs=np.linspace(low,high,int(numpts))
   dx = (high-low)/float(numpts)
   tot = sum(dist.pdf(x)*dx for x in xs)
   checkAnswer(name+' unity integration',tot,1,tol)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #1157 
Ref. #1114 

##### What are the significant changes in functionality due to this change request?
Windows should work again, because:
1. cashflow has been updated to not have an aux file
2. numpy has been updated to not have  a fft problem.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

