### PR TITLE
Input data work

### DIFF
--- a/framework/Distributions.py
+++ b/framework/Distributions.py
@@ -766,7 +766,9 @@ class Gamma(BoostDistribution):
   def __init__(self, low=0.0, alpha=0.0, beta=1.0):
     """
       Constructor
-      @ In, None
+      @ In, low, float, lower domain boundary
+      @ In, alpha, float, shape parameter
+      @ In, beta, float, 1/scale or the inverse scale parameter
       @ Out, None
     """
     BoostDistribution.__init__(self)

--- a/framework/Distributions.py
+++ b/framework/Distributions.py
@@ -763,16 +763,16 @@ class Gamma(BoostDistribution):
 
     return inputSpecification
 
-  def __init__(self):
+  def __init__(self, low=0.0, alpha=0.0, beta=1.0):
     """
       Constructor
       @ In, None
       @ Out, None
     """
     BoostDistribution.__init__(self)
-    self.low = 0.0
-    self.alpha = 0.0
-    self.beta = 1.0
+    self.low = low
+    self.alpha = alpha
+    self.beta = beta
     self.type = 'Gamma'
     self.disttype = 'Continuous'
     self.hasInfiniteBound = True

--- a/framework/OrthoPolynomials.py
+++ b/framework/OrthoPolynomials.py
@@ -297,15 +297,7 @@ class Hermite(OrthogonalPolynomial):
       @ In, None
       @ Out, normal, Distribution, the normal distribution
     """
-    normalElement = ET.Element("Normal")
-    element = ET.Element("mean",{})
-    element.text = "0"
-    normalElement.append(element)
-    element = ET.Element("sigma",{})
-    element.text = "1"
-    normalElement.append(element)
-    normal = Distributions.Normal()
-    normal._readMoreXML(normalElement)
+    normal = Distributions.Normal(0.0, 1.0)
     normal.initializeDistribution()
     return normal
 
@@ -356,15 +348,7 @@ class Laguerre(OrthogonalPolynomial):
       @ In, None
       @ Out, gamma, Distribution, the gamma distribution
     """
-    gammaElement = ET.Element("Gamma")
-    element = ET.Element("low",{})
-    element.text = "0"
-    gammaElement.append(element)
-    element = ET.Element("alpha",{})
-    element.text = "%s" %(self.params[0]+1)
-    gammaElement.append(element)
-    gamma = Distributions.Gamma()
-    gamma._readMoreXML(gammaElement)
+    gamma = Distributions.Gamma(0.0,self.params[0]+1)
     gamma.initializeDistribution()
     return gamma
 

--- a/framework/PostProcessorFunctions/HS2PS.py
+++ b/framework/PostProcessorFunctions/HS2PS.py
@@ -24,6 +24,7 @@ import numpy as np
 #External Modules End--------------------------------------------------------------------------------
 
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from utils import InputData, InputTypes
 
 
 class HS2PS(PostProcessorInterfaceBase):
@@ -34,6 +35,21 @@ class HS2PS(PostProcessorInterfaceBase):
    Note!!!! Here it is assumed that all histories have been sync so that they have the same length, start point and end point.
             If you are not sure, do a pre-processing the the original history set
   """
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super().getInputSpecification()
+    inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("features", contentType=InputTypes.StringListType))
+    #Should method be in super class?
+    inputSpecification.addSub(InputData.parameterInputFactory("method", contentType=InputTypes.StringType))
+    return inputSpecification
 
   def initialize(self):
     """
@@ -58,12 +74,15 @@ class HS2PS(PostProcessorInterfaceBase):
       @ In, xmlNode, ElementTree, Xml element node
       @ Out, None
     """
-    for child in xmlNode:
-      if child.tag == 'pivotParameter':
-        self.pivotParameter = child.text
-      elif child.tag == 'features':
-        self.features = child.text.split(',')
-      elif child.tag !='method':
+    paramInput = HS2PS.getInputSpecification()()
+    paramInput.parseNode(xmlNode)
+
+    for child in paramInput.subparts:
+      if child.getName() == 'pivotParameter':
+        self.pivotParameter = child.value
+      elif child.getName() == 'features':
+        self.features = child.value
+      elif child.getName() !='method':
         self.raiseAnError(IOError, 'HS2PS Interfaced Post-Processor ' + str(self.name) + ' : XML node ' + str(child) + ' is not recognized')
 
     if self.pivotParameter == None:

--- a/framework/PostProcessorFunctions/HS2PS.py
+++ b/framework/PostProcessorFunctions/HS2PS.py
@@ -45,6 +45,8 @@ class HS2PS(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.addCheckedParams({"name":"HS2PS",
+                                         "subType":"InterfacedPostProcessor"})
     inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
     inputSpecification.addSub(InputData.parameterInputFactory("features", contentType=InputTypes.StringListType))
     #Should method be in super class?

--- a/framework/PostProcessorFunctions/HS2PS.py
+++ b/framework/PostProcessorFunctions/HS2PS.py
@@ -77,7 +77,14 @@ class HS2PS(PostProcessorInterfaceBase):
     """
     paramInput = HS2PS.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
 
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
     for child in paramInput.subparts:
       if child.getName() == 'pivotParameter':
         self.pivotParameter = child.value

--- a/framework/PostProcessorFunctions/HS2PS.py
+++ b/framework/PostProcessorFunctions/HS2PS.py
@@ -23,7 +23,7 @@ import itertools
 import numpy as np
 #External Modules End--------------------------------------------------------------------------------
 
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 from utils import InputData, InputTypes
 
 
@@ -45,8 +45,7 @@ class HS2PS(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
-    inputSpecification.addCheckedParams({"name":"HS2PS",
-                                         "subType":"InterfacedPostProcessor"})
+    inputSpecification.setCheckClass(CheckInterfacePP("HS2PS"))
     inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
     inputSpecification.addSub(InputData.parameterInputFactory("features", contentType=InputTypes.StringListType))
     #Should method be in super class?

--- a/framework/PostProcessorFunctions/HS2PS.py
+++ b/framework/PostProcessorFunctions/HS2PS.py
@@ -69,16 +69,6 @@ class HS2PS(PostProcessorInterfaceBase):
     self.features     = 'all'
 
 
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = HS2PS.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
-
   def _handleInput(self, paramInput):
     """
       Function to handle the parameter input.

--- a/framework/PostProcessorFunctions/HStoPSOperator.py
+++ b/framework/PostProcessorFunctions/HStoPSOperator.py
@@ -82,6 +82,14 @@ class HStoPSOperator(PostProcessorInterfaceBase):
     """
     paramInput = HStoPSOperator.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     foundPivot = False
     for child in paramInput.subparts:

--- a/framework/PostProcessorFunctions/HStoPSOperator.py
+++ b/framework/PostProcessorFunctions/HStoPSOperator.py
@@ -26,7 +26,7 @@ import copy
 import numpy as np
 #External Modules End--------------------------------------------------------------------------------
 
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 from utils import InputData, InputTypes
 
 
@@ -48,6 +48,7 @@ class HStoPSOperator(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("HStoPSOperator"))
     inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
     inputSpecification.addSub(InputData.parameterInputFactory("row", contentType=InputTypes.FloatType))
     inputSpecification.addSub(InputData.parameterInputFactory("pivotValue", contentType=InputTypes.FloatType))

--- a/framework/PostProcessorFunctions/HStoPSOperator.py
+++ b/framework/PostProcessorFunctions/HStoPSOperator.py
@@ -74,16 +74,6 @@ class HStoPSOperator(PostProcessorInterfaceBase):
     self.pivotParameter = 'time'
     self.settings       = {'operationType':None,'operationValue':None,'pivotStrategy':'nearest'}
 
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = HStoPSOperator.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
-
   def _handleInput(self, paramInput):
     """
       Function to handle the parameter input.

--- a/framework/PostProcessorFunctions/HistorySetSampling.py
+++ b/framework/PostProcessorFunctions/HistorySetSampling.py
@@ -27,6 +27,7 @@ from scipy import interpolate
 from scipy import integrate
 import copy
 
+from utils import InputData, InputTypes
 
 class HistorySetSampling(PostProcessorInterfaceBase):
   """
@@ -34,6 +35,27 @@ class HistorySetSampling(PostProcessorInterfaceBase):
    The conversion is made so that each history H is re-sampled accordingly to a specific sampling strategy.
    It can be used to reduce the amount of space required by the HistorySet.
   """
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super().getInputSpecification()
+    HSSamplingType = InputTypes.makeEnumType("HSSampling", "HSSamplingType", ['uniform','firstDerivative','secondDerivative','filteredFirstDerivative','filteredSecondDerivative'])
+    inputSpecification.addSub(InputData.parameterInputFactory("samplingType", contentType=HSSamplingType))
+    inputSpecification.addSub(InputData.parameterInputFactory("numberOfSamples", contentType=InputTypes.IntegerType))
+    inputSpecification.addSub(InputData.parameterInputFactory("tolerance", contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
+    HSInterpolationType = InputTypes.makeEnumType("HSInterpolation", "HSInterpolationType", ['linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic', 'intervalAverage'])
+    inputSpecification.addSub(InputData.parameterInputFactory("interpolation", contentType=HSInterpolationType))
+    #Should method be in super class?
+    inputSpecification.addSub(InputData.parameterInputFactory("method", contentType=InputTypes.StringType))
+    return inputSpecification
+
   def initialize(self):
     """
      Method to initialize the Interfaced Post-processor
@@ -58,32 +80,29 @@ class HistorySetSampling(PostProcessorInterfaceBase):
       @ In, xmlNode, ElementTree, Xml element node
       @ Out, None
     """
+    paramInput = HistorySetSampling.getInputSpecification()()
+    paramInput.parseNode(xmlNode)
 
-    for child in xmlNode:
-      if child.tag == 'samplingType':
-        self.samplingType = child.text
-      elif child.tag == 'numberOfSamples':
-        self.numberOfSamples = int(child.text)
-      elif child.tag == 'tolerance':
-        self.tolerance = float(child.text)
-      elif child.tag == 'pivotParameter':
-        self.pivotParameter = child.text
-      elif child.tag == 'interpolation':
-        self.interpolation = child.text
-      elif child.tag !='method':
+    for child in paramInput.subparts:
+      if child.getName() == 'samplingType':
+        self.samplingType = child.value
+      elif child.getName() == 'numberOfSamples':
+        self.numberOfSamples = child.value
+      elif child.getName() == 'tolerance':
+        self.tolerance = child.value
+      elif child.getName() == 'pivotParameter':
+        self.pivotParameter = child.value
+      elif child.getName() == 'interpolation':
+        self.interpolation = child.value
+      elif child.getName() !='method':
         self.raiseAnError(IOError, 'HistorySetSampling Interfaced Post-Processor ' + str(self.name) + ' : XML node ' + str(child) + ' is not recognized')
 
-    if self.samplingType not in set(['uniform','firstDerivative','secondDerivative','filteredFirstDerivative','filteredSecondDerivative']):
-      self.raiseAnError(IOError, 'HistorySetSampling Interfaced Post-Processor ' + str(self.name) + ' : sampling type is not correctly specified')
     if self.pivotParameter is None:
       self.raiseAnError(IOError, 'HistorySetSampling Interfaced Post-Processor ' + str(self.name) + ' : time ID is not specified')
 
     if self.samplingType == 'uniform' or self.samplingType == 'firstDerivative' or self.samplingType == 'secondDerivative':
       if self.numberOfSamples is None or self.numberOfSamples < 0:
         self.raiseAnError(IOError, 'HistorySetSampling Interfaced Post-Processor ' + str(self.name) + ' : number of samples is not specified or less than 0')
-      if self.interpolation not in set(['linear', 'nearest', 'zero', 'slinear', 'quadratic', 'cubic', 'intervalAverage']):
-        self.raiseAnError(IOError, 'HistorySetSampling Interfaced Post-Processor ' + str(self.name) + ' : interpolation is not correctly specified; possible values: linear, nearest, zero, slinear, quadratic, cubic')
-
     if self.samplingType == 'filteredFirstDerivative' or self.samplingType == 'filteredSecondDerivative':
       if self.tolerance is  None or self.tolerance < 0.0:
         self.raiseAnError(IOError, 'HistorySetSampling Interfaced Post-Processor ' + str(self.name) + ' : tolerance is not specified or less than 0')

--- a/framework/PostProcessorFunctions/HistorySetSampling.py
+++ b/framework/PostProcessorFunctions/HistorySetSampling.py
@@ -83,6 +83,14 @@ class HistorySetSampling(PostProcessorInterfaceBase):
     """
     paramInput = HistorySetSampling.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     for child in paramInput.subparts:
       if child.getName() == 'samplingType':

--- a/framework/PostProcessorFunctions/HistorySetSampling.py
+++ b/framework/PostProcessorFunctions/HistorySetSampling.py
@@ -18,7 +18,7 @@ Created on October 28, 2015
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 
 
 import os
@@ -45,6 +45,7 @@ class HistorySetSampling(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("HistorySetSampling"))
     HSSamplingType = InputTypes.makeEnumType("HSSampling", "HSSamplingType", ['uniform','firstDerivative','secondDerivative','filteredFirstDerivative','filteredSecondDerivative'])
     inputSpecification.addSub(InputData.parameterInputFactory("samplingType", contentType=HSSamplingType))
     inputSpecification.addSub(InputData.parameterInputFactory("numberOfSamples", contentType=InputTypes.IntegerType))

--- a/framework/PostProcessorFunctions/HistorySetSampling.py
+++ b/framework/PostProcessorFunctions/HistorySetSampling.py
@@ -75,16 +75,6 @@ class HistorySetSampling(PostProcessorInterfaceBase):
     self.pivotParameter  = None
     self.interpolation   = None
 
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = HistorySetSampling.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
-
   def _handleInput(self, paramInput):
     """
       Function to handle the parameter input.

--- a/framework/PostProcessorFunctions/HistorySetSnapShot.py
+++ b/framework/PostProcessorFunctions/HistorySetSnapShot.py
@@ -18,7 +18,7 @@ Created on October 28, 2015
 
 from __future__ import division, print_function, unicode_literals, absolute_import
 
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 
 import os
 import numpy as np
@@ -48,6 +48,7 @@ class HistorySetSnapShot(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("HistorySetSnapShot"))
     HSSSTypeType = InputTypes.makeEnumType("HSSSType", "HSSSTypeType", ['min','max','average','value','timeSlice','mixed'])
     inputSpecification.addSub(InputData.parameterInputFactory("type", contentType=HSSSTypeType))
     inputSpecification.addSub(InputData.parameterInputFactory("numberOfSamples", contentType=InputTypes.IntegerType))

--- a/framework/PostProcessorFunctions/HistorySetSnapShot.py
+++ b/framework/PostProcessorFunctions/HistorySetSnapShot.py
@@ -92,16 +92,6 @@ class HistorySetSnapShot(PostProcessorInterfaceBase):
 
     self.classifiers = {} #for "mixed" mode
 
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = HistorySetSnapShot.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
-
   def _handleInput(self, paramInput):
     """
       Function to handle the parameter input.

--- a/framework/PostProcessorFunctions/HistorySetSnapShot.py
+++ b/framework/PostProcessorFunctions/HistorySetSnapShot.py
@@ -100,6 +100,14 @@ class HistorySetSnapShot(PostProcessorInterfaceBase):
     """
     paramInput = HistorySetSnapShot.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     for child in paramInput.subparts:
       tag = child.getName()

--- a/framework/PostProcessorFunctions/HistorySetSnapShot.py
+++ b/framework/PostProcessorFunctions/HistorySetSnapShot.py
@@ -155,15 +155,10 @@ class HistorySetSnapShot(PostProcessorInterfaceBase):
         self.raiseIOError(IOError,'When using "timeSlice" a "numberOfSamples" must be specified for synchronizing!')
       if self.extension is None:
         self.raiseAnError(IOError,'When using "timeSlice" an "extension" method must be specified for synchronizing!')
-      #if self.extension not in ['zeroed','extended']:
-      #  self.raiseAnError(IOError,'Unrecognized "extension" method:',self.extension)
       #perform sync
       PostProcessorInterfaces = importlib.import_module("PostProcessorInterfaces")
       self.HSsyncPP = PostProcessorInterfaces.returnPostProcessorInterface('HistorySetSync',self)
       self.HSsyncPP.initialize(self.numberOfSamples,self.pivotParameter,self.extension,syncMethod='grid')
-
-    #if self.type not in set(['min','max','average','value','timeSlice','mixed']):
-    #  self.raiseAnError(IOError, 'HistorySetSnapShot Interfaced Post-Processor "' + str(self.name) + '" : type "%s" is not recognized' %self.type)
 
   def run(self,inputDic, pivotVal=None):
     """

--- a/framework/PostProcessorFunctions/HistorySetSync.py
+++ b/framework/PostProcessorFunctions/HistorySetSync.py
@@ -27,6 +27,7 @@ import numpy as np
 #External Modules End--------------------------------------------------------------------------------
 
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from utils import InputData, InputTypes
 
 
 class HistorySetSync(PostProcessorInterfaceBase):
@@ -35,6 +36,24 @@ class HistorySetSync(PostProcessorInterfaceBase):
     The conversion is made so that all histories are syncronized in time.
     It can be used to allow the histories to be sampled at the same time instant.
   """
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super().getInputSpecification()
+    inputSpecification.addSub(InputData.parameterInputFactory("numberOfSamples", contentType=InputTypes.IntegerType))
+    HSSSyncType = InputTypes.makeEnumType("HSSSync", "HSSSyncType", ['all','grid','max','min'])
+    inputSpecification.addSub(InputData.parameterInputFactory("syncMethod", contentType=HSSSyncType))
+    inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("extension", contentType=InputTypes.StringType))
+    #Should method be in super class?
+    inputSpecification.addSub(InputData.parameterInputFactory("method", contentType=InputTypes.StringType))
+    return inputSpecification
 
   def initialize(self, numberOfSamples=None, pivotParameter=None, extension=None, syncMethod=None):
     """
@@ -60,21 +79,24 @@ class HistorySetSync(PostProcessorInterfaceBase):
       @ In, xmlNode, ElementTree, Xml element node
       @ Out, None
     """
-    for child in xmlNode:
-      if child.tag == 'numberOfSamples':
-        self.numberOfSamples = int(child.text)
-      elif child.tag == 'syncMethod':
-        self.syncMethod = child.text
-      elif child.tag == 'pivotParameter':
-        self.pivotParameter = child.text
-      elif child.tag == 'extension':
-        self.extension = child.text
-      elif child.tag !='method':
+    paramInput = HistorySetSync.getInputSpecification()()
+    paramInput.parseNode(xmlNode)
+
+    for child in paramInput.subparts:
+      if child.getName() == 'numberOfSamples':
+        self.numberOfSamples = child.value
+      elif child.getName() == 'syncMethod':
+        self.syncMethod = child.value
+      elif child.getName() == 'pivotParameter':
+        self.pivotParameter = child.value
+      elif child.getName() == 'extension':
+        self.extension = child.value
+      elif child.getName() !='method':
         self.raiseAnError(IOError, 'HistorySetSync Interfaced Post-Processor ' + str(self.name) + ' : XML node ' + str(child) + ' is not recognized')
 
-    validSyncMethods = ['all','grid','max','min']
-    if self.syncMethod not in validSyncMethods:
-      self.raiseAnError(NotImplementedError,'Method for synchronizing was not recognized: \'',self.syncMethod,'\'. Options are:',validSyncMethods)
+    #validSyncMethods = ['all','grid','max','min']
+    #if self.syncMethod not in validSyncMethods:
+    #  self.raiseAnError(NotImplementedError,'Method for synchronizing was not recognized: \'',self.syncMethod,'\'. Options are:',validSyncMethods)
     if self.syncMethod == 'grid' and not isinstance(self.numberOfSamples, int):
       self.raiseAnError(IOError, 'HistorySetSync Interfaced Post-Processor ' + str(self.name) + ' : number of samples is not correctly specified (either not specified or not integer)')
     if self.pivotParameter is None:

--- a/framework/PostProcessorFunctions/HistorySetSync.py
+++ b/framework/PostProcessorFunctions/HistorySetSync.py
@@ -93,9 +93,6 @@ class HistorySetSync(PostProcessorInterfaceBase):
       elif child.getName() !='method':
         self.raiseAnError(IOError, 'HistorySetSync Interfaced Post-Processor ' + str(self.name) + ' : XML node ' + str(child) + ' is not recognized')
 
-    #validSyncMethods = ['all','grid','max','min']
-    #if self.syncMethod not in validSyncMethods:
-    #  self.raiseAnError(NotImplementedError,'Method for synchronizing was not recognized: \'',self.syncMethod,'\'. Options are:',validSyncMethods)
     if self.syncMethod == 'grid' and not isinstance(self.numberOfSamples, int):
       self.raiseAnError(IOError, 'HistorySetSync Interfaced Post-Processor ' + str(self.name) + ' : number of samples is not correctly specified (either not specified or not integer)')
     if self.pivotParameter is None:

--- a/framework/PostProcessorFunctions/HistorySetSync.py
+++ b/framework/PostProcessorFunctions/HistorySetSync.py
@@ -82,6 +82,14 @@ class HistorySetSync(PostProcessorInterfaceBase):
     """
     paramInput = HistorySetSync.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     for child in paramInput.subparts:
       if child.getName() == 'numberOfSamples':

--- a/framework/PostProcessorFunctions/HistorySetSync.py
+++ b/framework/PostProcessorFunctions/HistorySetSync.py
@@ -26,7 +26,7 @@ import itertools
 import numpy as np
 #External Modules End--------------------------------------------------------------------------------
 
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 from utils import InputData, InputTypes
 
 
@@ -46,6 +46,7 @@ class HistorySetSync(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("HistorySetSync"))
     inputSpecification.addSub(InputData.parameterInputFactory("numberOfSamples", contentType=InputTypes.IntegerType))
     HSSSyncType = InputTypes.makeEnumType("HSSSync", "HSSSyncType", ['all','grid','max','min'])
     inputSpecification.addSub(InputData.parameterInputFactory("syncMethod", contentType=HSSSyncType))

--- a/framework/PostProcessorFunctions/HistorySetSync.py
+++ b/framework/PostProcessorFunctions/HistorySetSync.py
@@ -74,16 +74,6 @@ class HistorySetSync(PostProcessorInterfaceBase):
     self.extension       = extension
     self.syncMethod      = syncMethod
 
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = HistorySetSync.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
-
   def _handleInput(self, paramInput):
     """
       Function to handle the parameter input.

--- a/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
+++ b/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
@@ -22,7 +22,7 @@ import numpy as np
 import copy
 from collections import defaultdict
 from functools import partial
-from utils import mathUtils, utils
+from utils import mathUtils, utils, InputData, InputTypes
 
 class TypicalHistoryFromHistorySet(PostProcessorInterfaceBase):
   """
@@ -31,6 +31,22 @@ class TypicalHistoryFromHistorySet(PostProcessorInterfaceBase):
     S. WIlcox and W. Marion, "User Manual for TMY3 Data Sets," Technical Report, NREL/TP-581-43156,
     National Renewable Energy Laboratory Golden, CO, May 2008
   """
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super().getInputSpecification()
+    inputSpecification.addSub(InputData.parameterInputFactory("subseqLen", contentType=InputTypes.IntegerListType))
+    inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("outputLen", contentType=InputTypes.FloatType))
+    #Should method be in super class?
+    inputSpecification.addSub(InputData.parameterInputFactory("method", contentType=InputTypes.StringType))
+    return inputSpecification
 
   def initialize(self):
     """
@@ -52,14 +68,17 @@ class TypicalHistoryFromHistorySet(PostProcessorInterfaceBase):
       @ In, xmlNode, ElementTree, Xml element node
       @ Out, None
     """
-    self.name = xmlNode.attrib['name']
-    for child in xmlNode:
-      if child.tag == 'subseqLen':
-        self.subseqLen = list(map(int, child.text.split(',')))
-      elif child.tag == 'pivotParameter':
-        self.pivotParameter = child.text
-      elif child.tag == 'outputLen':
-        self.outputLen = float(child.text)
+    paramInput = TypicalHistoryFromHistorySet.getInputSpecification()()
+    paramInput.parseNode(xmlNode)
+
+    self.name = paramInput.parameterValues['name']
+    for child in paramInput.subparts:
+      if child.getName() == 'subseqLen':
+        self.subseqLen = child.value
+      elif child.getName() == 'pivotParameter':
+        self.pivotParameter = child.value
+      elif child.getName() == 'outputLen':
+        self.outputLen = child.value
 
     # checks
     if not hasattr(self, 'pivotParameter'):

--- a/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
+++ b/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
@@ -17,7 +17,7 @@
 '''
 from __future__ import division, print_function, unicode_literals, absolute_import
 
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 import numpy as np
 import copy
 from collections import defaultdict
@@ -41,6 +41,7 @@ class TypicalHistoryFromHistorySet(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("TypicalHistoryFromHistorySet"))
     inputSpecification.addSub(InputData.parameterInputFactory("subseqLen", contentType=InputTypes.IntegerListType))
     inputSpecification.addSub(InputData.parameterInputFactory("pivotParameter", contentType=InputTypes.StringType))
     inputSpecification.addSub(InputData.parameterInputFactory("outputLen", contentType=InputTypes.FloatType))

--- a/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
+++ b/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
@@ -63,16 +63,6 @@ class TypicalHistoryFromHistorySet(PostProcessorInterfaceBase):
     if not hasattr(self, 'outputLen'):
       self.outputLen = None
 
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = TypicalHistoryFromHistorySet.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
-
   def _handleInput(self, paramInput):
     """
       Function to handle the parameter input.

--- a/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
+++ b/framework/PostProcessorFunctions/TypicalHistoryFromHistorySet.py
@@ -71,6 +71,14 @@ class TypicalHistoryFromHistorySet(PostProcessorInterfaceBase):
     """
     paramInput = TypicalHistoryFromHistorySet.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     self.name = paramInput.parameterValues['name']
     for child in paramInput.subparts:

--- a/framework/PostProcessorFunctions/dataObjectLabelFilter.py
+++ b/framework/PostProcessorFunctions/dataObjectLabelFilter.py
@@ -23,11 +23,30 @@ import numpy as np
 from scipy import interpolate
 import copy
 
+from utils import InputData, InputTypes
 
 class dataObjectLabelFilter(PostProcessorInterfaceBase):
   """
    This Post-Processor filters out the points or histories accordingly to a chosen clustering label
   """
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super().getInputSpecification()
+    DOLFDataTypeType = InputTypes.makeEnumType("DOLFDataType", "DOLFDataTypeType", ['HistorySet','PointSet'])
+    inputSpecification.addSubSimple("dataType", DOLFDataTypeType)
+    inputSpecification.addSubSimple("label", InputTypes.StringType)
+    inputSpecification.addSubSimple("clusterIDs", InputTypes.IntegerListType)
+    #Should method be in super class?
+    inputSpecification.addSubSimple("method", contentType=InputTypes.StringType)
+    return inputSpecification
+
   def initialize(self):
     """
      Method to initialize the Interfaced Post-processor
@@ -49,22 +68,23 @@ class dataObjectLabelFilter(PostProcessorInterfaceBase):
       @ In, xmlNode, ElementTree, Xml element node
       @ Out, None
     """
+    paramInput = dataObjectLabelFilter.getInputSpecification()()
+    paramInput.parseNode(xmlNode)
 
-    for child in xmlNode:
-      if child.tag == 'dataType':
-        dataType = child.text
+    for child in paramInput.subparts:
+      if child.getName() == 'dataType':
+        dataType = child.value
         if dataType in set(['HistorySet','PointSet']):
           self.inputFormat  = dataType
           self.outputFormat = dataType
         else:
           self.raiseAnError(IOError, 'dataObjectLabelFilter Interfaced Post-Processor ' + str(self.name) + ' : dataType ' + str(dataType) + ' is not recognized (available are HistorySet, PointSet)')
-      elif child.tag == 'label':
-        self.label = child.text
-      elif child.tag == 'clusterIDs':
-        for clusterID in child.text.split(','):
-          clusterID = clusterID.strip()
-          self.clusterIDs.append(int(clusterID))
-      elif child.tag !='method':
+      elif child.getName() == 'label':
+        self.label = child.value
+      elif child.getName() == 'clusterIDs':
+        for clusterID in child.value:
+          self.clusterIDs.append(clusterID)
+      elif child.getName() !='method':
         self.raiseAnError(IOError, 'dataObjectLabelFilter Interfaced Post-Processor ' + str(self.name) + ' : XML node ' + str(child) + ' is not recognized')
 
   def run(self,inputDic):

--- a/framework/PostProcessorFunctions/dataObjectLabelFilter.py
+++ b/framework/PostProcessorFunctions/dataObjectLabelFilter.py
@@ -17,7 +17,7 @@ Created on October 28, 2015
 """
 
 from __future__ import division, print_function, unicode_literals, absolute_import
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 import os
 import numpy as np
 from scipy import interpolate
@@ -39,6 +39,7 @@ class dataObjectLabelFilter(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("dataObjectLabelFilter"))
     DOLFDataTypeType = InputTypes.makeEnumType("DOLFDataType", "DOLFDataTypeType", ['HistorySet','PointSet'])
     inputSpecification.addSubSimple("dataType", DOLFDataTypeType)
     inputSpecification.addSubSimple("label", InputTypes.StringType)

--- a/framework/PostProcessorFunctions/dataObjectLabelFilter.py
+++ b/framework/PostProcessorFunctions/dataObjectLabelFilter.py
@@ -63,16 +63,6 @@ class dataObjectLabelFilter(PostProcessorInterfaceBase):
     self.label        = None
     self.clusterIDs   = []
 
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = dataObjectLabelFilter.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
-
   def _handleInput(self, paramInput):
     """
       Function to handle the parameter input.

--- a/framework/PostProcessorFunctions/dataObjectLabelFilter.py
+++ b/framework/PostProcessorFunctions/dataObjectLabelFilter.py
@@ -71,6 +71,14 @@ class dataObjectLabelFilter(PostProcessorInterfaceBase):
     """
     paramInput = dataObjectLabelFilter.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     for child in paramInput.subparts:
       if child.getName() == 'dataType':

--- a/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
+++ b/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
@@ -25,7 +25,7 @@ import numpy as np
 import copy
 #External Modules End--------------------------------------------------------------------------------
 
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 from utils import InputData, InputTypes
 
 class riskMeasuresDiscrete(PostProcessorInterfaceBase):
@@ -47,6 +47,7 @@ class riskMeasuresDiscrete(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("riskMeasuresDiscrete"))
     inputSpecification.addSubSimple("measures", InputTypes.StringListType)
     variableSub = InputData.parameterInputFactory("variable", contentType=InputTypes.StringType)
     variableSub.addParam("R0values", InputTypes.FloatListType)

--- a/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
+++ b/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
@@ -34,7 +34,6 @@ class riskMeasuresDiscrete(PostProcessorInterfaceBase):
     This class inherits form the base class PostProcessorInterfaceBase and it contains three methods:
       - initialize
       - run
-      - readMoreXML
   """
   _availableMeasures = set(['B','FV','RAW','RRW','R0'])
   @classmethod
@@ -81,17 +80,6 @@ class riskMeasuresDiscrete(PostProcessorInterfaceBase):
     PostProcessorInterfaceBase.initialize(self)
     self.inputFormat  = 'PointSet|HistorySet'
     self.outputFormat = 'PointSet'
-
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-
-    paramInput = riskMeasuresDiscrete.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
 
   def _handleInput(self, paramInput):
     """

--- a/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
+++ b/framework/PostProcessorFunctions/riskMeasuresDiscrete.py
@@ -91,6 +91,14 @@ class riskMeasuresDiscrete(PostProcessorInterfaceBase):
 
     paramInput = riskMeasuresDiscrete.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     self.variables = {}
     self.target    = {}

--- a/framework/PostProcessorFunctions/testInterfacedPP.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP.py
@@ -22,6 +22,7 @@ import itertools
 import numpy as np
 
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from utils import InputData, InputTypes
 
 class testInterfacedPP(PostProcessorInterfaceBase):
   """ This class represents the most basic interfaced post-processor
@@ -30,6 +31,19 @@ class testInterfacedPP(PostProcessorInterfaceBase):
       - run
       - readMoreXML
   """
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super().getInputSpecification()
+    inputSpecification.addSubSimple("xmlNodeExample", InputTypes.StringType)
+    inputSpecification.addSubSimple("method", InputTypes.StringType)
+    return inputSpecification
 
   def initialize(self):
     """
@@ -67,6 +81,9 @@ class testInterfacedPP(PostProcessorInterfaceBase):
       @ In, xmlNode, ElementTree, Xml element node
       @ Out, None
     """
-    for child in xmlNode:
-      if child.tag == 'xmlNodeExample':
-        self.xmlNodeExample = child.text
+    paramInput = testInterfacedPP.getInputSpecification()()
+    paramInput.parseNode(xmlNode)
+
+    for child in paramInput.subparts:
+      if child.getName() == 'xmlNodeExample':
+        self.xmlNodeExample = child.value

--- a/framework/PostProcessorFunctions/testInterfacedPP.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP.py
@@ -29,7 +29,6 @@ class testInterfacedPP(PostProcessorInterfaceBase):
       This class inherits form the base class PostProcessorInterfaceBase and it contains the three methods that need to be implemented:
       - initialize
       - run
-      - readMoreXML
   """
   @classmethod
   def getInputSpecification(cls):
@@ -75,16 +74,6 @@ class testInterfacedPP(PostProcessorInterfaceBase):
       for key in inputDict['metaKeys']:
         outputDict['data'][key] = inputDict['data'][key]
       return outputDict
-
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = testInterfacedPP.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
 
   def _handleInput(self, paramInput):
     """

--- a/framework/PostProcessorFunctions/testInterfacedPP.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP.py
@@ -21,7 +21,7 @@ import copy
 import itertools
 import numpy as np
 
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 from utils import InputData, InputTypes
 
 class testInterfacedPP(PostProcessorInterfaceBase):
@@ -41,6 +41,7 @@ class testInterfacedPP(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("testInterfacedPP"))
     inputSpecification.addSubSimple("xmlNodeExample", InputTypes.StringType)
     inputSpecification.addSubSimple("method", InputTypes.StringType)
     return inputSpecification

--- a/framework/PostProcessorFunctions/testInterfacedPP.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP.py
@@ -84,6 +84,14 @@ class testInterfacedPP(PostProcessorInterfaceBase):
     """
     paramInput = testInterfacedPP.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     for child in paramInput.subparts:
       if child.getName() == 'xmlNodeExample':

--- a/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
@@ -19,6 +19,7 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 
 import copy
 from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from utils import InputData, InputTypes
 
 class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
   """ This class represents the most basic interfaced post-processor
@@ -27,6 +28,19 @@ class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
       - run
       - readMoreXML
   """
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super().getInputSpecification()
+    inputSpecification.addSubSimple("xmlNodeExample", InputTypes.StringType)
+    inputSpecification.addSubSimple("method", InputTypes.StringType)
+    return inputSpecification
 
   def initialize(self):
     """
@@ -65,6 +79,9 @@ class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
       @ In, xmlNode, ElementTree, Xml element node
       @ Out, None
     """
-    for child in xmlNode:
-      if child.tag == 'xmlNodeExample':
-        self.xmlNodeExample = child.text
+    paramInput = testInterfacedPP_PointSet.getInputSpecification()()
+    paramInput.parseNode(xmlNode)
+
+    for child in paramInput.subparts:
+      if child.getName() == 'xmlNodeExample':
+        self.xmlNodeExample = child.value

--- a/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
@@ -82,6 +82,14 @@ class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
     """
     paramInput = testInterfacedPP_PointSet.getInputSpecification()()
     paramInput.parseNode(xmlNode)
+    self._handleInput(paramInput)
+
+  def _handleInput(self, paramInput):
+    """
+      Function to handle the parameter input.
+      @ In, paramInput, ParameterInput, the already parsed input.
+      @ Out, None
+    """
 
     for child in paramInput.subparts:
       if child.getName() == 'xmlNodeExample':

--- a/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
@@ -26,7 +26,6 @@ class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
       This class inherits form the base class PostProcessorInterfaceBase and it contains the three methods that need to be implemented:
       - initialize
       - run
-      - readMoreXML
   """
   @classmethod
   def getInputSpecification(cls):
@@ -73,16 +72,6 @@ class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
       for key in inputDict['metaKeys']:
         outputDict['data'][key] = inputDict['data'][key]
       return outputDict
-
-  def readMoreXML(self,xmlNode):
-    """
-      Function that reads elements this post-processor will use
-      @ In, xmlNode, ElementTree, Xml element node
-      @ Out, None
-    """
-    paramInput = testInterfacedPP_PointSet.getInputSpecification()()
-    paramInput.parseNode(xmlNode)
-    self._handleInput(paramInput)
 
   def _handleInput(self, paramInput):
     """

--- a/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
+++ b/framework/PostProcessorFunctions/testInterfacedPP_PointSet.py
@@ -18,7 +18,7 @@ Created on December 1, 2015
 from __future__ import division, print_function, unicode_literals, absolute_import
 
 import copy
-from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase
+from PostProcessorInterfaceBaseClass import PostProcessorInterfaceBase, CheckInterfacePP
 from utils import InputData, InputTypes
 
 class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
@@ -38,6 +38,7 @@ class testInterfacedPP_PointSet(PostProcessorInterfaceBase):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
+    inputSpecification.setCheckClass(CheckInterfacePP("testInterfacedPP_PointSet"))
     inputSpecification.addSubSimple("xmlNodeExample", InputTypes.StringType)
     inputSpecification.addSubSimple("method", InputTypes.StringType)
     return inputSpecification

--- a/framework/PostProcessorInterfaceBaseClass.py
+++ b/framework/PostProcessorInterfaceBaseClass.py
@@ -27,6 +27,7 @@ import numpy as np
 from utils.cached_ndarray import c1darray
 from utils import utils
 import MessageHandler
+from utils import InputData, InputTypes
 #Internal Modules End--------------------------------------------------------------------------------
 
 class PostProcessorInterfaceBase(utils.metaclass_insert(abc.ABCMeta,object),MessageHandler.MessageUser):
@@ -37,6 +38,21 @@ class PostProcessorInterfaceBase(utils.metaclass_insert(abc.ABCMeta,object),Mess
       - run
       - readMoreXML
   """
+
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = InputData.parameterInputFactory(cls.__name__, ordered=False)
+    inputSpecification.addParam("subType", InputTypes.StringType)
+    inputSpecification.addParam("name", InputTypes.StringType)
+
+    return inputSpecification
 
   def __init__(self, messageHandler):
     """

--- a/framework/PostProcessorInterfaceBaseClass.py
+++ b/framework/PostProcessorInterfaceBaseClass.py
@@ -25,10 +25,52 @@ import numpy as np
 
 #Internal Modules------------------------------------------------------------------------------------
 from utils.cached_ndarray import c1darray
-from utils import utils
+from utils import utils, InputData
 import MessageHandler
 from utils import InputData, InputTypes
 #Internal Modules End--------------------------------------------------------------------------------
+
+class CheckInterfacePP(InputData.CheckClass):
+  """
+  Checks that this is an Interface Post Processor of a given type
+  """
+  def __init__(self, name):
+    """
+      Creates a CheckInterfacePP class
+      @ In, name, string, the method name
+      @ Out, None
+    """
+    self.name = name
+    self.__reason = ""
+
+  def check(self, node):
+    """
+      Checks the node to see if it matches the checkDict
+      @ In, node, xml node to check
+      @ Out, bool, true if matches
+    """
+    self.__reason = ""
+    passed = "subType" in node.attrib and node.attrib["subType"] == "InterfacedPostProcessor"
+    if not passed:
+      self.__reason = "subType=InterfacedPostProcessor not in attribs"
+    methods = node.findall("method")
+    if len(methods) == 1:
+      match = methods[0].text == self.name
+      if not match:
+        self.__reason += ""+repr(methods[0].text)+ "!=" + self.name + " "
+      passed = passed and match
+    else:
+      self.__reason += "wrong number of method blocks "+str(len(methods))+" "
+      passed = False
+    return passed
+
+  def failCheckReason(self, node):
+    """
+      returns a string about why the check failed
+      @ In, node, xml node to check
+      @ Out, string, message for user about why check failed.
+    """
+    return self.__reason
 
 class PostProcessorInterfaceBase(utils.metaclass_insert(abc.ABCMeta,object),MessageHandler.MessageUser):
   """

--- a/framework/PostProcessorInterfaceBaseClass.py
+++ b/framework/PostProcessorInterfaceBaseClass.py
@@ -91,6 +91,7 @@ class PostProcessorInterfaceBase(utils.metaclass_insert(abc.ABCMeta,object),Mess
         specifying input of cls.
     """
     inputSpecification = InputData.parameterInputFactory(cls.__name__, ordered=False)
+    inputSpecification.setCheckClass(CheckInterfacePP("PostProcessorInterfaceBaseClass"))
     inputSpecification.addParam("subType", InputTypes.StringType)
     inputSpecification.addParam("name", InputTypes.StringType)
 

--- a/framework/PostProcessorInterfaces.py
+++ b/framework/PostProcessorInterfaces.py
@@ -55,6 +55,14 @@ for moduleIndex in range(len(__moduleInterfaceList)):
         __interFaceDict[key] = modClass
 __knownTypes = list(__interFaceDict.keys())
 
+def interfaceClasses():
+  """
+    This returns the classes available
+    @ In, None
+    @ Out, interfaceClasses, list of classes available
+  """
+  return list(__interFaceDict.values())
+
 def knownTypes():
   """
     This function returns the types of interfaced post-processors available

--- a/framework/PostProcessors/InterfacedPostProcessor.py
+++ b/framework/PostProcessors/InterfacedPostProcessor.py
@@ -112,12 +112,8 @@ class InterfacedPostProcessor(PostProcessor):
     # paramInput.parseNode(xmlNode)
 
     interfaceClasses = [c.getInputSpecification() for c in InterfacedPostProcessor.PostProcessorInterfaces.interfaceClasses()]
-    #print(interfaceClasses,[c.getName() for c in interfaceClasses])
     paramInput = InputData.parseFromList(xmlNode, interfaceClasses)
 
-    #for child in xmlNode:
-    #  if child.tag == 'method':
-    #    self.methodToRun = child.text
     self.methodToRun = paramInput.getName()
     self.postProcessor = InterfacedPostProcessor.PostProcessorInterfaces.returnPostProcessorInterface(self.methodToRun,self)
     if not isinstance(self.postProcessor,PostProcessorInterfaceBase):
@@ -125,7 +121,6 @@ class InterfacedPostProcessor(PostProcessor):
                         ' : not correctly coded; it must inherit the PostProcessorInterfaceBase class')
 
     self.postProcessor.initialize()
-    #self.postProcessor.readMoreXML(xmlNode)
     self.postProcessor._handleInput(paramInput)
     if not set(self.returnFormat("input").split("|")) <= set(['HistorySet','PointSet']):
       self.raiseAnError(IOError,'InterfacedPostProcessor Post-Processor '+ self.name +

--- a/framework/PostProcessors/InterfacedPostProcessor.py
+++ b/framework/PostProcessors/InterfacedPostProcessor.py
@@ -38,6 +38,7 @@ from utils import utils
 from utils import mathUtils
 from utils import xmlUtils
 from utils.RAVENiterators import ravenArrayIterator
+from utils import InputData
 import DataObjects
 from Assembler import Assembler
 import LearningGate
@@ -110,16 +111,22 @@ class InterfacedPostProcessor(PostProcessor):
     # paramInput = InterfacedPostProcessor.getInputSpecification()()
     # paramInput.parseNode(xmlNode)
 
-    for child in xmlNode:
-      if child.tag == 'method':
-        self.methodToRun = child.text
+    interfaceClasses = [c.getInputSpecification() for c in InterfacedPostProcessor.PostProcessorInterfaces.interfaceClasses()]
+    #print(interfaceClasses,[c.getName() for c in interfaceClasses])
+    paramInput = InputData.parseFromList(xmlNode, interfaceClasses)
+
+    #for child in xmlNode:
+    #  if child.tag == 'method':
+    #    self.methodToRun = child.text
+    self.methodToRun = paramInput.getName()
     self.postProcessor = InterfacedPostProcessor.PostProcessorInterfaces.returnPostProcessorInterface(self.methodToRun,self)
     if not isinstance(self.postProcessor,PostProcessorInterfaceBase):
       self.raiseAnError(IOError, 'InterfacedPostProcessor Post-Processor '+ self.name +
                         ' : not correctly coded; it must inherit the PostProcessorInterfaceBase class')
 
     self.postProcessor.initialize()
-    self.postProcessor.readMoreXML(xmlNode)
+    #self.postProcessor.readMoreXML(xmlNode)
+    self.postProcessor._handleInput(paramInput)
     if not set(self.returnFormat("input").split("|")) <= set(['HistorySet','PointSet']):
       self.raiseAnError(IOError,'InterfacedPostProcessor Post-Processor '+ self.name +
                         ' : self.inputFormat not correctly initialized')

--- a/framework/Samplers/Sampler.py
+++ b/framework/Samplers/Sampler.py
@@ -81,6 +81,10 @@ class Sampler(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
         descr=r"""for an NDDistribution, indicates the dimension within the NDDistribution that corresponds
               to this variable.""")
     variableInput.addSub(distributionInput)
+    gridInput = InputData.parameterInputFactory("grid", contentType=InputTypes.StringType)
+    gridInput.addParam("type", InputTypes.StringType)
+    gridInput.addParam("construction", InputTypes.StringType)
+    variableInput.addSub(gridInput)
     functionInput = InputData.parameterInputFactory("function", contentType=InputTypes.StringType,
         descr=r"""name of the function that
               defines the calculation of this variable from other distributed variables.  Its name

--- a/framework/Samplers/Sampler.py
+++ b/framework/Samplers/Sampler.py
@@ -84,6 +84,7 @@ class Sampler(utils.metaclass_insert(abc.ABCMeta,BaseType),Assembler):
     gridInput = InputData.parameterInputFactory("grid", contentType=InputTypes.StringType)
     gridInput.addParam("type", InputTypes.StringType)
     gridInput.addParam("construction", InputTypes.StringType)
+    gridInput.addParam("steps", InputTypes.IntegerType)
     variableInput.addSub(gridInput)
     functionInput = InputData.parameterInputFactory("function", contentType=InputTypes.StringType,
         descr=r"""name of the function that

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -176,6 +176,18 @@ class ParameterInput(object):
            sub.getName()," in ",cls.getName())
 
   @classmethod
+  def addSubSimple(cls, name, contentType, quantity=Quantity.zero_to_infinity):
+    """
+      Adds a subnode to this class.
+      @ In, name, String, the name of the subnode
+      @ In, contentType, InputTypes.InputType
+      @ In, quantity, value in Quantity, the number of this subnode to allow.
+      @ Out, None
+    """
+    cls.addSub(parameterInputFactory(name, contentType=contentType),
+               quantity)
+
+  @classmethod
   def removeSub(cls, sub):
     """
       Removes a subnode from this class.

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -152,10 +152,10 @@ class ParameterInput(object):
   @classmethod
   def removeParam(cls, name, param_type=InputTypes.StringType, required=False):
     """
-      Adds a direct parameter to this class.  In XML this is an attribute.
+      Removes a direct parameter to this class.  In XML this is an attribute.
       @ In, name, string, the name of the parameter
-      @ In, param_type, subclass of InputTypes.InputType, optional, that specifies the type of the attribute.
-      @ In, required, bool, optional, if True, this parameter is required.
+      @ In, param_type, subclass of InputTypes.InputType, optional, that specifies the type of the attribute. UNUSED
+      @ In, required, bool, optional, if True, this parameter is required. UNUSED
       @ Out, None
     """
     del cls.parameters[name]

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -60,6 +60,9 @@ class CheckClass(object):
     return "Check failed"
 
 class CheckParams(CheckClass):
+  """
+    Checks that some parameters exist in the class
+  """
 
   def __init__(self, checkDict):
     """

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -397,13 +397,6 @@ class ParameterInput(object):
       subs = self.subs
     # read in subnodes
     subNames = set()
-    #for sub in subs:
-    #  subName = sub.getName()
-    #  subNames.add(subName)
-    #  for subNode in node.findall(subName):
-    #    subInstance = sub()
-    #    subInstance.parseNode(subNode, errorList)
-    #    self.subparts.append(subInstance)
     for child in node:
       childName = child.tag
       subsSet = self._subDict.get(childName,set())
@@ -640,7 +633,6 @@ def parseFromList(node, inputList):
   """
   paramInput = None
   for inputClass in inputList:
-    #print(node.tag, inputClass.getName(), inputClass._checkCanRead is None or  inputClass._checkCanRead.check(node))
     if inputClass._checkCanRead is None or inputClass._checkCanRead.check(node):
       paramInput = inputClass()
       paramInput.parseNode(node)

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -359,7 +359,7 @@ class ParameterInput(object):
         self.subparts.append(subInstance)
       elif self.strictMode:
         allowed = [s.getName() for s in subs]
-        handleError('no class to handle '+str(child)+' tried '+str(subsSet)+" allowed:"+str(allowed)) #Extra if debugging: + ' keys: '+str(set(self._subDict.keys()))+ str({k: [j.getName() for j in self._subDict[k]] for k in self._subDict.keys()}))
+        handleError('no class to handle '+childName+' tried '+str(subsSet)+" allowed:"+str(allowed)) #Extra if debugging: + ' keys: '+str(set(self._subDict.keys()))+ str({k: [j.getName() for j in self._subDict[k]] for k in self._subDict.keys()}))
     if self.strictMode:
       nodeNames = set([child.tag for child in node])
       if nodeNames != subNames:

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -38,14 +38,14 @@ class Quantity:
 
 class CheckClass(object):
   """
-  This checks to figure out if a node is a ParameterInput type
-  If the check passes, then it is.
+    This checks to figure out if a node is a ParameterInput type
+    If the check passes, then it is.
   """
 
   def check(self, node):
     """
       Checks the node to see if it matches the checkDict
-      @ In, node, xml node to check
+      @ In, node, xml.etree.ElementTree.Element, xml node to check
       @ Out, bool, true if matches
     """
     assert False, "check function not implemented"
@@ -54,7 +54,7 @@ class CheckClass(object):
   def failCheckReason(self, node):
     """
       returns a string about why the check failed
-      @ In, node, xml node to check
+      @ In, node, xml.etree.ElementTree.Element, xml node to check
       @ Out, string, message for user about why check failed.
     """
     return "Check failed"

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -629,6 +629,24 @@ def assemblyInputFactory(*paramList, **paramDict):
       descr=r"""RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)""")
   return newClass
 
+def parseFromList(node, inputList):
+  """
+    Try all the ParameterInput classes in the inputList and parse the node
+    with the first that passes.
+    @ In, node, xml.etree.Element to parse
+    @ In, inputList, list of ParameterInput to try and parse node with
+    @ Out, paramInput, a ParameterInput instance or None if none found in the
+     list
+  """
+  paramInput = None
+  for inputClass in inputList:
+    #print(node.tag, inputClass.getName(), inputClass._checkCanRead is None or  inputClass._checkCanRead.check(node))
+    if inputClass._checkCanRead is None or inputClass._checkCanRead.check(node):
+      paramInput = inputClass()
+      paramInput.parseNode(node)
+      return paramInput
+  return paramInput
+
 def createXSD(outerElement):
   """
     Creates an XSD element.

--- a/framework/utils/InputTypes.py
+++ b/framework/utils/InputTypes.py
@@ -151,7 +151,9 @@ class IntegerType(InputType):
       @ Out, convert, int, the converted value
     """
     if mathUtils.isAString(value):
-      value = float(value)
+      value = float(value) #XXX Is this a bug?
+      #(tho' this does allow converting something like "1.0" to an integer,
+      #but that would fail the xsd check.)
     return int(value)
 
 IntegerType.createClass("integer", "xsd:integer")

--- a/tests/framework/TestXSD/TestStrictCheck.py
+++ b/tests/framework/TestXSD/TestStrictCheck.py
@@ -60,7 +60,7 @@ print(errors)
 
 checkAnswer('Required parameter required_string not in inner', errors[0])
 checkAnswer('no_such_element not in attributes and strict mode on in inner', errors[1])
-checkAnswer('Childs \"[no_such_sub]\" not allowed as sub-elements of \"ordered\"', errors[2])
+checkAnswer("no class to handle no_such_sub tried set() allowed:['sub_1', 'sub_2', 'sub_3', 'sub_bool']", errors[2])
 
 print("passes",passFails[0],"fails",passFails[1])
 sys.exit(passFails[1])


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? #84 
Ref. #936

##### What are the significant changes in functionality due to this change request?
Converting code to use InputData.
This includes adding support for ParameterInput classes to have a check class that can see if a ParameterInput can parse a given xml node.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

