### PR TITLE
add skip-check for library_handler

### DIFF
--- a/dependencies.ini
+++ b/dependencies.ini
@@ -83,3 +83,9 @@ pip = remove
 python = remove
 nomkl = remove
 numexpr = remove
+
+[skip-check]
+python
+hdf5
+swig
+nomkl

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -59,8 +59,6 @@ libAlias = {'scikit-learn': 'sklearn',
 # -> see findLibAndVersion
 metaExceptions = ['pyside2', 'AMSC']
 
-skipChecks = ['python', 'hdf5', 'swig', 'nomkl']
-
 # load up the ravenrc if it's present
 ## TODO we only want to do this once, but does it need to get updated?
 rcFile = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '.ravenrc'))
@@ -100,10 +98,11 @@ def checkLibraries(buildReport=False):
   notQA = []
   plugins = pluginHandler.getInstalledPlugins()
   need = getRequiredLibs(plugins=plugins)
+  skipCheckLibs = getSkipCheckLibs(plugins=plugins)
   messages = []
   for lib, needVersion in need.items():
     # some libs aren't checked from within python
-    if lib in skipChecks:
+    if lib in skipCheckLibs:
       continue
     found, msg, foundVersion = checkSingleLibrary(lib, version=needVersion)
     if not found:
@@ -239,6 +238,28 @@ def getRequiredLibs(useOS=None, installMethod=None, addOptional=False, limit=Non
       pluginLibs = _checkForUpdates(libs, pluginLibs, pluginName)
       libs.update(pluginLibs)
   return libs
+
+def getSkipCheckLibs(plugins=None):
+  """
+    Assembles dictionary of libraries that would not be checked.
+    @ In, plugins, list(tuple(str,str)), optional, plugins (name, location) that should be added to
+                   the required libs
+    @ Out, skipCheckLibs, dict, dictionary of libraries {name: version}
+  """
+  skipCheckLibs = OrderedDict()
+  mainConfigFile = os.path.abspath(os.path.expanduser(os.path.join(os.path.dirname(__file__),
+                                                                   '..', 'dependencies.ini')))
+  config = _readDependencies(mainConfigFile)
+  if config.has_section('skip-check'):
+    _addLibsFromSection(config.items('skip-check'), skipCheckLibs)
+  # extend config with plugin libs
+  for pluginName, pluginLoc in plugins:
+    pluginConfigFile = os.path.join(pluginLoc, 'dependencies.ini')
+    if os.path.isfile(pluginConfigFile):
+      pluginConfig = _readDependencies(pluginConfigFile)
+      if pluginConfig.has_section('skip-check'):
+        _addLibsFromSection(pluginConfig.items('skip-check'), skipCheckLibs)
+  return skipCheckLibs
 
 def _checkForUpdates(libs, pluginLibs, pluginName):
   """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1178 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

