### PR TITLE
Cogljj/lazy import

### DIFF
--- a/dependencies.ini
+++ b/dependencies.ini
@@ -56,7 +56,6 @@ pyside2
 
 # tertiary installs directly from pip
 [pip]
-lazy-import
 
 # optional libraries
 [optional]

--- a/framework/SupervisedLearning/KerasClassifier.py
+++ b/framework/SupervisedLearning/KerasClassifier.py
@@ -32,17 +32,18 @@ from scipy import stats
 from sklearn import preprocessing
 import os
 
+import contrib.lazy.lazy_loader as lazy_loader
 _tensorflowAvailable = False
 # TensorFlow is optional and Python3 is required in order to use tensorflow for DNNs
 try:
   import tensorflow as tf
   import tensorflow.keras as Keras
-  from tensorflow.keras import models as KerasModels
-  from tensorflow.keras import layers as KerasLayers
-  from tensorflow.keras import optimizers as KerasOptimizers
-  from tensorflow.keras import utils as KerasUtils
-  from tensorflow.python.keras.backend import set_session
-  from tensorflow.python.keras.models import load_model
+  #from tensorflow.keras import models as KerasModels
+  #from tensorflow.keras import layers as KerasLayers
+  #from tensorflow.keras import optimizers as KerasOptimizers
+  #from tensorflow.keras import utils as KerasUtils
+  #from tensorflow.python.keras.backend import set_session
+  #from tensorflow.python.keras.models import load_model
   _tensorflowAvailable = True
   # tf.enable_eager_execution()
 except ImportError as e:
@@ -77,139 +78,139 @@ if isTensorflowAvailable():
     # An optimizer is required for compiling a Keras model
     availOptimizer = {}
     # stochastic gradient descent optimizer, includes support for momentum,learning rate decay, and Nesterov momentum
-    availOptimizer['sgd'] = KerasOptimizers.SGD
+    availOptimizer['sgd'] = Keras.optimizers.SGD
     # RMSprop optimizer, usually a good choice for recurrent neural network
-    availOptimizer['rmsprop'] = KerasOptimizers.RMSprop
+    availOptimizer['rmsprop'] = Keras.optimizers.RMSprop
     # Adagrad is an optimzer with parameter-specific learning rates, which are adapted relative to
     # how frequently a parameter gets updated during training. The more updates  a parameter receives,
     # the smaller the updates.
-    availOptimizer['adagrad'] = KerasOptimizers.Adagrad
+    availOptimizer['adagrad'] = Keras.optimizers.Adagrad
     # Adadelta is a more robust extension of Adagrad that adapts learning rates based on a moving
     # window of gradient updates, instead of accumulating all past gradients. This way, Adadelta
     # continues learning even when many updates have been done.
-    availOptimizer['adadelta'] = KerasOptimizers.Adadelta
+    availOptimizer['adadelta'] = Keras.optimizers.Adadelta
     # Adam optimzer
-    availOptimizer['adam'] = KerasOptimizers.Adam
+    availOptimizer['adam'] = Keras.optimizers.Adam
     # Adamax optimizer from Adam paper's section 7
-    availOptimizer['adamax'] = KerasOptimizers.Adamax
+    availOptimizer['adamax'] = Keras.optimizers.Adamax
     # Nesterov Adam optimizer
-    availOptimizer['nadam'] = KerasOptimizers.Nadam
+    availOptimizer['nadam'] = Keras.optimizers.Nadam
 
     # available convolutional layers
     availLayer = {}
     # dense layer
-    availLayer['dense'] = KerasLayers.Dense
+    availLayer['dense'] = Keras.layers.Dense
     # apply dropout to the input
-    availLayer['dropout'] = KerasLayers.Dropout
+    availLayer['dropout'] = Keras.layers.Dropout
     # Flatten layer
-    availLayer['flatten'] = KerasLayers.Flatten
+    availLayer['flatten'] = Keras.layers.Flatten
     # 1D convolution layer (e.g. temporal convolution).
-    availLayer['conv1d'] = KerasLayers.Conv1D
+    availLayer['conv1d'] = Keras.layers.Conv1D
     # 2D convolution layer (e.g. spatial convolution over images).
-    availLayer['conv2d'] = KerasLayers.Conv2D
+    availLayer['conv2d'] = Keras.layers.Conv2D
     # Depthwise separable 1D convolution.
-    #availConvNet['separableconv1d'] = KerasLayers.SeparableConv1D
+    #availConvNet['separableconv1d'] = Keras.layers.SeparableConv1D
     # Depthwise separable 2D convolution.
-    availLayer['separableconv2d'] = KerasLayers.SeparableConv2D
+    availLayer['separableconv2d'] = Keras.layers.SeparableConv2D
     # Depthwise separable 2D convolution.
-    #availConvNet['depthwiseconv2d'] = KerasLayers.DepthwiseConv2D
+    #availConvNet['depthwiseconv2d'] = Keras.layers.DepthwiseConv2D
     # Transposed convolution layer (sometimes called Deconvolution).
-    availLayer['conv2dtranspose'] = KerasLayers.Conv2DTranspose
+    availLayer['conv2dtranspose'] = Keras.layers.Conv2DTranspose
     # 3D convolution layer (e.g. spatial convolution over volumes).
-    availLayer['conv3d'] = KerasLayers.Conv3D
+    availLayer['conv3d'] = Keras.layers.Conv3D
     # ransposed convolution layer (sometimes called Deconvolution).
-    #availConvNet['conv3dtranspose'] = KerasLayers.Conv3DTranspose
+    #availConvNet['conv3dtranspose'] = Keras.layers.Conv3DTranspose
     # Cropping layer for 1D input (e.g. temporal sequence). It crops along the time dimension (axis 1).
-    availLayer['cropping1d'] = KerasLayers.Cropping1D
+    availLayer['cropping1d'] = Keras.layers.Cropping1D
     # Cropping layer for 2D input (e.g. picture). It crops along spatial dimensions, i.e. height and width.
-    availLayer['cropping2d'] = KerasLayers.Cropping2D
+    availLayer['cropping2d'] = Keras.layers.Cropping2D
     # Cropping layer for 3D data (e.g. spatial or spatio-temporal).
-    availLayer['cropping3d'] = KerasLayers.Cropping3D
+    availLayer['cropping3d'] = Keras.layers.Cropping3D
     # Upsampling layer for 1D inputs
-    availLayer['upsampling1d'] = KerasLayers.UpSampling1D
+    availLayer['upsampling1d'] = Keras.layers.UpSampling1D
     # Upsampling layer for 2D inputs.
-    availLayer['upsampling2d'] = KerasLayers.UpSampling2D
+    availLayer['upsampling2d'] = Keras.layers.UpSampling2D
     # Upsampling layer for 3D inputs.
-    availLayer['upsampling3d'] = KerasLayers.UpSampling3D
+    availLayer['upsampling3d'] = Keras.layers.UpSampling3D
     # Zero-padding layer for 1D input (e.g. temporal sequence).
-    availLayer['zeropadding1d'] = KerasLayers.ZeroPadding1D
+    availLayer['zeropadding1d'] = Keras.layers.ZeroPadding1D
     # Zero-padding layer for 2D input (e.g. picture).
     # This layer can add rows and columns of zeros at the top, bottom, left and right side of an image tensor.
-    availLayer['zeropadding2d'] = KerasLayers.ZeroPadding2D
+    availLayer['zeropadding2d'] = Keras.layers.ZeroPadding2D
     # Zero-padding layer for 3D data (spatial or spatio-tempral)
-    availLayer['zeropadding3d'] = KerasLayers.ZeroPadding3D
+    availLayer['zeropadding3d'] = Keras.layers.ZeroPadding3D
     # Locally-connected layer for 1D inputs.
     # The LocallyConnected1D layer works similarly to the Conv1D layer, except that weights are unshared,
     # that is, a different set of filters is applied at each different patch of the input.
-    availLayer['locallyconnected1d'] = KerasLayers.LocallyConnected1D
+    availLayer['locallyconnected1d'] = Keras.layers.LocallyConnected1D
     # Locally-connected layer for 2D inputs.
     # The LocallyConnected1D layer works similarly to the Conv2D layer, except that weights are unshared,
     # that is, a different set of filters is applied at each different patch of the input.
-    availLayer['locallyconnected2d'] = KerasLayers.LocallyConnected2D
+    availLayer['locallyconnected2d'] = Keras.layers.LocallyConnected2D
 
     # available pooling layers
     # Max pooling operation for temporal data.
-    availLayer['maxpooling1d'] = KerasLayers.MaxPooling1D
+    availLayer['maxpooling1d'] = Keras.layers.MaxPooling1D
     # Max pooling operation for spatial data.
-    availLayer['maxpooling2d'] = KerasLayers.MaxPooling2D
+    availLayer['maxpooling2d'] = Keras.layers.MaxPooling2D
     # Max pooling operation for 3D data (spatial or spatio-temporal).
-    availLayer['maxpooling3d'] = KerasLayers.MaxPooling3D
+    availLayer['maxpooling3d'] = Keras.layers.MaxPooling3D
     # Average pooling for temporal data.
-    availLayer['averagepooling1d'] = KerasLayers.AveragePooling1D
+    availLayer['averagepooling1d'] = Keras.layers.AveragePooling1D
     # Average pooling for spatial data.
-    availLayer['averagepooling2d'] = KerasLayers.AveragePooling2D
+    availLayer['averagepooling2d'] = Keras.layers.AveragePooling2D
     # Average pooling operation for 3D data (spatial or spatio-temporal).
-    availLayer['averagepooling3d'] = KerasLayers.AveragePooling3D
+    availLayer['averagepooling3d'] = Keras.layers.AveragePooling3D
     # Global max pooling operation for temporal data.
-    availLayer['globalmaxpooling1d'] = KerasLayers.GlobalMaxPooling1D
+    availLayer['globalmaxpooling1d'] = Keras.layers.GlobalMaxPooling1D
     # Global average pooling operation for temporal data.
-    availLayer['globalaveragepooling1d'] = KerasLayers.GlobalAveragePooling1D
+    availLayer['globalaveragepooling1d'] = Keras.layers.GlobalAveragePooling1D
     # Global max pooling operation for spatial data.
-    availLayer['globalmaxpooling2d'] = KerasLayers.GlobalMaxPooling2D
+    availLayer['globalmaxpooling2d'] = Keras.layers.GlobalMaxPooling2D
     # Global average pooling operation for spatial data.
-    availLayer['globalaveragepooling2d'] = KerasLayers.GlobalAveragePooling2D
+    availLayer['globalaveragepooling2d'] = Keras.layers.GlobalAveragePooling2D
     # Global Max pooling operation for 3D data.
-    availLayer['globalmaxpooling3d'] = KerasLayers.GlobalMaxPooling3D
+    availLayer['globalmaxpooling3d'] = Keras.layers.GlobalMaxPooling3D
     # Global Average pooling operation for 3D data.
-    availLayer['globalaveragepooling3d'] = KerasLayers.GlobalAveragePooling3D
+    availLayer['globalaveragepooling3d'] = Keras.layers.GlobalAveragePooling3D
 
     # available embedding layers
     # turns positive integers (indexes) into dense vectors of fixed size
     # This layer can only be used as the first layer in a model.
-    availLayer['embedding'] = KerasLayers.Embedding
+    availLayer['embedding'] = Keras.layers.Embedding
 
     # available recurrent layers
     # Fully-connected RNN where the output is to be fed back to input.
-    availLayer['simplernn'] = KerasLayers.SimpleRNN
+    availLayer['simplernn'] = Keras.layers.SimpleRNN
     # Gated Recurrent Unit - Cho et al. 2014.
-    availLayer['gru'] = KerasLayers.GRU
+    availLayer['gru'] = Keras.layers.GRU
     # Long Short-Term Memory layer - Hochreiter 1997.
-    availLayer['lstm'] = KerasLayers.LSTM
+    availLayer['lstm'] = Keras.layers.LSTM
     # Convolutional LSTM.
     # It is similar to an LSTM layer, but the input transformations and recurrent transformations are both convolutional.
-    availLayer['convlstm2d'] = KerasLayers.ConvLSTM2D
+    availLayer['convlstm2d'] = Keras.layers.ConvLSTM2D
     # Fast GRU implementation backed by CuDNN.
-    #availRecurrent['cudnngru'] = KerasLayers.CuDNNGRU
+    #availRecurrent['cudnngru'] = Keras.layers.CuDNNGRU
     # Fast LSTM implementation with CuDNN.
-   # availRecurrent['cudnnlstm'] = KerasLayers.CuDNNLSTM
+   # availRecurrent['cudnnlstm'] = Keras.layers.CuDNNLSTM
 
     # available normalization layers
     availNormalization = {}
-    availNormalization['batchnormalization'] = KerasLayers.BatchNormalization
+    availNormalization['batchnormalization'] = Keras.layers.BatchNormalization
 
     # available noise layers
     availNoise = {}
     # Apply additive zero-centered Gaussian noise.
     # This is useful to mitigate overfitting (you could see it as a form of random data augmentation).
     # Gaussian Noise (GS) is a natural choice as corruption process for real valued inputs.
-    availNoise['gaussiannoise'] = KerasLayers.GaussianNoise
+    availNoise['gaussiannoise'] = Keras.layers.GaussianNoise
     # Apply multiplicative 1-centered Gaussian noise. As it is a regularization layer, it is only active at training time.
-    availNoise['gaussiandropout'] = KerasLayers.GaussianDropout
+    availNoise['gaussiandropout'] = Keras.layers.GaussianDropout
     # Applies Alpha Dropout to the input.
     # Alpha Dropout is a Dropout that keeps mean and variance of inputs to their original values, in order to ensure
     # the self-normalizing property even after this dropout. Alpha Dropout fits well to Scaled Exponential Linear Units
     #  by randomly setting activations to the negative saturation value.
-    #availNoise['alphadropout'] = KerasLayers.AlphaDropout
+    #availNoise['alphadropout'] = Keras.layers.AlphaDropout
     # Temp Model File that used to dump and load Keras Model
     tempModelFile = "a_temporary_file_for_storing_a_keras_model.h5"
     modelAttr = "the_model_all_serialized_and_turned_into_an_hdf5_file_and_stuff"
@@ -271,7 +272,7 @@ if isTensorflowAvailable():
       # a new session (which) does not contain any previously loaded weights, models, and so on)
       # is created for each thread, i.e. for each request. By saving the session that contains all
       # the models and setting it to be used by keras in each thread.
-      set_session(self._session)
+      Keras.backend.set_session(self._session)
 
       modelName = self.initOptionDict.pop('name','')
       # number of classes for classifier
@@ -328,7 +329,7 @@ if isTensorflowAvailable():
         @ Out, state, dict, it contains all the information needed by the ROM to be initialized
       """
       state = supervisedLearning.__getstate__(self)
-      KerasModels.save_model(self._ROM, KerasClassifier.tempModelFile)
+      Keras.models.save_model(self._ROM, KerasClassifier.tempModelFile)
       # another method to save the TensorFlow model
       # self._ROM.save(KerasClassifier.tempModelFile)
       with open(KerasClassifier.tempModelFile, "rb") as f:
@@ -348,8 +349,8 @@ if isTensorflowAvailable():
       with open(KerasClassifier.tempModelFile, "wb") as f:
         f.write(d[KerasClassifier.modelAttr])
       del d[KerasClassifier.modelAttr]
-      set_session(self._session)
-      self._ROM = KerasModels.load_model(KerasClassifier.tempModelFile)
+      Keras.backend.set_session(self._session)
+      self._ROM = Keras.models.load_model(KerasClassifier.tempModelFile)
       os.remove(KerasClassifier.tempModelFile)
       self.__dict__.update(d)
 
@@ -368,7 +369,7 @@ if isTensorflowAvailable():
         @ Out, None
       """
       # start to build the ROM
-      self._ROM = KerasModels.Sequential()
+      self._ROM = Keras.models.Sequential()
       # loop over layers
       for index, layerName in enumerate(self.layerLayout[:-1]):
         layerDict = copy.deepcopy(self.initOptionDict[layerName])
@@ -443,7 +444,7 @@ if isTensorflowAvailable():
       if self.numClasses > 1 and 'categorical_crossentropy' in self.lossFunction:
         # Transform the labels (i.e. numerical or non-numerical) to normalized numerical labels
         targetValues = self.labelEncoder.fit_transform(targetValues.ravel())
-        targetValues = KerasUtils.to_categorical(targetValues)
+        targetValues = Keras.utils.to_categorical(targetValues)
         if self.numClasses != targetValues.shape[-1]:
           self.raiseAWarning('The num_classes:',self.numClasses, 'specified by the user is not equal number of classes',
                              targetValues.shape[-1], ' in the provided data!')
@@ -502,7 +503,7 @@ if isTensorflowAvailable():
       # The following requires pydot-ng and graphviz to be installed (See the manual)
       # https://github.com/keras-team/keras/issues/3210
       if self.plotModel:
-        KerasUtils.plot_model(self._ROM,to_file=self.plotModelFilename,show_shapes=True)
+        Keras.utils.plot_model(self._ROM,to_file=self.plotModelFilename,show_shapes=True)
 
     def writeXML(self, writeTo, targets=None, skip=None):
       """
@@ -540,7 +541,7 @@ if isTensorflowAvailable():
       featureVals = self._preprocessInputs(featureVals)
       prediction = {}
       with self.graph.as_default():
-        set_session(self._session)
+        Keras.backend.set_session(self._session)
         outcome = self._ROM.predict(featureVals)
       if self.numClasses > 1 and self.lossFunction in ['categorical_crossentropy']:
         outcome = np.argmax(outcome,axis=1)
@@ -585,7 +586,7 @@ if isTensorflowAvailable():
         Returns a dictionary with the parameters and their current values
         The model can be reinstantiated from its config via:
         config = model.get_config()
-        self._ROM = KerasModels.Sequential.from_config(config)
+        self._ROM = Keras.models.Sequential.from_config(config)
         @ In, None
         @ Out, params, dict, dictionary of parameter names and current values
       """

--- a/framework/SupervisedLearning/KerasClassifier.py
+++ b/framework/SupervisedLearning/KerasClassifier.py
@@ -35,19 +35,21 @@ import os
 import contrib.lazy.lazy_loader as lazy_loader
 _tensorflowAvailable = False
 # TensorFlow is optional and Python3 is required in order to use tensorflow for DNNs
-try:
-  import tensorflow as tf
-  import tensorflow.keras as Keras
-  #from tensorflow.keras import models as KerasModels
-  #from tensorflow.keras import layers as KerasLayers
-  #from tensorflow.keras import optimizers as KerasOptimizers
-  #from tensorflow.keras import utils as KerasUtils
-  #from tensorflow.python.keras.backend import set_session
-  #from tensorflow.python.keras.models import load_model
-  _tensorflowAvailable = True
+#try:
+# import tensorflow as tf
+tf = lazy_loader.LazyLoader("tf", globals(), "tensorflow")
+# import tensorflow.keras as Keras
+Keras = lazy_loader.LazyLoader("Keras", globals(), "tensorflow.keras")
+#from tensorflow.keras import models as KerasModels
+#from tensorflow.keras import layers as KerasLayers
+#from tensorflow.keras import optimizers as KerasOptimizers
+#from tensorflow.keras import utils as KerasUtils
+#from tensorflow.python.keras.backend import set_session
+#from tensorflow.python.keras.models import load_model
+_tensorflowAvailable = True
   # tf.enable_eager_execution()
-except ImportError as e:
-  _tensorflowAvailable = False
+#except ImportError as e:
+#  _tensorflowAvailable = False
 #External Modules End--------------------------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------

--- a/framework/SupervisedLearning/KerasClassifier.py
+++ b/framework/SupervisedLearning/KerasClassifier.py
@@ -39,7 +39,7 @@ _tensorflowAvailable = False
 # import tensorflow as tf
 tf = lazy_loader.LazyLoader("tf", globals(), "tensorflow")
 # import tensorflow.keras as Keras
-Keras = lazy_loader.LazyLoader("Keras", globals(), "tensorflow.keras")
+#Keras = lazy_loader.LazyLoader("Keras", globals(), "tensorflow.keras")
 #from tensorflow.keras import models as KerasModels
 #from tensorflow.keras import layers as KerasLayers
 #from tensorflow.keras import optimizers as KerasOptimizers
@@ -79,140 +79,20 @@ if isTensorflowAvailable():
     ROMType = 'KerasClassifier'
     # An optimizer is required for compiling a Keras model
     availOptimizer = {}
-    # stochastic gradient descent optimizer, includes support for momentum,learning rate decay, and Nesterov momentum
-    availOptimizer['sgd'] = Keras.optimizers.SGD
-    # RMSprop optimizer, usually a good choice for recurrent neural network
-    availOptimizer['rmsprop'] = Keras.optimizers.RMSprop
-    # Adagrad is an optimzer with parameter-specific learning rates, which are adapted relative to
-    # how frequently a parameter gets updated during training. The more updates  a parameter receives,
-    # the smaller the updates.
-    availOptimizer['adagrad'] = Keras.optimizers.Adagrad
-    # Adadelta is a more robust extension of Adagrad that adapts learning rates based on a moving
-    # window of gradient updates, instead of accumulating all past gradients. This way, Adadelta
-    # continues learning even when many updates have been done.
-    availOptimizer['adadelta'] = Keras.optimizers.Adadelta
-    # Adam optimzer
-    availOptimizer['adam'] = Keras.optimizers.Adam
-    # Adamax optimizer from Adam paper's section 7
-    availOptimizer['adamax'] = Keras.optimizers.Adamax
-    # Nesterov Adam optimizer
-    availOptimizer['nadam'] = Keras.optimizers.Nadam
 
     # available convolutional layers
     availLayer = {}
-    # dense layer
-    availLayer['dense'] = Keras.layers.Dense
-    # apply dropout to the input
-    availLayer['dropout'] = Keras.layers.Dropout
-    # Flatten layer
-    availLayer['flatten'] = Keras.layers.Flatten
-    # 1D convolution layer (e.g. temporal convolution).
-    availLayer['conv1d'] = Keras.layers.Conv1D
-    # 2D convolution layer (e.g. spatial convolution over images).
-    availLayer['conv2d'] = Keras.layers.Conv2D
-    # Depthwise separable 1D convolution.
-    #availConvNet['separableconv1d'] = Keras.layers.SeparableConv1D
-    # Depthwise separable 2D convolution.
-    availLayer['separableconv2d'] = Keras.layers.SeparableConv2D
-    # Depthwise separable 2D convolution.
-    #availConvNet['depthwiseconv2d'] = Keras.layers.DepthwiseConv2D
-    # Transposed convolution layer (sometimes called Deconvolution).
-    availLayer['conv2dtranspose'] = Keras.layers.Conv2DTranspose
-    # 3D convolution layer (e.g. spatial convolution over volumes).
-    availLayer['conv3d'] = Keras.layers.Conv3D
-    # ransposed convolution layer (sometimes called Deconvolution).
-    #availConvNet['conv3dtranspose'] = Keras.layers.Conv3DTranspose
-    # Cropping layer for 1D input (e.g. temporal sequence). It crops along the time dimension (axis 1).
-    availLayer['cropping1d'] = Keras.layers.Cropping1D
-    # Cropping layer for 2D input (e.g. picture). It crops along spatial dimensions, i.e. height and width.
-    availLayer['cropping2d'] = Keras.layers.Cropping2D
-    # Cropping layer for 3D data (e.g. spatial or spatio-temporal).
-    availLayer['cropping3d'] = Keras.layers.Cropping3D
-    # Upsampling layer for 1D inputs
-    availLayer['upsampling1d'] = Keras.layers.UpSampling1D
-    # Upsampling layer for 2D inputs.
-    availLayer['upsampling2d'] = Keras.layers.UpSampling2D
-    # Upsampling layer for 3D inputs.
-    availLayer['upsampling3d'] = Keras.layers.UpSampling3D
-    # Zero-padding layer for 1D input (e.g. temporal sequence).
-    availLayer['zeropadding1d'] = Keras.layers.ZeroPadding1D
-    # Zero-padding layer for 2D input (e.g. picture).
-    # This layer can add rows and columns of zeros at the top, bottom, left and right side of an image tensor.
-    availLayer['zeropadding2d'] = Keras.layers.ZeroPadding2D
-    # Zero-padding layer for 3D data (spatial or spatio-tempral)
-    availLayer['zeropadding3d'] = Keras.layers.ZeroPadding3D
-    # Locally-connected layer for 1D inputs.
-    # The LocallyConnected1D layer works similarly to the Conv1D layer, except that weights are unshared,
-    # that is, a different set of filters is applied at each different patch of the input.
-    availLayer['locallyconnected1d'] = Keras.layers.LocallyConnected1D
-    # Locally-connected layer for 2D inputs.
-    # The LocallyConnected1D layer works similarly to the Conv2D layer, except that weights are unshared,
-    # that is, a different set of filters is applied at each different patch of the input.
-    availLayer['locallyconnected2d'] = Keras.layers.LocallyConnected2D
-
-    # available pooling layers
-    # Max pooling operation for temporal data.
-    availLayer['maxpooling1d'] = Keras.layers.MaxPooling1D
-    # Max pooling operation for spatial data.
-    availLayer['maxpooling2d'] = Keras.layers.MaxPooling2D
-    # Max pooling operation for 3D data (spatial or spatio-temporal).
-    availLayer['maxpooling3d'] = Keras.layers.MaxPooling3D
-    # Average pooling for temporal data.
-    availLayer['averagepooling1d'] = Keras.layers.AveragePooling1D
-    # Average pooling for spatial data.
-    availLayer['averagepooling2d'] = Keras.layers.AveragePooling2D
-    # Average pooling operation for 3D data (spatial or spatio-temporal).
-    availLayer['averagepooling3d'] = Keras.layers.AveragePooling3D
-    # Global max pooling operation for temporal data.
-    availLayer['globalmaxpooling1d'] = Keras.layers.GlobalMaxPooling1D
-    # Global average pooling operation for temporal data.
-    availLayer['globalaveragepooling1d'] = Keras.layers.GlobalAveragePooling1D
-    # Global max pooling operation for spatial data.
-    availLayer['globalmaxpooling2d'] = Keras.layers.GlobalMaxPooling2D
-    # Global average pooling operation for spatial data.
-    availLayer['globalaveragepooling2d'] = Keras.layers.GlobalAveragePooling2D
-    # Global Max pooling operation for 3D data.
-    availLayer['globalmaxpooling3d'] = Keras.layers.GlobalMaxPooling3D
-    # Global Average pooling operation for 3D data.
-    availLayer['globalaveragepooling3d'] = Keras.layers.GlobalAveragePooling3D
-
-    # available embedding layers
-    # turns positive integers (indexes) into dense vectors of fixed size
-    # This layer can only be used as the first layer in a model.
-    availLayer['embedding'] = Keras.layers.Embedding
-
-    # available recurrent layers
-    # Fully-connected RNN where the output is to be fed back to input.
-    availLayer['simplernn'] = Keras.layers.SimpleRNN
-    # Gated Recurrent Unit - Cho et al. 2014.
-    availLayer['gru'] = Keras.layers.GRU
-    # Long Short-Term Memory layer - Hochreiter 1997.
-    availLayer['lstm'] = Keras.layers.LSTM
-    # Convolutional LSTM.
-    # It is similar to an LSTM layer, but the input transformations and recurrent transformations are both convolutional.
-    availLayer['convlstm2d'] = Keras.layers.ConvLSTM2D
-    # Fast GRU implementation backed by CuDNN.
-    #availRecurrent['cudnngru'] = Keras.layers.CuDNNGRU
-    # Fast LSTM implementation with CuDNN.
-   # availRecurrent['cudnnlstm'] = Keras.layers.CuDNNLSTM
 
     # available normalization layers
     availNormalization = {}
-    availNormalization['batchnormalization'] = Keras.layers.BatchNormalization
 
     # available noise layers
     availNoise = {}
-    # Apply additive zero-centered Gaussian noise.
-    # This is useful to mitigate overfitting (you could see it as a form of random data augmentation).
-    # Gaussian Noise (GS) is a natural choice as corruption process for real valued inputs.
-    availNoise['gaussiannoise'] = Keras.layers.GaussianNoise
-    # Apply multiplicative 1-centered Gaussian noise. As it is a regularization layer, it is only active at training time.
-    availNoise['gaussiandropout'] = Keras.layers.GaussianDropout
     # Applies Alpha Dropout to the input.
     # Alpha Dropout is a Dropout that keeps mean and variance of inputs to their original values, in order to ensure
     # the self-normalizing property even after this dropout. Alpha Dropout fits well to Scaled Exponential Linear Units
     #  by randomly setting activations to the negative saturation value.
-    #availNoise['alphadropout'] = Keras.layers.AlphaDropout
+    #availNoise['alphadropout'] = tf.keras.layers.AlphaDropout
     # Temp Model File that used to dump and load Keras Model
     tempModelFile = "a_temporary_file_for_storing_a_keras_model.h5"
     modelAttr = "the_model_all_serialized_and_turned_into_an_hdf5_file_and_stuff"
@@ -224,6 +104,135 @@ if isTensorflowAvailable():
         @ In, kwargs, dict, an arbitrary dictionary of keywords and values
         @ Out, None
       """
+      if len(self.availOptimizer) == 0:
+        # stochastic gradient descent optimizer, includes support for momentum,learning rate decay, and Nesterov momentum
+        self.availOptimizer['sgd'] = tf.keras.optimizers.SGD
+        # RMSprop optimizer, usually a good choice for recurrent neural network
+        self.availOptimizer['rmsprop'] = tf.keras.optimizers.RMSprop
+        # Adagrad is an optimzer with parameter-specific learning rates, which are adapted relative to
+        # how frequently a parameter gets updated during training. The more updates  a parameter receives,
+        # the smaller the updates.
+        self.availOptimizer['adagrad'] = tf.keras.optimizers.Adagrad
+        # Adadelta is a more robust extension of Adagrad that adapts learning rates based on a moving
+        # window of gradient updates, instead of accumulating all past gradients. This way, Adadelta
+        # continues learning even when many updates have been done.
+        self.availOptimizer['adadelta'] = tf.keras.optimizers.Adadelta
+        # Adam optimzer
+        self.availOptimizer['adam'] = tf.keras.optimizers.Adam
+        # Adamax optimizer from Adam paper's section 7
+        self.availOptimizer['adamax'] = tf.keras.optimizers.Adamax
+        # Nesterov Adam optimizer
+        self.availOptimizer['nadam'] = tf.keras.optimizers.Nadam
+
+      if len(self.availLayer) == 0:
+        # dense layer
+        self.availLayer['dense'] = tf.keras.layers.Dense
+        # apply dropout to the input
+        self.availLayer['dropout'] = tf.keras.layers.Dropout
+        # Flatten layer
+        self.availLayer['flatten'] = tf.keras.layers.Flatten
+        # 1D convolution layer (e.g. temporal convolution).
+        self.availLayer['conv1d'] = tf.keras.layers.Conv1D
+        # 2D convolution layer (e.g. spatial convolution over images).
+        self.availLayer['conv2d'] = tf.keras.layers.Conv2D
+        # Depthwise separable 1D convolution.
+        #availConvNet['separableconv1d'] = tf.keras.layers.SeparableConv1D
+        # Depthwise separable 2D convolution.
+        self.availLayer['separableconv2d'] = tf.keras.layers.SeparableConv2D
+        # Depthwise separable 2D convolution.
+        #availConvNet['depthwiseconv2d'] = tf.keras.layers.DepthwiseConv2D
+        # Transposed convolution layer (sometimes called Deconvolution).
+        self.availLayer['conv2dtranspose'] = tf.keras.layers.Conv2DTranspose
+        # 3D convolution layer (e.g. spatial convolution over volumes).
+        self.availLayer['conv3d'] = tf.keras.layers.Conv3D
+        # ransposed convolution layer (sometimes called Deconvolution).
+        #availConvNet['conv3dtranspose'] = tf.keras.layers.Conv3DTranspose
+        # Cropping layer for 1D input (e.g. temporal sequence). It crops along the time dimension (axis 1).
+        self.availLayer['cropping1d'] = tf.keras.layers.Cropping1D
+        # Cropping layer for 2D input (e.g. picture). It crops along spatial dimensions, i.e. height and width.
+        self.availLayer['cropping2d'] = tf.keras.layers.Cropping2D
+        # Cropping layer for 3D data (e.g. spatial or spatio-temporal).
+        self.availLayer['cropping3d'] = tf.keras.layers.Cropping3D
+        # Upsampling layer for 1D inputs
+        self.availLayer['upsampling1d'] = tf.keras.layers.UpSampling1D
+        # Upsampling layer for 2D inputs.
+        self.availLayer['upsampling2d'] = tf.keras.layers.UpSampling2D
+        # Upsampling layer for 3D inputs.
+        self.availLayer['upsampling3d'] = tf.keras.layers.UpSampling3D
+        # Zero-padding layer for 1D input (e.g. temporal sequence).
+        self.availLayer['zeropadding1d'] = tf.keras.layers.ZeroPadding1D
+        # Zero-padding layer for 2D input (e.g. picture).
+        # This layer can add rows and columns of zeros at the top, bottom, left and right side of an image tensor.
+        self.availLayer['zeropadding2d'] = tf.keras.layers.ZeroPadding2D
+        # Zero-padding layer for 3D data (spatial or spatio-tempral)
+        self.availLayer['zeropadding3d'] = tf.keras.layers.ZeroPadding3D
+        # Locally-connected layer for 1D inputs.
+        # The LocallyConnected1D layer works similarly to the Conv1D layer, except that weights are unshared,
+        # that is, a different set of filters is applied at each different patch of the input.
+        self.availLayer['locallyconnected1d'] = tf.keras.layers.LocallyConnected1D
+        # Locally-connected layer for 2D inputs.
+        # The LocallyConnected1D layer works similarly to the Conv2D layer, except that weights are unshared,
+        # that is, a different set of filters is applied at each different patch of the input.
+        self.availLayer['locallyconnected2d'] = tf.keras.layers.LocallyConnected2D
+
+        # available pooling layers
+        # Max pooling operation for temporal data.
+        self.availLayer['maxpooling1d'] = tf.keras.layers.MaxPooling1D
+        # Max pooling operation for spatial data.
+        self.availLayer['maxpooling2d'] = tf.keras.layers.MaxPooling2D
+        # Max pooling operation for 3D data (spatial or spatio-temporal).
+        self.availLayer['maxpooling3d'] = tf.keras.layers.MaxPooling3D
+        # Average pooling for temporal data.
+        self.availLayer['averagepooling1d'] = tf.keras.layers.AveragePooling1D
+        # Average pooling for spatial data.
+        self.availLayer['averagepooling2d'] = tf.keras.layers.AveragePooling2D
+        # Average pooling operation for 3D data (spatial or spatio-temporal).
+        self.availLayer['averagepooling3d'] = tf.keras.layers.AveragePooling3D
+        # Global max pooling operation for temporal data.
+        self.availLayer['globalmaxpooling1d'] = tf.keras.layers.GlobalMaxPooling1D
+        # Global average pooling operation for temporal data.
+        self.availLayer['globalaveragepooling1d'] = tf.keras.layers.GlobalAveragePooling1D
+        # Global max pooling operation for spatial data.
+        self.availLayer['globalmaxpooling2d'] = tf.keras.layers.GlobalMaxPooling2D
+        # Global average pooling operation for spatial data.
+        self.availLayer['globalaveragepooling2d'] = tf.keras.layers.GlobalAveragePooling2D
+        # Global Max pooling operation for 3D data.
+        self.availLayer['globalmaxpooling3d'] = tf.keras.layers.GlobalMaxPooling3D
+        # Global Average pooling operation for 3D data.
+        self.availLayer['globalaveragepooling3d'] = tf.keras.layers.GlobalAveragePooling3D
+
+        # available embedding layers
+        # turns positive integers (indexes) into dense vectors of fixed size
+        # This layer can only be used as the first layer in a model.
+        self.availLayer['embedding'] = tf.keras.layers.Embedding
+
+        # available recurrent layers
+        # Fully-connected RNN where the output is to be fed back to input.
+        self.availLayer['simplernn'] = tf.keras.layers.SimpleRNN
+        # Gated Recurrent Unit - Cho et al. 2014.
+        self.availLayer['gru'] = tf.keras.layers.GRU
+        # Long Short-Term Memory layer - Hochreiter 1997.
+        self.availLayer['lstm'] = tf.keras.layers.LSTM
+        # Convolutional LSTM.
+        # It is similar to an LSTM layer, but the input transformations and recurrent transformations are both convolutional.
+        self.availLayer['convlstm2d'] = tf.keras.layers.ConvLSTM2D
+        # Fast GRU implementation backed by CuDNN.
+        #availRecurrent['cudnngru'] = tf.keras.layers.CuDNNGRU
+        # Fast LSTM implementation with CuDNN.
+        # availRecurrent['cudnnlstm'] = tf.keras.layers.CuDNNLSTM
+
+      if len(self.availNormalization) == 0:
+        self.availNormalization['batchnormalization'] = tf.keras.layers.BatchNormalization
+
+      if len(self.availNoise) == 0:
+        # Apply additive zero-centered Gaussian noise.
+        # This is useful to mitigate overfitting (you could see it as a form of random data augmentation).
+        # Gaussian Noise (GS) is a natural choice as corruption process for real valued inputs.
+        self.availNoise['gaussiannoise'] = tf.keras.layers.GaussianNoise
+        # Apply multiplicative 1-centered Gaussian noise. As it is a regularization layer, it is only active at training time.
+        self.availNoise['gaussiandropout'] = tf.keras.layers.GaussianDropout
+
+
       supervisedLearning.__init__(self,messageHandler,**kwargs)
 
       # parameter dictionary at the initial stage
@@ -274,7 +283,7 @@ if isTensorflowAvailable():
       # a new session (which) does not contain any previously loaded weights, models, and so on)
       # is created for each thread, i.e. for each request. By saving the session that contains all
       # the models and setting it to be used by keras in each thread.
-      Keras.backend.set_session(self._session)
+      tf.keras.backend.set_session(self._session)
 
       modelName = self.initOptionDict.pop('name','')
       # number of classes for classifier
@@ -331,7 +340,7 @@ if isTensorflowAvailable():
         @ Out, state, dict, it contains all the information needed by the ROM to be initialized
       """
       state = supervisedLearning.__getstate__(self)
-      Keras.models.save_model(self._ROM, KerasClassifier.tempModelFile)
+      tf.keras.models.save_model(self._ROM, KerasClassifier.tempModelFile)
       # another method to save the TensorFlow model
       # self._ROM.save(KerasClassifier.tempModelFile)
       with open(KerasClassifier.tempModelFile, "rb") as f:
@@ -351,8 +360,8 @@ if isTensorflowAvailable():
       with open(KerasClassifier.tempModelFile, "wb") as f:
         f.write(d[KerasClassifier.modelAttr])
       del d[KerasClassifier.modelAttr]
-      Keras.backend.set_session(self._session)
-      self._ROM = Keras.models.load_model(KerasClassifier.tempModelFile)
+      tf.keras.backend.set_session(self._session)
+      self._ROM = tf.keras.models.load_model(KerasClassifier.tempModelFile)
       os.remove(KerasClassifier.tempModelFile)
       self.__dict__.update(d)
 
@@ -371,7 +380,7 @@ if isTensorflowAvailable():
         @ Out, None
       """
       # start to build the ROM
-      self._ROM = Keras.models.Sequential()
+      self._ROM = tf.keras.models.Sequential()
       # loop over layers
       for index, layerName in enumerate(self.layerLayout[:-1]):
         layerDict = copy.deepcopy(self.initOptionDict[layerName])
@@ -446,7 +455,7 @@ if isTensorflowAvailable():
       if self.numClasses > 1 and 'categorical_crossentropy' in self.lossFunction:
         # Transform the labels (i.e. numerical or non-numerical) to normalized numerical labels
         targetValues = self.labelEncoder.fit_transform(targetValues.ravel())
-        targetValues = Keras.utils.to_categorical(targetValues)
+        targetValues = tf.keras.utils.to_categorical(targetValues)
         if self.numClasses != targetValues.shape[-1]:
           self.raiseAWarning('The num_classes:',self.numClasses, 'specified by the user is not equal number of classes',
                              targetValues.shape[-1], ' in the provided data!')
@@ -505,7 +514,7 @@ if isTensorflowAvailable():
       # The following requires pydot-ng and graphviz to be installed (See the manual)
       # https://github.com/keras-team/keras/issues/3210
       if self.plotModel:
-        Keras.utils.plot_model(self._ROM,to_file=self.plotModelFilename,show_shapes=True)
+        tf.keras.utils.plot_model(self._ROM,to_file=self.plotModelFilename,show_shapes=True)
 
     def writeXML(self, writeTo, targets=None, skip=None):
       """
@@ -543,7 +552,7 @@ if isTensorflowAvailable():
       featureVals = self._preprocessInputs(featureVals)
       prediction = {}
       with self.graph.as_default():
-        Keras.backend.set_session(self._session)
+        tf.keras.backend.set_session(self._session)
         outcome = self._ROM.predict(featureVals)
       if self.numClasses > 1 and self.lossFunction in ['categorical_crossentropy']:
         outcome = np.argmax(outcome,axis=1)
@@ -588,7 +597,7 @@ if isTensorflowAvailable():
         Returns a dictionary with the parameters and their current values
         The model can be reinstantiated from its config via:
         config = model.get_config()
-        self._ROM = Keras.models.Sequential.from_config(config)
+        self._ROM = tf.keras.models.Sequential.from_config(config)
         @ In, None
         @ Out, params, dict, dictionary of parameter names and current values
       """

--- a/framework/SupervisedLearning/SciKitLearn.py
+++ b/framework/SupervisedLearning/SciKitLearn.py
@@ -23,7 +23,7 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 #End compatibility block for Python 3----------------------------------------------------------------
 
 #Internal Modules (Lazy Importer)--------------------------------------------------------------------
-from utils.lazyImporterUtils import import_module_lazy, import_collable_lazy
+from utils.lazyImporterUtils import import_module_lazy
 #Internal Modules (Lazy Importer) End----------------------------------------------------------------
 
 #External Modules------------------------------------------------------------------------------------

--- a/framework/contrib/lazy/LICENSE
+++ b/framework/contrib/lazy/LICENSE
@@ -1,0 +1,203 @@
+Copyright 2019 The TensorFlow Authors.  All rights reserved.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/framework/contrib/lazy/README
+++ b/framework/contrib/lazy/README
@@ -1,0 +1,4 @@
+lazy_loader.py originally copyied from:
+https://raw.githubusercontent.com/tensorflow/tensorflow/master/tensorflow/python/util/lazy_loader.py
+Commit id: 64e362bb910e9121480cbdf27162968496533bcd
+Part of tensorflow: https://github.com/tensorflow/tensorflow

--- a/framework/contrib/lazy/lazy_loader.py
+++ b/framework/contrib/lazy/lazy_loader.py
@@ -1,0 +1,67 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""A LazyLoader class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import types
+from tensorflow.python.platform import tf_logging as logging
+
+
+class LazyLoader(types.ModuleType):
+  """Lazily import a module, mainly to avoid pulling in large dependencies.
+
+  `contrib`, and `ffmpeg` are examples of modules that are large and not always
+  needed, and this allows them to only be loaded when they are used.
+  """
+
+  # The lint error here is incorrect.
+  def __init__(self, local_name, parent_module_globals, name, warning=None):  # pylint: disable=super-on-old-class
+    self._local_name = local_name
+    self._parent_module_globals = parent_module_globals
+    self._warning = warning
+
+    super(LazyLoader, self).__init__(name)
+
+  def _load(self):
+    """Load the module and insert it into the parent's globals."""
+    # Import the target module and insert it into the parent's namespace
+    module = importlib.import_module(self.__name__)
+    self._parent_module_globals[self._local_name] = module
+
+    # Emit a warning if one was specified
+    if self._warning:
+      logging.warning(self._warning)
+      # Make sure to only warn once.
+      self._warning = None
+
+    # Update this object's dict so that if someone keeps a reference to the
+    #   LazyLoader, lookups are efficient (__getattr__ is only called on lookups
+    #   that fail).
+    self.__dict__.update(module.__dict__)
+
+    return module
+
+  def __getattr__(self, item):
+    module = self._load()
+    return getattr(module, item)
+
+  def __dir__(self):
+    module = self._load()
+    return dir(module)

--- a/framework/contrib/lazy/lazy_loader.py
+++ b/framework/contrib/lazy/lazy_loader.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+# Modified to simplify by RAVEN
+
 """A LazyLoader class."""
 
 from __future__ import absolute_import
@@ -21,7 +23,6 @@ from __future__ import print_function
 
 import importlib
 import types
-from tensorflow.python.platform import tf_logging as logging
 
 
 class LazyLoader(types.ModuleType):
@@ -32,10 +33,9 @@ class LazyLoader(types.ModuleType):
   """
 
   # The lint error here is incorrect.
-  def __init__(self, local_name, parent_module_globals, name, warning=None):  # pylint: disable=super-on-old-class
+  def __init__(self, local_name, parent_module_globals, name):  # pylint: disable=super-on-old-class
     self._local_name = local_name
     self._parent_module_globals = parent_module_globals
-    self._warning = warning
 
     super(LazyLoader, self).__init__(name)
 
@@ -44,12 +44,6 @@ class LazyLoader(types.ModuleType):
     # Import the target module and insert it into the parent's namespace
     module = importlib.import_module(self.__name__)
     self._parent_module_globals[self._local_name] = module
-
-    # Emit a warning if one was specified
-    if self._warning:
-      logging.warning(self._warning)
-      # Make sure to only warn once.
-      self._warning = None
 
     # Update this object's dict so that if someone keeps a reference to the
     #   LazyLoader, lookups are efficient (__getattr__ is only called on lookups

--- a/framework/utils/lazyImporterUtils.py
+++ b/framework/utils/lazyImporterUtils.py
@@ -23,7 +23,7 @@ from __future__ import division, print_function, absolute_import
 #----- end python 2 - 3 compatibility
 
 #External Modules------------------------------------------------------------------------------------
-import lazy_import
+import contrib.lazy.lazy_loader as lazy_loader
 #External Modules End--------------------------------------------------------------------------------
 #Internal Modules------------------------------------------------------------------------------------
 #Internal Modules End--------------------------------------------------------------------------------
@@ -34,13 +34,14 @@ def import_module_lazy(moduleString):
     @ In, moduleString, str, the module to import (e.g. numpy or scipy.stats, etc.)
     @ Out, mod, Object, the imported module (lazy)
   """
-  return lazy_import.lazy_module(moduleString.strip())
+  name = moduleString.strip()
+  return lazy_loader.LazyLoader(name, globals(), name)
 
-def import_collable_lazy(collableString):
-  """
-    This method is aimed to import a collable method or attribute
-    within a module that needs to be lazy imported
-    @ In, moduleString, str, the collable to point (e.g. numpy.arange, numpy.ndarray, etc.)
-    @ Out, callable, Object_Pointer, the collable (lazy)
-  """
-  return lazy_import.lazy_callable(collableString.strip())
+#def import_collable_lazy(collableString):
+#  """
+#    This method is aimed to import a collable method or attribute
+#    within a module that needs to be lazy imported
+#    @ In, moduleString, str, the collable to point (e.g. numpy.arange, numpy.ndarray, etc.)
+#    @ Out, callable, Object_Pointer, the collable (lazy)
+#  """
+#  return lazy_import.lazy_callable(collableString.strip())

--- a/framework/utils/lazyImporterUtils.py
+++ b/framework/utils/lazyImporterUtils.py
@@ -37,11 +37,3 @@ def import_module_lazy(moduleString):
   name = moduleString.strip()
   return lazy_loader.LazyLoader(name, globals(), name)
 
-#def import_collable_lazy(collableString):
-#  """
-#    This method is aimed to import a collable method or attribute
-#    within a module that needs to be lazy imported
-#    @ In, moduleString, str, the collable to point (e.g. numpy.arange, numpy.ndarray, etc.)
-#    @ Out, callable, Object_Pointer, the collable (lazy)
-#  """
-#  return lazy_import.lazy_callable(collableString.strip())

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -532,4 +532,7 @@ if __name__ == '__main__':
                          .format(lib=lib,
                                  ver=('{}{}'.format(equals, ver) if ver is not None else ''))
                          for lib, ver in libs.items()])
-    print(preamble + libTexts)
+    if len(libTexts) > 0:
+      print(preamble + libTexts)
+    else:
+      print("echo no libs")


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #1182 

##### What are the significant changes in functionality due to this change request?
This adds the TensorFlow lazy loading library, and removes lazy-import. It uses the lazy loading library to load TensorFlow and switches the other lazy loading to it.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

