### PR TITLE
Closes #1185

### DIFF
--- a/framework/Models/EnsembleModel.py
+++ b/framework/Models/EnsembleModel.py
@@ -331,9 +331,9 @@ class EnsembleModel(Dummy):
 
     for modelIn in self.modelsDictionary.keys():
       # in case there are metadataToTransfer, let's check if the source model is executed before the one that requests info
-      if self.modelsDictionary[modelIn]['metadataToTransfer']:
+      if self.modelsInputDictionary[modelIn]['metadataToTransfer']:
         indexModelIn = self.orderList.index(modelIn)
-        for metadataToGet, source, _ in self.modelsDictionary[modelIn]['metadataToTransfer']:
+        for metadataToGet, source, _ in self.modelsInputDictionary[modelIn]['metadataToTransfer']:
           if self.orderList.index(source) >= indexModelIn:
             self.raiseAnError(IOError, 'In model "'+modelIn+'" the "metadataToTransfer" named "'+metadataToGet+
                                        '" is linked to the source"'+source+'" that will be executed after this model.')
@@ -593,9 +593,9 @@ class EnsembleModel(Dummy):
         # clear the model's Target Evaluation data object
         # in case there are metadataToTransfer, let's collect them from the source
         metadataToTransfer = None
-        if self.modelsDictionary[modelIn]['metadataToTransfer']:
+        if self.modelsInputDictionary[modelIn]['metadataToTransfer']:
           metadataToTransfer = {}
-        for metadataToGet, source, alias in self.modelsDictionary[modelIn]['metadataToTransfer']:
+        for metadataToGet, source, alias in self.modelsInputDictionary[modelIn]['metadataToTransfer']:
           if metadataToGet in returnDict[source]['general_metadata']:
             metaDataValue = returnDict[source]['general_metadata'][metadataToGet]
             metaDataValue = metaDataValue[0] if len(metaDataValue) == 1 else metaDataValue

--- a/tests/framework/CodeInterfaceTests/RELAP5/tests
+++ b/tests/framework/CodeInterfaceTests/RELAP5/tests
@@ -48,7 +48,7 @@
  [./RELAP5interfaceTestAliasAndMetadataTransfer]
   type = 'RavenFramework'
   input = 'test_relap5_code_ensemble_alias_metadata.xml'
-  output = 'RELAP5ensemble2relaps/testEnsemble2Relaps/MyRELAP_restart++1/out~snc01_restart.csv RELAP5ensemble2relaps/testEnsemble2Relaps/MyRELAP_restart++2/out~snc01_restart.csv'
+  output = 'RELAP5ensemble2relaps/testEnsemble2Relaps/MyRELAP_restart++1/out~snc01_restart.csv RELAP5ensemble2relaps/testEnsemble2Relaps/MyRELAP_restart++2/out~snc01_restart.csv RELAP5ensemble2relaps/testEnsemble2Relaps/MyRELAP_restart++2/restrt RELAP5ensemble2relaps/testEnsemble2Relaps/MyRELAP_restart++1/restrt'
   test_interface_only = True
  [../]
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Closes #1185

##### What are the significant changes in functionality due to this change request?

when moved to the "model dictionary" in the ensemble model, the metadata transfer container has not been checked back. this has been fixed and the test that was testing it has been modified
 
----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

