### PR TITLE
Closes #1277

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -316,10 +316,7 @@ if [ -z $PYTHON_COMMAND ];
 then
     # check the RC file first
     PYTHON_COMMAND=$(read_ravenrc "PYTHON_COMMAND")
-    local_py_command=python3
-    if ! python_com="$(type -p python3)" || [[ -z $python_com ]]; then
-      local_py_command=python
-    fi
+    local_py_command=python
     #If not found through the RC file, will be empty string, so default python
     PYTHON_COMMAND=${PYTHON_COMMAND:=$local_py_command}
 fi

--- a/scripts/library_report
+++ b/scripts/library_report
@@ -1,4 +1,3 @@
-si
 #!/usr/bin/env python
 from __future__ import print_function
 import sys, os, subprocess, re

--- a/scripts/library_report
+++ b/scripts/library_report
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+si
+#!/usr/bin/env python
 from __future__ import print_function
 import sys, os, subprocess, re
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1277

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

