### PR TITLE
Always specify the conda channel even when default

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -364,11 +364,12 @@ if [[ "$INSTALL_MANAGER" == "CONDA" ]];
   then
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Found conda definitions at ${CONDA_DEFS}; fi
     source ${CONDA_DEFS}
-    if [[ $ECE_VERBOSE == 0 ]]; then
-	echo ... conda:
-	which conda || echo no conda
-	conda info || echo conda info failed
-    fi
+    #The next lines are useful sometimes, but excessivly verbose.
+    #if [[ $ECE_VERBOSE == 0 ]]; then
+    #  echo ... conda:
+    #  which conda || echo no conda
+    #  conda info || echo conda info failed
+    #fi
   else
     echo ... Conda definitions not found at \"${CONDA_DEFS}\"!
     echo ... \>\> Specify the location of miniconda3/etc/profile.d/conda.sh through the --conda-defs option.

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -364,6 +364,10 @@ if [[ "$INSTALL_MANAGER" == "CONDA" ]];
   then
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Found conda definitions at ${CONDA_DEFS}; fi
     source ${CONDA_DEFS}
+    if [[ $ECE_VERBOSE == 0 ]]; then
+	echo ... conda:
+	which conda || echo no conda
+    fi
   else
     echo ... Conda definitions not found at \"${CONDA_DEFS}\"!
     echo ... \>\> Specify the location of miniconda3/etc/profile.d/conda.sh through the --conda-defs option.

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -367,6 +367,7 @@ if [[ "$INSTALL_MANAGER" == "CONDA" ]];
     if [[ $ECE_VERBOSE == 0 ]]; then
 	echo ... conda:
 	which conda || echo no conda
+	conda info || echo conda info failed
     fi
   else
     echo ... Conda definitions not found at \"${CONDA_DEFS}\"!

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -491,8 +491,8 @@ if __name__ == '__main__':
       actionArgs = '--name {env} -y {src}'
       # which part of the install are we doing?
       if args.subset == 'core':
-        # no special source
-        src = ''
+        # from defaults
+        src = '-c defaults'
         addOptional = args.addOptional
         limit = ['core']
       elif args.subset == 'forge':


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #1207 

##### What are the significant changes in functionality due to this change request?
This always specifies the conda channel, since sometime the first channel is not the default.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

