### PR TITLE
Adding .* to pip depends to allow subversions

### DIFF
--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -568,6 +568,7 @@ if __name__ == '__main__':
   else:
     # provide an installation command
     preamble = '{installer} {action} {args} '
+    equalsTail = '' #if something is needed after an equals
     if args.installer == 'conda':
       installer = 'conda'
       equals = '='
@@ -587,6 +588,7 @@ if __name__ == '__main__':
         src = ''
         installer = 'pip'
         equals = '=='
+        equalsTail = '.*'
         actionArgs = ''
         addOptional = False
         limit = ['pip']
@@ -607,6 +609,7 @@ if __name__ == '__main__':
     elif args.installer == 'pip':
       installer = 'pip3'
       equals = '=='
+      equalsTail = '.*'
       actionArgs = ''
       libs = getRequiredLibs(useOS=args.useOS,
                              installMethod='pip',
@@ -622,7 +625,7 @@ if __name__ == '__main__':
     preamble = preamble.format(installer=installer, action=action, args=actionArgs)
     libTexts = ' '.join(['{lib}{ver}'
                          .format(lib=lib,
-                                 ver=('{e}{r}'.format(e=equals, r=request['version']) if request['version'] is not None else ''))
+                                 ver=('{e}{r}{et}'.format(e=equals, r=request['version'], et=equalsTail) if request['version'] is not None else ''))
                          for lib, request in libs.items()])
     if len(libTexts) > 0:
       print(preamble + libTexts)

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -124,15 +124,15 @@ def checkSameVersion(expected, received):
     return True
   # A.B.C versioning -> 1.1.0 should match 1.1
   expSplit = [int(x) for x in expected.split('.')]
-  rcvSplit = [int(x) for x in received.split('.')]
+  #Only check as many digits as given in expSplit
+  rcvSplit = [int(x) for x in received.split('.')[:len(expSplit)]]
   # drop trailing 0s on both
   while expSplit[-1] == 0:
     expSplit.pop()
   while rcvSplit[-1] == 0:
     rcvSplit.pop()
   exp = '.'.join(str(x) for x in expSplit)
-  #Only check as many digits as given in expSplit
-  rcv = '.'.join(str(x) for x in rcvSplit[:len(expSplit)])
+  rcv = '.'.join(str(x) for x in rcvSplit)
   if exp == rcv:
     return True
   return False


### PR DESCRIPTION
Right now, if pip is asked for say numpy==1.18 it will
force it to numpy 1.18.0, but we want it to allow
things like numpy 1.18.5 (other wise we would specify 1.18.5)

--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #1388 

##### What are the significant changes in functionality due to this change request?
Allows pip to match conda semantics for version specification.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

