### PR TITLE
Alfoa/issue1023

### DIFF
--- a/tests/cluster_tests/test_mpiqsub_1_proc.xml
+++ b/tests/cluster_tests/test_mpiqsub_1_proc.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" ?>
+<Simulation>
+  <TestInfo>
+    <name>cluster_tests/test_mpiqsub</name>
+    <author>alfoa</author>
+    <created>2020-04-22</created>
+    <classesTested>MPISimulationMode</classesTested>
+    <description>
+      This tests running with mpi and a qsub and test that a single
+      processor can be used (issue 1023)
+    </description>
+    <revisions>
+        <revision author="alfoa" date="2018-10-01">This is a requirement test now.</revision>
+    </revisions>
+    <requirements>R-IS-7</requirements>
+  </TestInfo>
+
+  <RunInfo>
+    <WorkingDir>.</WorkingDir>
+    <Sequence>FirstMQRun</Sequence>
+    <batchSize>1</batchSize>
+    <NumMPI>2</NumMPI>
+    <expectedTime>0:10:00</expectedTime>
+    <JobName>test_mpiqsu</JobName>
+  </RunInfo>
+
+  <Files>
+    <Input name="simple_gp_test.i" type="">simple_gp_test.i</Input>
+  </Files>
+
+  <Models>
+    <Code name="MyRAVEN" subType="RELAP7">
+      <executable>%FRAMEWORK_DIR%/../tests/cluster_tests/simple_gp.py </executable>
+    </Code>
+  </Models>
+
+  <Distributions>
+    <Normal name="Gauss1">
+      <mean>1</mean>
+      <sigma>0.001</sigma>
+      <lowerBound>0</lowerBound>
+      <upperBound>2</upperBound>
+    </Normal>
+    <Normal name="auxBackUpTimeDist">
+      <mean>1</mean>
+      <sigma>0.001</sigma>
+      <lowerBound>0</lowerBound>
+      <upperBound>2</upperBound>
+    </Normal>
+    <Normal name="Gauss2">
+      <mean>1</mean>
+      <sigma>0.4</sigma>
+      <lowerBound>0</lowerBound>
+      <upperBound>2</upperBound>
+    </Normal>
+    <Triangular name="CladFailureDist">
+      <apex>1</apex>
+      <min>-0.1</min>
+      <max>3</max>
+      <!--
+        <lowerBound>0</lowerBound>
+         This is not yet supported
+        <upperBound>2</upperBound>
+        <adjustement>up</adjustement>
+      -->
+    </Triangular>
+  </Distributions>
+
+  <Samplers>
+    <MonteCarlo name="RAVENmc6">
+      <samplerInit>
+        <limit>6</limit>
+      </samplerInit>
+    </MonteCarlo>
+  </Samplers>
+
+  <Steps>
+    <MultiRun name="FirstMQRun">
+      <Input class="Files" type="">simple_gp_test.i</Input>
+      <Model class="Models" type="Code">MyRAVEN</Model>
+      <Sampler class="Samplers" type="MonteCarlo">RAVENmc6</Sampler>
+      <Output class="DataObjects" type="HistorySet">stories</Output>
+    </MultiRun>
+  </Steps>
+
+  <DataObjects>
+    <HistorySet name="stories">
+      <Input>pipe_Area</Input>
+      <Output>pipe_Hw,pipe_Tw</Output>
+    </HistorySet>
+  </DataObjects>
+
+</Simulation>

--- a/tests/cluster_tests/test_mpiqsub_1_proc.xml
+++ b/tests/cluster_tests/test_mpiqsub_1_proc.xml
@@ -10,14 +10,13 @@
       processor can be used (issue 1023)
     </description>
     <revisions>
-        <revision author="alfoa" date="2018-10-01">This is a requirement test now.</revision>
+        <revision author="alfoa" date="2020-14-22">This test shows that issue #1023 is fixed.</revision>
     </revisions>
-    <requirements>R-IS-7</requirements>
   </TestInfo>
 
   <RunInfo>
     <WorkingDir>.</WorkingDir>
-    <Sequence>FirstMQRun</Sequence>
+    <Sequence>FirstMQ1ProcRun</Sequence>
     <batchSize>1</batchSize>
     <NumMPI>2</NumMPI>
     <expectedTime>0:10:00</expectedTime>
@@ -75,7 +74,7 @@
   </Samplers>
 
   <Steps>
-    <MultiRun name="FirstMQRun">
+    <MultiRun name="FirstMQ1ProcRun">
       <Input class="Files" type="">simple_gp_test.i</Input>
       <Model class="Models" type="Code">MyRAVEN</Model>
       <Sampler class="Samplers" type="MonteCarlo">RAVENmc6</Sampler>

--- a/tests/cluster_tests/test_mpiqsub_1_proc.xml
+++ b/tests/cluster_tests/test_mpiqsub_1_proc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <Simulation>
   <TestInfo>
-    <name>cluster_tests/test_mpiqsub</name>
+      <name>cluster_tests.test_mpiqsub_1_proc</name>
     <author>alfoa</author>
     <created>2020-04-22</created>
     <classesTested>MPISimulationMode</classesTested>
@@ -10,7 +10,7 @@
       processor can be used (issue 1023)
     </description>
     <revisions>
-        <revision author="alfoa" date="2020-14-22">This test shows that issue #1023 is fixed.</revision>
+        <revision date="2020-04-22" author="alfoa" >This test shows that issue #1023 is fixed.</revision>
     </revisions>
   </TestInfo>
 

--- a/tests/cluster_tests/test_mpiqsub_1_proc.xml
+++ b/tests/cluster_tests/test_mpiqsub_1_proc.xml
@@ -33,38 +33,6 @@
     </Code>
   </Models>
 
-  <Distributions>
-    <Normal name="Gauss1">
-      <mean>1</mean>
-      <sigma>0.001</sigma>
-      <lowerBound>0</lowerBound>
-      <upperBound>2</upperBound>
-    </Normal>
-    <Normal name="auxBackUpTimeDist">
-      <mean>1</mean>
-      <sigma>0.001</sigma>
-      <lowerBound>0</lowerBound>
-      <upperBound>2</upperBound>
-    </Normal>
-    <Normal name="Gauss2">
-      <mean>1</mean>
-      <sigma>0.4</sigma>
-      <lowerBound>0</lowerBound>
-      <upperBound>2</upperBound>
-    </Normal>
-    <Triangular name="CladFailureDist">
-      <apex>1</apex>
-      <min>-0.1</min>
-      <max>3</max>
-      <!--
-        <lowerBound>0</lowerBound>
-         This is not yet supported
-        <upperBound>2</upperBound>
-        <adjustement>up</adjustement>
-      -->
-    </Triangular>
-  </Distributions>
-
   <Samplers>
     <MonteCarlo name="RAVENmc6">
       <samplerInit>

--- a/tests/cluster_tests/tests
+++ b/tests/cluster_tests/tests
@@ -63,4 +63,12 @@
    skip = 'cluster only test'
    type = RavenFramework
  [../]
+ [./test_mpiqsub_1_proc]
+   input='test_mpiqsub_1_proc.xml pbspro_mpi.xml cluster_runinfo_legacy.xml'
+   run_types = 'qsub'
+   output = 'FirstMQRun/1/out~simple_gp_test.csv FirstMQRun/6/out~simple_gp_test.csv'
+   output_wait_time = 60
+   type = RavenFramework
+   max_time = 3600
+ [../]
 []

--- a/tests/cluster_tests/tests
+++ b/tests/cluster_tests/tests
@@ -66,7 +66,7 @@
  [./test_mpiqsub_1_proc]
    input='test_mpiqsub_1_proc.xml pbspro_mpi.xml cluster_runinfo_legacy.xml'
    run_types = 'qsub'
-   output = 'FirstMQRun/1/out~simple_gp_test.csv FirstMQRun/6/out~simple_gp_test.csv'
+   output = 'FirstMQ1ProcRun/1/out~simple_gp_test.csv FirstMQ1ProcRun/6/out~simple_gp_test.csv'
    output_wait_time = 60
    type = RavenFramework
    max_time = 3600


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Closes #1023

##### What are the significant changes in functionality due to this change request?

added a test. The issue is not valid anymore.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

