### PR TITLE
Alfoa/no realization batching

### DIFF
--- a/framework/DataObjects/DataObject.py
+++ b/framework/DataObjects/DataObject.py
@@ -405,14 +405,17 @@ class DataObject(utils.metaclass_insert(abc.ABCMeta,BaseType)):
     pass
 
   @abc.abstractmethod
-  def realization(self,index=None,matchDict=None,tol=1e-15):
+  def realization(self,index=None, matchDict=None, noMatchDict=None, tol=1e-15, unpackXArray=False, options = None):
     """
       Method to obtain a realization from the data, either by index or matching value.
       Either "index" or "matchDict" must be supplied.
       If matchDict and no match is found, will return (len(self),None) after the pattern of numpy, scipy
       @ In, index, int, optional, number of row to retrieve (by index, not be "sample")
       @ In, matchDict, dict, optional, {key:val} to search for matches
+      @ In, noMatchDict, dict, optional, {key:val} to search for antimatches (vars should NOT match vals within tolerance)
       @ In, tol, float, optional, tolerance to which match should be made
+      @ In, unpackXArray, bool, optional, True if the coordinates of the xarray variables must be exposed in the dict (e.g. if P(t) => {P:ndarray, t:ndarray}) (valid only for dataset)
+      @ In, options, dict, optional, options to be applied to the search
       @ Out, index, int, optional, index where found (or len(self) if not found), only returned if matchDict
       @ Out, rlz, dict, realization requested (None if not found)
     """

--- a/framework/DataObjects/DataObject.py
+++ b/framework/DataObjects/DataObject.py
@@ -405,10 +405,10 @@ class DataObject(utils.metaclass_insert(abc.ABCMeta,BaseType)):
     pass
 
   @abc.abstractmethod
-  def realization(self,index=None, matchDict=None, noMatchDict=None, tol=1e-15, unpackXArray=False, options = None):
+  def realization(self, index=None, matchDict=None, noMatchDict=None, tol=1e-15, unpackXArray=False, asDataSet = False, options = None):
     """
       Method to obtain a realization from the data, either by index or matching value.
-      Either "index" or "matchDict" must be supplied.
+      Either "index" or one of ("matchDict", "noMatchDict") must be supplied.
       If matchDict and no match is found, will return (len(self),None) after the pattern of numpy, scipy
       @ In, index, int, optional, number of row to retrieve (by index, not be "sample")
       @ In, matchDict, dict, optional, {key:val} to search for matches

--- a/framework/DataObjects/DataSet.py
+++ b/framework/DataObjects/DataSet.py
@@ -577,7 +577,8 @@ class DataSet(DataObject):
           if numInCollector > 0:
             index, rlz = self._getRealizationFromCollectorByValue(matchDict, noMatchDict, tol=tol, options=options)
       # add index map where necessary
-      rlz = self._addIndexMapToRlz(rlz)
+      for rl in (rlz if type(rlz).__name__ in "list" else [rlz]):
+        rl = self._addIndexMapToRlz(rl)
       if asDataSet:
         if type(rlz).__name__ in "list":
           d = {}
@@ -1588,7 +1589,7 @@ class DataSet(DataObject):
     matchVars, matchVals = zip(*toMatch.items()) if toMatch else ([], [])
     avoidVars, avoidVals = zip(*noMatch.items()) if noMatch else ([], [])
     matchIndices = tuple(self._orderedVars.index(var) for var in matchVars)
-    matchIndices, matchRlz = [], [] # used if allMatch == True
+    if allMatch: matchIndices, matchRlz = [], [] # used if allMatch == True
     for r, row in enumerate(self._collector[:]):
       match = True
       # find matches first

--- a/framework/DataObjects/DataSet.py
+++ b/framework/DataObjects/DataSet.py
@@ -506,7 +506,7 @@ class DataSet(DataObject):
     self._setScalingFactors()
 
   # @profile
-  def realization(self, index=None, matchDict=None, noMatchDict=None, tol=1e-15, unpackXArray=False, asDataSet = False):
+  def realization(self, index=None, matchDict=None, noMatchDict=None, tol=1e-15, unpackXArray=False, asDataSet = False, options = None):
     """
       Method to obtain a realization from the data, either by index or matching value.
       Either "index" or one of ("matchDict", "noMatchDict") must be supplied.
@@ -516,6 +516,7 @@ class DataSet(DataObject):
       @ In, noMatchDict, dict, optional, {key:val} to search for antimatches (vars should NOT match vals within tolerance)
       @ In, tol, float, optional, tolerance to which match should be made
       @ In, unpackXArray, bool, optional, True if the coordinates of the xarray variables must be exposed in the dict (e.g. if P(t) => {P:ndarray, t:ndarray}) (valid only for dataset)
+      @ In, options, dict, optional, options to be applied to the search
       @ Out, index, int, optional, index where found (or len(self) if not found), only returned if matchDict
       @ Out, rlz, dict, realization requested (None if not found)
     """
@@ -567,14 +568,14 @@ class DataSet(DataObject):
           return 0, None
         # otherwise, get it from the collector
         else:
-          index, rlz = self._getRealizationFromCollectorByValue(matchDict, noMatchDict, tol=tol)
+          index, rlz = self._getRealizationFromCollectorByValue(matchDict, noMatchDict, tol=tol, options=options)
       # otherwise, first try to find it in the data
       else:
-        index, rlz = self._getRealizationFromDataByValue(matchDict, noMatchDict, tol=tol, unpackXArray=unpackXArray)
+        index, rlz = self._getRealizationFromDataByValue(matchDict, noMatchDict, tol=tol, unpackXArray=unpackXArray, options=options)
         # if no match found in data, try in the collector (if there's anything in it)
         if rlz is None:
           if numInCollector > 0:
-            index, rlz = self._getRealizationFromCollectorByValue(matchDict, noMatchDict, tol=tol)
+            index, rlz = self._getRealizationFromCollectorByValue(matchDict, noMatchDict, tol=tol, options=options)
       # add index map where necessary
       rlz = self._addIndexMapToRlz(rlz)
       if asDataSet:

--- a/framework/Samplers/CustomSampler.py
+++ b/framework/Samplers/CustomSampler.py
@@ -220,6 +220,8 @@ class CustomSampler(ForwardSampler):
     #TODO: add restart capability here!
     if self.restartData:
       self.raiseAnError(IOError,"restart capability not implemented for CustomSampler yet!")
+    if self.batch > 1:
+      self.addMetaKeys(["batchId"])
 
   def localGenerateInput(self,model,myInput):
     """
@@ -275,6 +277,7 @@ class CustomSampler(ForwardSampler):
       self.inputInfo['SamplerType'] = 'Custom'
       if self.inputInfo['batchMode']:
         self.inputInfo['SampledVars'] = self.values
+        self.inputInfo['batchId'] = self.name + str(self.batchId)
         batchData.append(copy.deepcopy(self.inputInfo))
         self._incrementCounter()
     if self.inputInfo['batchMode']:

--- a/framework/Steps.py
+++ b/framework/Steps.py
@@ -668,7 +668,7 @@ class MultiRun(SingleRun):
           # collect run if it succeeded
           if finishedJob.getReturnCode() == 0:
             for myLambda, outIndex in self._outputCollectionLambda:
-              myLambda([finishedJob,outputs[outIndex]])
+              myLambda([finishedJob,outputs[outIndex]])              
               self.raiseADebug('Just collected job {j:^8} and sent to output "{o}"'
                               .format(j=finishedJob.identifier,
                                       o=inDictionary['Output'][outIndex].name))


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

