### PR TITLE
pythonpath modification

### DIFF
--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -183,8 +183,6 @@ class JobHandler(MessageHandler.MessageUser):
     if self.runInfoDict['internalParallel']:
       ## Check if the list of unique nodes is present and, in case, initialize the
       servers = None
-      ## set up enviroment
-      # os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
       if len(self.runInfoDict['Nodes']) > 0:
         availableNodes = [nodeId.strip() for nodeId in self.runInfoDict['Nodes']]
         ## identify the local host name and get the number of local processors

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -181,10 +181,10 @@ class JobHandler(MessageHandler.MessageUser):
       @ Out, None
     """
     if self.runInfoDict['internalParallel']:
-       ## Check if the list of unique nodes is present and, in case, initialize the
-       servers = None
-       ## set up enviroment
-       # os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
+      ## Check if the list of unique nodes is present and, in case, initialize the
+      servers = None
+      ## set up enviroment
+      # os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
       if len(self.runInfoDict['Nodes']) > 0:
         availableNodes = [nodeId.strip() for nodeId in self.runInfoDict['Nodes']]
         ## identify the local host name and get the number of local processors

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -180,11 +180,11 @@ class JobHandler(MessageHandler.MessageUser):
       @ In, None
       @ Out, None
     """
-    ## set up enviroment
-    os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
-    ## Check if the list of unique nodes is present and, in case, initialize the
-    servers = None
     if self.runInfoDict['internalParallel']:
+       ## Check if the list of unique nodes is present and, in case, initialize the
+       servers = None
+       ## set up enviroment
+       # os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
       if len(self.runInfoDict['Nodes']) > 0:
         availableNodes = [nodeId.strip() for nodeId in self.runInfoDict['Nodes']]
         ## identify the local host name and get the number of local processors

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -656,7 +656,7 @@ def find_crow(framework_dir):
       if os.path.exists(pmoduleDir):
         sys.path.append(pmoduleDir)
         # we add it in pythonpath too
-        os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep.join(pmoduleDir)
+        os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep + pmoduleDir
         return
     for crowDir in crowDirs:
       if os.path.exists(os.path.join(crowDir,"tests")):
@@ -673,7 +673,7 @@ def add_path(absolutepath):
     raise IOError(UreturnPrintTag('UTILS') + ': '+UreturnPrintPostTag('ERROR')+ ' -> "'+absolutepath+ '" directory has not been found!')
   sys.path.append(absolutepath)
   # we add it in pythonpath too
-  os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep.join(absolutepath)
+  os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep + absolutepath
 
 def add_path_recursively(absoluteInitialPath):
   """

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -673,7 +673,7 @@ def add_path(absolutepath):
     raise IOError(UreturnPrintTag('UTILS') + ': '+UreturnPrintPostTag('ERROR')+ ' -> "'+absolutepath+ '" directory has not been found!')
   sys.path.append(absolutepath)
   # we add it in pythonpath too
-  os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep.join(pmoduleDir)
+  os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep.join(absolutepath)
 
 def add_path_recursively(absoluteInitialPath):
   """

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -655,6 +655,8 @@ def find_crow(framework_dir):
       pmoduleDir = os.path.join(crowDir,"install")
       if os.path.exists(pmoduleDir):
         sys.path.append(pmoduleDir)
+        # we add it in pythonpath too
+        os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep.join(pmoduleDir)
         return
     for crowDir in crowDirs:
       if os.path.exists(os.path.join(crowDir,"tests")):
@@ -670,6 +672,8 @@ def add_path(absolutepath):
   if not os.path.exists(absolutepath):
     raise IOError(UreturnPrintTag('UTILS') + ': '+UreturnPrintPostTag('ERROR')+ ' -> "'+absolutepath+ '" directory has not been found!')
   sys.path.append(absolutepath)
+  # we add it in pythonpath too
+  os.environ['PYTHONPATH'] = os.environ.get("PYTHONPATH","") + os.pathsep.join(pmoduleDir)
 
 def add_path_recursively(absoluteInitialPath):
   """

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -529,6 +529,10 @@ def importFromPath(filename, printImporting = True):
     (name, ext) = os.path.splitext(name)
     (file, filename, data) = imp.find_module(name, [path])
     importedModule = imp.load_module(name, file, filename, data)
+    pythonPath = os.environ.get("PYTHONPATH","")
+    absPath = os.path.abspath(path)
+    if absPath not in pythonPath:
+      os.environ['PYTHONPATH'] = pythonPath+ os.pathsep + absPath
   except Exception as ae:
     raise Exception('(            ) '+ UreturnPrintTag('UTILS') + ': '+UreturnPrintPostTag('ERROR')+ '-> importing module '+ filename + ' at '+path+os.sep+name+' failed with error '+str(ae))
   return importedModule


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1343

##### What are the significant changes in functionality due to this change request?
Removed update of the pythonpath if not needed 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.  (Done)
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts). (No changes)
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details. (Yes)
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass. (Yes)
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.  (No significant functionality added)
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync. (No changes to tests)
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done. (close checklist done.)
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added? (No analytic tests)
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example. (No changes needed.)

