### PR TITLE
ray cluster

### DIFF
--- a/framework/CodeInterfaces/RAVEN/RAVENInterface.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENInterface.py
@@ -318,7 +318,6 @@ class RAVEN(CodeInterfaceBase):
       @ Out, dataObjectsToReturn, dict, optional, this is a special case for RAVEN only. It returns the constructed dataobjects
                                                  (internally we check if the return variable is a dict and if it is returned by RAVEN (if not, we error out))
     """
-
     ##### TODO This is an exception to the way CodeInterfaces usually run.
     # The return dict for this CodeInterface is a dictionary of data objects (either one or two of them, up to one each point set and history set).
     # Normally, the end result of this method is producing a CSV file with the data to load.

--- a/framework/CodeInterfaces/RAVEN/RAVENInterface.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENInterface.py
@@ -246,11 +246,14 @@ class RAVEN(CodeInterfaceBase):
     if int(Kwargs['numberNodes']) > 0:
       # we are in a distributed memory machine => we allocate a node file
       nodeFileToUse = os.path.join(Kwargs['BASE_WORKING_DIR'],"node_" +str(Kwargs['INDEX']))
-      if os.path.exists(nodeFileToUse):
-        modifDict['RunInfo|mode'           ] = 'mpi'
-        modifDict['RunInfo|mode|nodefile'  ] = nodeFileToUse
-      else:
-        raise IOError(self.printTag+' ERROR: The nodefile "'+str(nodeFileToUse)+'" does not exist!')
+      if not os.path.exists(nodeFileToUse):
+        if "NodeParameter" not in Kwargs:
+          raise IOError(self.printTag+' ERROR: The nodefile "'+str(nodeFileToUse)+'" does not exist and no NodeParameter has been found!!')
+        else:
+          nodeFileToUse = Kwargs["NodeParameter"]
+      modifDict['RunInfo|mode'           ] = 'mpi'
+      modifDict['RunInfo|mode|nodefile'  ] = nodeFileToUse
+
     if internalParallel or newBatchSize > 1:
       # either we have an internal parallel or NumMPI > 1
       modifDict['RunInfo|batchSize'] = newBatchSize

--- a/framework/CodeInterfaces/RAVEN/RAVENInterface.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENInterface.py
@@ -239,7 +239,6 @@ class RAVEN(CodeInterfaceBase):
       if convDict['scalar']:
         # call conversion, value changes happen in-place
         module.manipulateScalarSampledVariables(modifDict)
-
     # we work on batchSizes here
     newBatchSize = Kwargs['NumMPI']
     internalParallel = Kwargs.get('internalParallel',False)
@@ -247,13 +246,12 @@ class RAVEN(CodeInterfaceBase):
       # we are in a distributed memory machine => we allocate a node file
       nodeFileToUse = os.path.join(Kwargs['BASE_WORKING_DIR'],"node_" +str(Kwargs['INDEX']))
       if not os.path.exists(nodeFileToUse):
-        if "NodeParameter" not in Kwargs:
-          raise IOError(self.printTag+' ERROR: The nodefile "'+str(nodeFileToUse)+'" does not exist and no NodeParameter has been found!!')
+        if "PBS_NODEFILE" not in os.environ:
+          raise IOError(self.printTag+' ERROR: The nodefile "'+str(nodeFileToUse)+'" and PBS_NODEFILE enviroment var do not exist!')
         else:
-          nodeFileToUse = Kwargs["NodeParameter"]
+          nodeFileToUse = os.environ["PBS_NODEFILE"]
       modifDict['RunInfo|mode'           ] = 'mpi'
       modifDict['RunInfo|mode|nodefile'  ] = nodeFileToUse
-
     if internalParallel or newBatchSize > 1:
       # either we have an internal parallel or NumMPI > 1
       modifDict['RunInfo|batchSize'] = newBatchSize

--- a/framework/CodeInterfaces/RAVEN/RAVENInterface.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENInterface.py
@@ -255,6 +255,13 @@ class RAVEN(CodeInterfaceBase):
     if internalParallel or newBatchSize > 1:
       # either we have an internal parallel or NumMPI > 1
       modifDict['RunInfo|batchSize'] = newBatchSize
+
+    if 'headNode' in kwargs:
+      modifDict['RunInfo|headNode'] = kwargs['headNode']
+      modifDict['RunInfo|redisPassword'] = kwargs['redisPassword']
+    if 'remoteNodes' in kwargs:
+      modifDict['RunInfo|remoteNodes'] = ','.join(kwargs['remoteNodes'])
+
     #modifDict['RunInfo|internalParallel'] = internalParallel
     # make tree
     modifiedRoot = parser.modifyOrAdd(modifDict, save=True, allowAdd=True)

--- a/framework/CodeInterfaces/RAVEN/RAVENInterface.py
+++ b/framework/CodeInterfaces/RAVEN/RAVENInterface.py
@@ -256,11 +256,11 @@ class RAVEN(CodeInterfaceBase):
       # either we have an internal parallel or NumMPI > 1
       modifDict['RunInfo|batchSize'] = newBatchSize
 
-    if 'headNode' in kwargs:
-      modifDict['RunInfo|headNode'] = kwargs['headNode']
-      modifDict['RunInfo|redisPassword'] = kwargs['redisPassword']
-    if 'remoteNodes' in kwargs:
-      modifDict['RunInfo|remoteNodes'] = ','.join(kwargs['remoteNodes'])
+    if 'headNode' in Kwargs:
+      modifDict['RunInfo|headNode'] = Kwargs['headNode']
+      modifDict['RunInfo|redisPassword'] = Kwargs['redisPassword']
+    if 'remoteNodes' in Kwargs:
+      modifDict['RunInfo|remoteNodes'] = ','.join(Kwargs['remoteNodes'])
 
     #modifDict['RunInfo|internalParallel'] = internalParallel
     # make tree

--- a/framework/CustomModes/MPISimulationMode.py
+++ b/framework/CustomModes/MPISimulationMode.py
@@ -56,6 +56,13 @@ class MPISimulationMode(Simulation.SimulationMode):
       @ In, runInfoDict, dict, the original runInfo
       @ Out, newRunInfo, dict, of modified values
     """
+    magicSyntax = False
+    if runInfoDict['NumMPI'] == -runInfoDict['NumThreads']:
+      # our special keyword
+      # we selected the nodes as select=batchSize:ncpus=NumThreads
+      # in the PBS_NODEFILE we have only a batchSize number of nodes
+      # but we want to have NumThreads nodes in each of them
+      magicSyntax = True
     newRunInfo = {}
     newRunInfo['batchSize'] = runInfoDict['batchSize']
     if self.__nodefile or self.__inPbs:
@@ -69,11 +76,16 @@ class MPISimulationMode(Simulation.SimulationMode):
       #XXX This is an undocumented way to pass information back
       newRunInfo['Nodes'] = list(lines)
       numMPI = runInfoDict['NumMPI']
+      numThreads = runInfoDict['NumThreads']
       oldBatchsize = runInfoDict['batchSize']
       #the batchsize is just the number of nodes of which there is one
       # per line in the nodefile divided by the numMPI (which is per run)
       # and the floor and int and max make sure that the numbers are reasonable
-      maxBatchsize = max(int(math.floor(len(lines)/numMPI)),1)
+      if not magicSyntax:
+        maxBatchsize = max(int(math.floor(len(lines)/numMPI)),1)
+      else:
+        maxBatchsize = newRunInfo['batchSize']
+
       if maxBatchsize < oldBatchsize:
         newRunInfo['batchSize'] = maxBatchsize
         self.raiseAWarning("changing batchsize from "+str(oldBatchsize)+" to "+str(maxBatchsize)+" to fit on "+str(len(lines))+" processors")
@@ -82,11 +94,19 @@ class MPISimulationMode(Simulation.SimulationMode):
       if self.__inPbs or self.__runQsub: # OLD: if newBatchsize > 1:
         #need to split node lines so that numMPI nodes are available per run
         workingDir = runInfoDict['WorkingDir']
-        for i in range(newBatchsize):
-          nodeFile = open(os.path.join(workingDir,"node_"+str(i)),"w")
-          for line in lines[i*numMPI:(i+1)*numMPI]:
-            nodeFile.write(line)
-          nodeFile.close()
+        if not magicSyntax:
+          for i in range(newBatchsize):
+            nodeFile = open(os.path.join(workingDir,"node_"+str(i)),"w")
+            for line in lines[i*numMPI:(i+1)*numMPI]:
+              nodeFile.write(line)
+            nodeFile.close()
+        else:
+          for i in range(newBatchsize):
+            nodeFile = open(os.path.join(workingDir,"node_"+str(i)),"w")
+            line = lines[i]
+            for _ in range(numThreads):
+              nodeFile.write(line)
+            nodeFile.close()
 
         #then give each index a separate file.
         nodeCommand = runInfoDict["NodeParameter"]+" %BASE_WORKING_DIR%/node_%INDEX% "
@@ -108,10 +128,18 @@ class MPISimulationMode(Simulation.SimulationMode):
 
     # Create the mpiexec pre command
     # Note, with defaults the precommand is "mpiexec -f nodeFile -n numMPI"
+    #if not magicSyntax:
     newRunInfo['precommand'] = runInfoDict["MPIExec"]+" "+nodeCommand+" -n "+str(numMPI)+" "+runInfoDict['precommand']
-    if(runInfoDict['NumThreads'] > 1):
+    #else:
+    #  newRunInfo['precommand'] = "_specialSyntax_" + runInfoDict["MPIExec"]+" "+nodeCommand+" "+runInfoDict['precommand']
+
+    if runInfoDict['NumThreads'] > 1 and not magicSyntax:
       #add number of threads to the post command.
       newRunInfo['postcommand'] = " --n-threads=%NUM_CPUS% "+runInfoDict['postcommand']
+    else:
+      if self.__inPbs and magicSyntax:
+        newRunInfo['NumMPI'] = -1*runInfoDict['NumMPI']
+
     self.raiseAMessage("precommand: "+newRunInfo['precommand']+", postcommand: "+newRunInfo.get('postcommand',runInfoDict['postcommand']))
     return newRunInfo
 
@@ -127,6 +155,9 @@ class MPISimulationMode(Simulation.SimulationMode):
       coresNeeded = self.__coresNeeded
     else:
       coresNeeded = runInfoDict['batchSize']*runInfoDict['NumMPI']
+      if runInfoDict['NumMPI'] == -runInfoDict['NumThreads']:
+        coresNeeded = runInfoDict['batchSize']
+
     # get the requested memory, if any
     if self.__memNeeded is not None:
       memString = ":mem="+self.__memNeeded

--- a/framework/CustomModes/MPISimulationMode.py
+++ b/framework/CustomModes/MPISimulationMode.py
@@ -79,7 +79,7 @@ class MPISimulationMode(Simulation.SimulationMode):
         self.raiseAWarning("changing batchsize from "+str(oldBatchsize)+" to "+str(maxBatchsize)+" to fit on "+str(len(lines))+" processors")
       newBatchsize = newRunInfo['batchSize']
       self.raiseADebug('Batch size is "{}"'.format(newBatchsize))
-      if newBatchsize > 1:
+      if self.__inPbs or self.__runQsub: # OLD: if newBatchsize > 1:
         #need to split node lines so that numMPI nodes are available per run
         workingDir = runInfoDict['WorkingDir']
         for i in range(newBatchsize):

--- a/framework/CustomModes/MPISimulationMode.py
+++ b/framework/CustomModes/MPISimulationMode.py
@@ -93,6 +93,7 @@ class MPISimulationMode(Simulation.SimulationMode):
       else:
         #If only one batch just use original node file
         nodeCommand = runInfoDict["NodeParameter"]+" "+nodefile
+
     else:
       #Not in PBS, so can't look at PBS_NODEFILE and none supplied in input
       newBatchsize = newRunInfo['batchSize']

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -205,7 +205,7 @@ class JobHandler(MessageHandler.MessageUser):
           self.raiseADebug("Head host IP      :", address)
           self.raiseADebug("Head redis pass   :", redisPassword)
         ## Get servers and run ray remote listener
-        if 'remoteNodes' in self.runInfoDict
+        if 'remoteNodes' in self.runInfoDict:
           servers = self.runInfoDict['remoteNodes']
         else:
           servers = self.__runRemoteListeningSockets(address)

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -321,7 +321,7 @@ class JobHandler(MessageHandler.MessageUser):
         ## Activate the remote socketing system
         ## let's build the command and then call the os-agnostic version
         if _rayAvail:
-          command=" ".join(["ray start", "--address="+address, "-num-cpus",str(ntasks)])
+          command=" ".join(["ray start", "--address="+address, "--num-cpus",str(ntasks)])
         else:
           ppserverScript = os.path.join(self.runInfoDict['FrameworkDir'],"contrib","pp","ppserver.py")
           command=" ".join([pythonCommand,ppserverScript,"-w",str(ntasks),"-i",remoteHostName,"-p",str(randint(1024,65535)),"-t","50000","-g",localenv["PYTHONPATH"],"-d"])

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -191,7 +191,7 @@ class JobHandler(MessageHandler.MessageUser):
         # number of processors
         nProcsHead = availableNodes.count(localHostName)
         if not nProcsHead:
-          selr.raiseAWarning("# of local procs are 0. Only remote procs are avalable")
+          self.raiseAWarning("# of local procs are 0. Only remote procs are avalable")
           nProcsHead = None
         self.raiseADebug("# of local procs    : ", str(nProcsHead))
         # create head node cluster

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -278,8 +278,9 @@ class JobHandler(MessageHandler.MessageUser):
     address, redisPassword = None, None
     with open(rayLog, 'r') as rayLogObj:
       for line in rayLogObj.readlines():
-        if line.strip().startswith("ray start"):
-          address, redisPassword = line.strip().replace("ray start","").strip().split()
+        if "ray start" in line.strip():
+          ix = line.strip().find("ray start")
+          address, redisPassword = line.strip()[ix:].replace("ray start","").strip().split()
           address = address.split("=")[-1].replace("'","")
           redisPassword = redisPassword.split("=")[-1].replace("'","")
           break

--- a/framework/JobHandler.py
+++ b/framework/JobHandler.py
@@ -194,13 +194,22 @@ class JobHandler(MessageHandler.MessageUser):
           self.raiseAWarning("# of local procs are 0. Only remote procs are avalable")
           nProcsHead = None
         self.raiseADebug("# of local procs    : ", str(nProcsHead))
+
         # create head node cluster
-        address, redisPassword = self.__runHeadNode(nProcsHead)
+        if 'headNode' in self.runInfoDict:
+          address, redisPassword = self.runInfoDict['headNode'], self.runInfoDict['redisPassword']
+        else:
+          address, redisPassword = self.__runHeadNode(nProcsHead)
+          self.runInfoDict['headNode'], self.runInfoDict['redisPassword'] = address, redisPassword
         if _rayAvail:
           self.raiseADebug("Head host IP      :", address)
           self.raiseADebug("Head redis pass   :", redisPassword)
         ## Get servers and run ray remote listener
-        servers = self.__runRemoteListeningSockets(address)
+        if 'remoteNodes' in self.runInfoDict
+          servers = self.runInfoDict['remoteNodes']
+        else:
+          servers = self.__runRemoteListeningSockets(address)
+          self.runInfoDict['remoteNodes'] = servers
         ## initialize ray server with nProcs
         self.rayServer = ray.init(address=address, _redis_password=redisPassword) if _rayAvail else pp.Server(ncpus=int(nProcsHead))
       else:
@@ -689,12 +698,19 @@ class JobHandler(MessageHandler.MessageUser):
             ## want to revisit this on the next iteration of this code.
             if len(item.args) > 0 and isinstance(item.args[0], Models.Code):
               kwargs = {}
+              if self.rayServer is not None and 'headNode' in self.runInfoDict:
+                kwargs['headNode'] = self.runInfoDict['headNode']
+                kwargs['redisPassword'] = self.runInfoDict['redisPassword']
+              if self.rayServer is not None and 'remoteNodes' in self.runInfoDict:
+                kwargs['remoteNodes'] = self.runInfoDict['remoteNodes']
               kwargs['INDEX'] = str(i)
               kwargs['INDEX1'] = str(i+i)
               kwargs['CURRENT_ID'] = str(self.__nextId)
               kwargs['CURRENT_ID1'] = str(self.__nextId+1)
               kwargs['SCRIPT_DIR'] = self.runInfoDict['ScriptDir']
               kwargs['FRAMEWORK_DIR'] = self.runInfoDict['FrameworkDir']
+
+
               ## This will not be used since the Code will create a new
               ## directory for its specific files and will spawn a process there
               ## so we will let the Code fill that in. Note, the line below

--- a/framework/Models/Code.py
+++ b/framework/Models/Code.py
@@ -515,8 +515,8 @@ class Code(Model):
     commands=[]
     for runtype,cmd in executeCommand:
       newCommand=''
-      if runtype.lower() == 'parallel':
-        newCommand += precommand
+      if runtype.lower() == 'parallel': #or precommand.startswith("_specialSyntax_"):
+        newCommand += precommand.replace("_specialSyntax_","")
         newCommand += cmd+' '
         newCommand += postcommand
         commands.append(newCommand)

--- a/framework/RemoteNodeScripts/server_start.py
+++ b/framework/RemoteNodeScripts/server_start.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import sys, os, subprocess
+# get working dir
+workingDir=sys.argv[1]
+# change working dir
+os.chdir(workingDir)
+# output
+output=sys.argv[2]
+# python path
+pythonpath=sys.argv[3]
+# command
+command=sys.argv[4:]
+#create an output file
+out = open(output, "a")
+print("working dir:", workingDir, file=out)
+print("command    :", command, file=out)
+print("pythonpath :", pythonpath, file=out)
+os.environ["PYTHONPATH"] = pythonpath
+
+#Close standard in, out, and error
+# Note if not done, ssh will wait until these close
+for f in [0,1,2]:
+  os.close(f)
+
+subprocess.Popen(command)

--- a/framework/RemoteNodeScripts/start_ray.sh
+++ b/framework/RemoteNodeScripts/start_ray.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# start ray
+# OUTPUT FILE FOR LOGGING
+OUTFILE=$1
+# BASH_PROFILE 
+HEAD_ADDRESS=$2
+REDIS_PASS=$3
+NUM_CPUS=$4
+
+echo starting >> $OUTFILE
+
+if [ $# -eq 5 ]
+  then
+  REMOTE_BASH=$5
+  source $REMOTE_BASH >> $OUTFILE 2>&1
+fi
+
+which ray >> $OUTFILE 2>&1
+hostname >> $OUTFILE
+
+echo loaded >> $OUTFILE
+command -v ray >> $OUTFILE 2>&1
+ray start --address=$HEAD_ADDRESS --redis-password=$REDIS_PASS --num-cpus $NUM_CPUS >> $OUTFILE 2>&1
+

--- a/framework/RemoteNodeScripts/start_remote_servers.sh
+++ b/framework/RemoteNodeScripts/start_remote_servers.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# USES:
+# --load - just finds and sources the conda environment (default)
+# --install - find (create if not found) and update the environment, then load it
+# OTHER OPTIONS:
+# --optional - if updating, install optional libraries as well as base ones
+
+# ENVIRONMENT VARIABLES
+# location of conda definitions: CONDA_DEFS (defaults if not set based on OS)
+# name for raven libraries: RAVEN_LIBS_NAME (defaults to raven_libraries if not set)
+
+ECE_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function establish_OS ()
+{
+	case $OSTYPE in
+		"linux")
+			OSOPTION="--os linux"
+			;;
+		"linux-gnu")
+			OSOPTION="--os linux"
+			;;
+		"darwin"*)
+			OSOPTION="--os mac"
+			;;
+		"msys"*)
+			OSOPTION="--os windows"
+			;;
+		"cygwin"*)
+			OSOPTION="--os windows"
+			;;
+		*)
+			echo Unknown OS: $OSTYPE\; ignoring.
+			OSOPTION=""
+			;;
+	esac
+}
+
+function display_usage()
+{
+	echo ''
+	echo '  ------------------------------------------'
+	echo '  Default usage:'
+	echo '    start_remote_servers.sh'
+	echo ''
+	echo '  Description:'
+	echo '      This script is in charge for instanciating ray servers in remote nodes'
+	echo '  ------------------------------------------'
+	echo ''
+	echo '  Options:'
+	echo '    --help'
+	echo '      Displays this text and exits'
+    echo ''
+    echo '    --remote-node-address'
+    echo '      Remote node address (ssh into)'
+    echo ''
+	echo '    --address'
+	echo '      Head node address'
+	echo ''
+	echo '    --redis-password'
+	echo '      Specify the password for redis (head node password)'
+	echo ''
+	echo '    --num-cpus'
+	echo '      Number of cpus available/to use in this node'
+	echo ''
+	echo '    --num-gpus'
+	echo '      Number of gpus available/to use in this node'
+	echo ''
+	echo '    --remote-bash-profile'
+	echo '      The bash profile to source before executing the tunneling commands'
+	echo ''
+	echo '     --python-path'
+	echo '      The PYTHONPATH enviroment variable'
+	echo ''
+	echo '     --working-dir'
+	echo '      The workind directory'
+	echo ''
+ 
+}
+
+# main
+# set control variable
+REMOTE_ADDRESS=""
+HEAD_ADDRESS=""
+REDIS_PASS=""
+PYTHONPATH=""
+WORKINGDIR=""
+# set default
+NUM_CPUS=1
+NUM_GPUS=-1
+REMOTE_BASH=""
+
+# parse command-line arguments
+while test $# -gt 0
+do
+  case "$1" in
+    --help)
+      display_usage
+      return
+      ;;
+    --remote-node-address)
+      shift
+      REMOTE_ADDRESS=$1
+      ;;
+    --address)
+      shift
+      HEAD_ADDRESS=$1
+      ;;
+    --redis-password)
+      shift
+      REDIS_PASS=$1
+      ;;
+    --num-cpus)
+      shift
+      NUM_CPUS=$1
+      ;;
+    --num-gpus)
+      shift
+      NUM_GPUS=$1
+      ;;
+    --remote-bash-profile)
+      shift
+      REMOTE_BASH=$1
+      ;;
+    --python-path)
+      shift
+      PYTHONPATH=$1
+      ;;
+      --working-dir)
+      shift
+      WORKINGDIR=$1
+      ;;
+  esac
+  shift
+done
+
+echo $REMOTE_ADDRESS
+if [[ "$REMOTE_ADDRESS" == "" ]];
+then
+  echo ... ERROR: --remote-node-address argument must be inputted !
+  exit
+fi
+
+if [[ "$HEAD_ADDRESS" == "" ]];
+then
+  echo ... ERROR: --address argument must be inputted !
+  exit
+fi
+
+if [[ "$REDIS_PASS" == "" ]];
+then
+  echo ... ERROR: --redis-password argument must be inputted !
+  exit
+fi
+
+if [[ "$PYTHONPATH" == "" ]];
+then
+  echo ... ERROR: --python-path argument must be inputted !
+  exit
+fi
+
+if [[ "$WORKINGDIR" == "" ]];
+then
+  echo ... ERROR: --working-dir argument must be inputted !
+  exit
+fi
+
+
+# start the script
+# ssh in the remote node and run the ray servers
+CWD=`pwd`
+OUTPUT=$CWD/server_debug_$REMOTE_ADDRESS
+
+if [[ "$REMOTE_BASH" == "" ]];
+then
+  ssh $REMOTE_ADDRESS $ECE_SCRIPT_DIR/server_start.py ${WORKINGDIR} ${OUTPUT} ${PYTHONPATH} "${ECE_SCRIPT_DIR}/start_ray.sh $OUTPUT $HEAD_ADDRESS $REDIS_PASS $NUM_CPUS"
+else
+  ssh $REMOTE_ADDRESS $ECE_SCRIPT_DIR/server_start.py ${WORKINGDIR} ${OUTPUT} ${PYTHONPATH} "${ECE_SCRIPT_DIR}/start_ray.sh $OUTPUT $HEAD_ADDRESS $REDIS_PASS $NUM_CPUS $REMOTE_BASH"
+fi
+
+

--- a/framework/Runners/DistributedMemoryRunner.py
+++ b/framework/Runners/DistributedMemoryRunner.py
@@ -26,6 +26,7 @@ import signal
 import copy
 import sys
 import abc
+import psutil
 from utils import importerUtils as im
 ## TODO: REMOVE WHEN RAY AVAILABLE FOR WINDOWOS
 if im.isLibAvail("ray"):
@@ -123,6 +124,12 @@ class DistributedMemoryRunner(InternalRunner):
                                              modules = tuple([self.functionToRun.__module__]+list(set(utils.returnImportModuleString(inspect.getmodule(self.functionToRun),True)))))
       self.trackTime('runner_started')
       self.started = True
+      #if psutil.virtual_memory().percent >= pct:
+      self.raiseADebug("XXXXXXX:             Virtual memory is currently at % "+str(psutil.virtual_memory().percent))
+      gc.collect()
+      self.raiseADebug("XXXXXXX: Collecting: Virtual memory is currently at % "+str(psutil.virtual_memory().percent))
+      return
+
     except Exception as ae:
       #Uncomment if you need the traceback
       #exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -632,6 +632,12 @@ class Simulation(MessageHandler.MessageUser):
         self.runInfoDict['postcommand'       ] = element.text
       elif element.tag == 'deleteOutExtension':
         self.runInfoDict['deleteOutExtension'] = element.text.strip().split(',')
+      elif element.tag == 'headNode':
+        self.runInfoDict['headNode'] = element.text.strip()
+      elif element.tag == 'redisPassword':
+        self.runInfoDict['redisPassword'] = element.text.strip()
+      elif element.tag == 'remoteNodes':
+        self.runInfoDict['remoteNodes'] = [el.strip() for el in element.text.strip().split(',')]
       elif element.tag == 'delSucLogFiles'    :
         if utils.stringIsTrue(element.text):
           self.runInfoDict['delSucLogFiles'    ] = True

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -571,6 +571,8 @@ class Simulation(MessageHandler.MessageUser):
           self.raiseAnError(IOError, 'RunInfo.WorkingDir is empty! Use "." to signify "work here" or specify a directory.')
         if '~' in tempName:
           tempName = os.path.expanduser(tempName)
+        xmlDirectory = os.path.dirname(os.path.abspath(xmlFilename))
+        self.runInfoDict['InputDir'] = xmlDirectory
         if os.path.isabs(tempName):
           self.runInfoDict['WorkingDir'] = tempName
         elif "runRelative" in element.attrib:

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -725,6 +725,7 @@ class Simulation(MessageHandler.MessageUser):
       subprocess.call(args=remoteRunCommand["args"],
                       cwd=remoteRunCommand.get("cwd", None),
                       env=remoteRunCommand.get("env", None))
+      self.jobHandler.shutdown()
       return
     #loop over the steps of the simulation
     for stepName in self.stepSequenceList:

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -725,6 +725,7 @@ class Simulation(MessageHandler.MessageUser):
       subprocess.call(args=remoteRunCommand["args"],
                       cwd=remoteRunCommand.get("cwd", None),
                       env=remoteRunCommand.get("env", None))
+      self.raiseADebug('Submitted in queque! Shutting down Jobhandler!')
       self.jobHandler.shutdown()
       return
     #loop over the steps of the simulation

--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -40,6 +40,7 @@ from scipy.stats import rv_histogram
 from utils import randomUtils, xmlUtils, mathUtils, utils
 import Distributions
 from .SupervisedLearning import supervisedLearning
+
 #Internal Modules End--------------------------------------------------------------------------------
 
 class ARMA(supervisedLearning):

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -646,7 +646,7 @@ def find_crow(framework_dir):
     @ Out, None
   """
   try:
-    import crow_modules.distribution1Dpy2
+    import crow_modules.distribution1Dpy3
     return
   except:
     ravenDir = os.path.dirname(framework_dir)

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -646,7 +646,7 @@ def find_crow(framework_dir):
     @ Out, None
   """
   try:
-    import crow_modules.distribution1Dpy3
+    import crow_modules.distribution1Dpy2
     return
   except:
     ravenDir = os.path.dirname(framework_dir)
@@ -704,7 +704,7 @@ def findCrowModule(name):
   ext = 'py3' if sys.version_info.major > 2 else 'py2'
   try:
     module = import_module("crow_modules.{}{}".format(name,ext))
-  except ImportError as ie:
+  except (ImportError, ModuleNotFoundError) as ie:
     if not str(ie).startswith("No module named"):
       raise ie
     module = import_module("{}{}".format(name,ext))


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

