### PR TITLE
Adding ability to sign the .so files.

### DIFF
--- a/build_raven
+++ b/build_raven
@@ -107,5 +107,15 @@ fi
 
 (cd $RAVEN_BUILD_DIR && ${PYTHON_COMMAND} ./setup.py build_ext build install --install-platlib=./framework/contrib/AMSC)
 
-
+if [ ! -z "$RAVEN_SIGNATURE" ];
+then
+    #This is to allow the code to be signed on mac os computers.
+    # It requires a signature (possibly self signed) to be used.
+    # Creating a signature is discussed at:
+    # https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html
+    # RAVEN_SIGNATURE can be added to .ravenrc
+    echo "... Signing code with '$RAVEN_SIGNATURE' ..."
+    (cd $CROW_DIR/install/crow_modules && pwd && codesign -s "$RAVEN_SIGNATURE" -v *.so)
+    (cd $RAVEN_BUILD_DIR/framework/contrib/AMSC && pwd && codesign -s "$RAVEN_SIGNATURE" -v *.so)
+fi
 echo ... done!

--- a/doc/workshop/.gitignore
+++ b/doc/workshop/.gitignore
@@ -57,3 +57,4 @@ stochasticCollocation/inputs/run/training_data.xml
 timeDepDataMining/inputs/basicStatisticsTimeDependent/
 timeDepDataMining/inputs/resultsHierarchicalDTW/
 timeDepDataMining/inputs/timeSliceKMeans/
+forwardSampling/Inputs/test_*.xml

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -470,4 +470,14 @@ fi
 # activate environment and write settings if successful
 activate_env
 
+if [ -z "$RAVEN_SIGNATURE" ];
+then
+    RAVEN_SIGNATURE=$(read_ravenrc "RAVEN_SIGNATURE")
+fi
+if [ ! -z "$RAVEN_SIGNATURE" ];
+then
+    if [[ $ECE_VERBOSE == 0 ]]; then echo "... Using '$RAVEN_SIGNATURE' for signing ..."; fi
+    export RAVEN_SIGNATURE
+fi
+
 if [[ $ECE_VERBOSE == 0 ]]; then echo  ... done!; fi

--- a/tests/framework/.gitignore
+++ b/tests/framework/.gitignore
@@ -168,3 +168,15 @@ unit_tests/utils/parse/fromXmltoGetpot.i
 user_guide/EnsembleModel/run_basic/sample/
 ROM/TimeSeries/ARMA/ARMAreseed/
 ROM/TimeSeries/ARMA/Segmented/arma.pk
+ROM/TimeSeries/ARMA/Multicycle/arma.pk
+DataObjects/StringIO/sample/
+CodeInterfaceTests/RAVEN/Code/sample/
+CodeInterfaceTests/Neutrino/Neutrino_Base/sampleNeutrino/[1-3]
+CodeInterfaceTests/MOOSEBaseApps/MooseExample18WithGenericFile/myMC/[12]
+CodeInterfaceTests/MOOSEBaseApps/MooseExample18OnlyGenericFile/myMC/[12]
+CodeInterfaceTests/MOOSEBaseApps/MooseExample18OnlyGenericFile/myMC/ex18.i
+CodeInterfaceTests/MOOSEBaseApps/MooseExample18WithGenericFile/myMC/ex18.i
+CodeInterfaceTests/MOOSEBaseApps/InputParser/sample/[12]/formattest.i
+CodeInterfaceTests/MOOSEBaseApps/InputParser/sample/[12]/out~formattest
+CodeInterfaceTests/MOOSEBaseApps/InputParser/sample/formattest.i
+hybridModel/logicalCode/logicalModelCode/


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
closes #1361 

##### What are the significant changes in functionality due to this change request?
Adds a variable to the .ravenrc with the signature to use and then if that is present, will sign the .so modules produced as part of the build.

This will probably be needed in future mac os releases.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

