### PR TITLE
Fixes finding TestHarness in windows

### DIFF
--- a/rook/main.py
+++ b/rook/main.py
@@ -222,6 +222,7 @@ def get_testers_and_differs(directory):
   """
   # if no testers added, that's fine
   if not os.path.isdir(directory):
+    print("invalid tester directory: "+directory)
     return {}, {}
   tester_dict = {}
   differ_dict = {}

--- a/run_tests
+++ b/run_tests
@@ -84,6 +84,10 @@ for A in "$@"; do
     esac
 done
 
+#Note that this is from the perspective of python
+FRAMEWORK_DIR=`$PYTHON_COMMAND $SCRIPT_DIR/scripts/plugin_handler.py -z`
+
+
 # run the tests
 # success/fail storage
 #   Names of successful test sets are stored in "PASSED"
@@ -124,7 +128,7 @@ if [[ $DO_RAVEN == 0 ]]; then
   echo
   echo Running $P tests ...
   # get location of ExamplePlugin test dir
-  ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $SCRIPT_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
+  ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $FRAMEWORK_DIR/../scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
   # $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --add-non-default-run-types qsub "${ARGS[@]}"
   $ROOK_COMMAND
   rc=$?
@@ -152,7 +156,7 @@ if [[ $DO_PLUGINS == 0 ]]; then
     echo
     echo Starting tests for plugin "$P" ...
     # add RAVEN testers to plugin testers
-    ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $SCRIPT_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
+    ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $FRAMEWORK_DIR/../scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
     $ROOK_COMMAND
     rc=$?
     ALL_PASS=$(($ALL_PASS + $rc))

--- a/scripts/plugin_handler.py
+++ b/scripts/plugin_handler.py
@@ -18,6 +18,7 @@
 # It takes the following command line arguments
 # -s, the plugin directory that needs to be installed
 # -f, force the copy if the directory in the destination location already exists
+# -z, print the framework directory
 # to run the script use the following command:
 #  python install_plugins -s path/to/plugin -f
 import os
@@ -182,6 +183,8 @@ if __name__ == '__main__':
                       help='provides location of requested plugin')
   parser.add_argument('-l', '--list', dest='list', action='store_true',
                       help='lists installed plugins')
+  parser.add_argument('-z', '--framework-dir', dest='framework_dir',
+                      action='store_true', help='prints framework directory')
 
   # no arguments? get some help!
   if len(sys.argv) == 1:
@@ -189,6 +192,8 @@ if __name__ == '__main__':
     sys.exit(1)
 
   args = parser.parse_args()
+  if args.framework_dir:
+    print(os.path.abspath(frameworkDir))
   # plugins list
   doList = args.list
   if doList:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
closes #1162 

##### What are the significant changes in functionality due to this change request?
Fixes windows plugin path finding.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

