### PR TITLE
Distribution changes from GA PR

### DIFF
--- a/framework/Distributions.py
+++ b/framework/Distributions.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """
 Created on Mar 7, 2013
-
 @author: crisr
 """
 #for future compatibility with Python 3--------------------------------------------------------------
@@ -509,6 +508,18 @@ class BoostDistribution(Distribution):
     else:
       # TODO to speed up, do this on the C side instead of in python
       rvsValue = np.array([self.rvs() for _ in range(size)])
+    return rvsValue
+
+  def selectedRvs(self, discardedElems):
+    """
+      Function to get random numbers for discrete distribution which exclude discardedElems
+      @ In, discardedElems, list, list of values to be discarded
+      @ Out, rvsValue, float, requested random number
+    """
+    if not self.memory:
+      self.raiseAnError(IOError,' The distribution '+ str(self.name) + ' does not support the method selectedRVS.')
+    else:
+      rvsValue = self.selectedPpf(random(),discardedElems)
     return rvsValue
 
 class Uniform(BoostDistribution):
@@ -1884,6 +1895,18 @@ class UniformDiscrete(Distribution):
     initialPerm = randomUtils.randomPermutation(self.xArray.tolist(),self)
     self.pot = np.asarray(initialPerm)
 
+  def initializeFromDict(self, inputDict):
+    """
+      Function that initializes the distribution provided a dictionary
+      @ In, inputDict, dict, dictionary containing the np.arrays for xAxis and pAxis
+      @ Out, None
+    """
+    self.strategy = inputDict['strategy']
+    self.categoricalDist = Categorical()
+    self.categoricalDist.initializeFromDict(inputDict)
+    initialPerm = randomUtils.randomPermutation(inputDict['xAxis'].tolist(),self)
+    self.pot = np.asarray(initialPerm)
+
   def pdf(self,x):
     """
       Function that calculates the pdf value of x
@@ -1923,6 +1946,31 @@ class UniformDiscrete(Distribution):
         self.raiseAWarning("The Uniform Discrete distribution " + str(self.name) + " has been internally reset outside the sampler.")
       rvsValue = self.pot[-1]
       self.pot = np.resize(self.pot, self.pot.size - 1)
+    return rvsValue
+
+  def selectedRvs(self,discardedElems):
+    """
+      Return a random state of the distribution without discardedElems
+      @ In, discardedElems, np array, list of discarded elements
+      @ Out, rvsValue, float, the random state
+    """
+    if self.nPoints is None:
+      self.xArray   = np.arange(self.lowerBound,self.upperBound+1)
+    else:
+      self.xArray   = np.linspace(self.lowerBound,self.upperBound,self.nPoints)
+
+    self.xArray = np.setdiff1d(self.xArray,discardedElems)
+
+    self.pdfArray = 1/self.xArray.size * np.ones(self.xArray.size)
+    paramsDict={}
+    paramsDict['xAxis'] = self.xArray
+    paramsDict['pAxis'] = self.pdfArray
+    paramsDict['strategy'] = self.strategy
+
+    self.tempUniformDiscrete = UniformDiscrete()
+    self.tempUniformDiscrete.initializeFromDict(paramsDict)
+
+    rvsValue = self.tempUniformDiscrete.rvs()
     return rvsValue
 
   def reset(self):

--- a/framework/utils/randomUtils.py
+++ b/framework/utils/randomUtils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """
  This file contains the random number generating methods used in the framework.
  created on 07/15/2017
@@ -26,7 +27,7 @@ from collections import deque, defaultdict
 from utils.utils import findCrowModule
 from utils import mathUtils
 
-# in general, we will use Crow for now, but let's make it easy to switch just in case it is helpfull eventually.
+# in general, we will use Crow for now, but let's make it easy to switch just in case it is helpful eventually.
 # Numpy stochastic environment can not pass the test as this point
 stochasticEnv = 'crow'
 #stochasticEnv = 'numpy'
@@ -200,20 +201,36 @@ def randomIntegers(low, high, caller=None, engine=None):
   else:
     raise TypeError('Engine type not recognized! {}'.format(type(engine)))
 
-def randomChoice(array, engine=None):
+def randomChoice(array, size = 1, replace = True, engine = None):
   """
-    Generates a random sample from a given array-like (list or such) or N-D array
+    Generates a random sample or a sequence of random samples from a given array-like (list or such) or N-D array
     This equivalent to np.random.choice but extending the functionality to N-D arrays
     @ In, array, list or np.ndarray, the array from which to pick
+    @ In, size, int, optional, the number of samples to return
+    @ In, replace, bool, optional, allows replacement if True, default is True
     @ In, engine, instance, optional, optional, random number generator
-    @ Out, randomChoice, object, the random choice (1 element)
+    @ Out, selected, object, the random choice (1 element) or a list of elements
   """
   assert(hasattr(array,"shape") or isinstance(array,list))
-  if hasattr(array,"shape"):
-    coord = tuple([randomIntegers(0, dim-1, engine=engine) for dim in array.shape])
-    return array[coord]
-  else:
-    return array[randomIntegers(0, len(array)-1, engine=engine)]
+
+  if not replace:
+    if hasattr(array,"shape"):
+      raise RuntimeError("Option with replace False not available for ndarrays")
+    if len(array) < size:
+      raise RuntimeError("array size < of number of requested samples (size)")
+
+  sel = []
+  coords = array
+  for _ in range(size):
+    if hasattr(array,"shape"):
+      coord = tuple([randomIntegers(0, dim-1, engine=engine) for dim in coords.shape])
+      sel.append(coords[coord])
+    else:
+      sel.append(coords[randomIntegers(0, len(coords)-1, engine=engine)])
+    if not replace:
+      coords.remove(sel[-1])
+  selected = sel[0] if size == 1 else sel
+  return selected
 
 def randomPermutation(l,caller,engine=None):
   """

--- a/tests/framework/unit_tests/Distributions/TestDistributions.py
+++ b/tests/framework/unit_tests/Distributions/TestDistributions.py
@@ -45,7 +45,7 @@ def createElement(tag,attrib={},text={}):
     Method to create a dummy xml element readable by the distribution classes
     @ In, tag, string, the node tag
     @ In, attrib, dict, optional, the attribute of the xml node
-    @ In, text, dict, optional, the dict containig what should be in the xml text
+    @ In, text, dict, optional, the dict containing what should be in the xml text
   """
   element = ET.Element(tag,attrib)
   element.text = text
@@ -79,8 +79,8 @@ def checkCrowDist(comment,dist,expectedCrowDist):
   """
     Check the consistency of the crow distributions
     @ In, comment, string, a comment
-    @ In, dist, instance, the distrubtion to inquire
-    @ In, expectedCrowDist, dict, the dictionary of the expected distrubution (with all the parameters)
+    @ In, dist, instance, the distribution to inquire
+    @ In, expectedCrowDist, dict, the dictionary of the expected distribution (with all the parameters)
     @ Out, None
   """
   crowDist = dist.getCrowDistDict()
@@ -94,7 +94,7 @@ def checkIntegral(name,dist,low,high,numpts=1e4,tol=1e-3):
   """
     Check the consistency of the pdf integral (cdf)
     @ In, name, string, the name printed out if it fails
-    @ In, dist, instance, the distrubtion to inquire
+    @ In, dist, instance, the distribution to inquire
     @ In, low, float, the lower bound of the dist
     @ In, high, float, the uppper bound of the dist
     @ In, numpts, int, optional, the number of integration points
@@ -1106,6 +1106,33 @@ checkAnswer("Custom1D cdf(1.9)",Custom1D.cdf(1.9), 0.971283153684)
 
 checkAnswer("Custom1D ppf(0.0139034475135)",Custom1D.ppf(0.0139034475135),-2.19999191499)
 checkAnswer("Custom1D ppf(00.971283440184)",Custom1D.ppf(0.971283440184),1.90000436617)
+
+#Test UniformDiscrete
+
+UniformDiscreteElement = ET.Element("UniformDiscrete",{"name":"test"})
+UniformDiscreteElement.append(createElement("lowerBound", text="3"))
+UniformDiscreteElement.append(createElement("upperBound", text="6"))
+UniformDiscreteElement.append(createElement("strategy", text="withoutReplacement"))
+
+UniformDiscrete = getDistribution(UniformDiscreteElement)
+
+## Should these be checked?
+initParams = UniformDiscrete.getInitParams()
+
+discardedElems = np.array([5,6])
+
+checkAnswer("UniformDiscrete rvs1",UniformDiscrete.selectedRvs(discardedElems),3)
+checkAnswer("UniformDiscrete rvs2",UniformDiscrete.selectedRvs(discardedElems),3)
+checkAnswer("UniformDiscrete rvs3",UniformDiscrete.selectedRvs(discardedElems),3)
+checkAnswer("UniformDiscrete rvs4",UniformDiscrete.selectedRvs(discardedElems),4)
+checkAnswer("UniformDiscrete rvs5",UniformDiscrete.selectedRvs(discardedElems),3)
+checkAnswer("UniformDiscrete rvs6",UniformDiscrete.selectedRvs(discardedElems),3)
+checkAnswer("UniformDiscrete rvs7",UniformDiscrete.selectedRvs(discardedElems),4)
+checkAnswer("UniformDiscrete rvs8",UniformDiscrete.selectedRvs(discardedElems),4)
+checkAnswer("UniformDiscrete rvs9",UniformDiscrete.selectedRvs(discardedElems),4)
+checkAnswer("UniformDiscrete rvs10",UniformDiscrete.selectedRvs(discardedElems),3)
+checkAnswer("UniformDiscrete rvs11",UniformDiscrete.selectedRvs(discardedElems),4)
+checkAnswer("UniformDiscrete rvs12",UniformDiscrete.selectedRvs(discardedElems),3)
 
 
 print(results)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
This PR contains the Distribution changes that are part of the GA PR #1253

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

