### PR TITLE
phisics related portion from GA PR

### DIFF
--- a/framework/CodeInterfaces/PHISICS/PhisicsInterface.py
+++ b/framework/CodeInterfaces/PHISICS/PhisicsInterface.py
@@ -19,6 +19,14 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 import os
 import re
 from CodeInterfaceBaseClass import CodeInterfaceBase
+from GenericParser import GenericParser
+import DecayParser
+import FissionYieldParser
+import QValuesParser
+import MaterialParser
+import PathParser
+import XSCreator
+import MassParser  # for MRTAU standalone
 import phisicsdata
 import xml.etree.ElementTree as ET
 
@@ -113,7 +121,9 @@ class Phisics(CodeInterfaceBase):
     """
     self.jobTitle = 'defaultInstant'
     for child in depletionRoot.findall(".//title"):
-      self.jobTitle = child.text
+      self.jobTitle = child.text.strip()
+      if " " in self.jobTitle:
+        raise IOError("Job title can not have spaces in the title but must be a single string. E.g. from "+self.jobTitle+ " to "+ self.jobTitle.replace(" ",""))
       break
     return
 
@@ -156,16 +166,18 @@ class Phisics(CodeInterfaceBase):
     """
     distributedPerturbedVars = {}
     pertType = []
-    for i in perturbedVars.keys(
-    ):  # teach what are the type of perturbation (decay FY etc...)
-      splittedKeywords = i.split('|')
-      pertType.append(splittedKeywords[0])
-    for i in range(
-        0, len(pertType)
-    ):  # declare all the dictionaries according the different type of pert
+    for i in perturbedVars.keys():
+      # teach what are the type of perturbation (decay FY etc...)
+      if "|" in i:
+        pertType.append(i.split('|')[0])
+      else:
+        pertType.append("generic")
+    for i in range(0, len(pertType)):
+      # declare all the dictionaries according the different type of pert
       distributedPerturbedVars[pertType[i]] = {}
-    for key, value in perturbedVars.items():  # populate the dictionaries
-      splittedKeywords = key.split('|')
+    for key, value in perturbedVars.items():
+      # populate the dictionaries
+      splittedKeywords = key.split('|') if '|' in key else ["generic"]
       for j in range(0, len(pertType)):
         if splittedKeywords[0] == pertType[j]:
           distributedPerturbedVars[pertType[j]][key] = value
@@ -249,11 +261,11 @@ class Phisics(CodeInterfaceBase):
       commandToRun = executable
       outputfile = 'out~'
     else:
-      commandToRun = executable + ' ' + inputFiles[mapDict['inp'.lower(
-      )]].getFilename() + ' ' + inputFiles[mapDict['Xs-library'.lower(
-      )]].getFilename() + ' ' + inputFiles[mapDict['Material'.lower(
-      )]].getFilename() + ' ' + inputFiles[mapDict['Depletion_input'.lower(
-      )]].getFilename() + ' ' + self.instantOutput
+      commandToRun = executable + ' -i ' + inputFiles[mapDict['inp'.lower(
+      )]].getFilename() + ' -xs ' + inputFiles[mapDict['Xs-library'.lower(
+      )]].getFilename() + ' -mat ' + inputFiles[mapDict['Material'.lower(
+      )]].getFilename() + ' -dep ' + inputFiles[mapDict['Depletion_input'.lower(
+      )]].getFilename() + ' -o ' + self.instantOutput
       commandToRun = commandToRun.replace("\n", " ")
       commandToRun = re.sub("\s\s+", " ", commandToRun)
       outputfile = 'out~' + inputFiles[mapDict['inp'.lower()]].getBase()
@@ -425,13 +437,7 @@ class Phisics(CodeInterfaceBase):
              where RAVEN stores the variables that got sampled (e.g. Kwargs['SampledVars'] => {'var1':10,'var2':40})
       @ Out, currentInputFiles, list, list of current input files (input files from last this method call) (perturbed)
     """
-    import DecayParser
-    import FissionYieldParser
-    import QValuesParser
-    import MaterialParser
-    import PathParser
-    import XSCreator
-    import MassParser  # for MRTAU standalone
+
     self.typeDict = {}
     self.typeDict = self.mapInputFileType(currentInputFiles)
     self.checkInput()
@@ -444,7 +450,7 @@ class Phisics(CodeInterfaceBase):
         currentInputFiles[self.typeDict['path']].getAbsFile(),
         currentInputFiles, self.typeDict)
     self.outputFileNames(currentInputFiles[self.typeDict['path']].getAbsFile())
-    self.instantOutput = self.jobTitle + '.o'
+    self.instantOutput = self.jobTitle.replace(" ", "") + '.o'
     self.depInp = currentInputFiles[self.typeDict[
         'depletion_input']].getAbsFile()  # for PHISICS/RELAP interface
     if not self.mrtauStandAlone:
@@ -517,6 +523,13 @@ class Phisics(CodeInterfaceBase):
             currentInputFiles[self.typeDict['mass']].getAbsFile(),
             currentInputFiles[self.typeDict['mass']].getPath(),
             **self.distributedPerturbedVars[perturbedParam])
+      if perturbedParam == 'generic':
+        # check and modify modelpar.inp file
+        modelParParser = GenericParser(currentInputFiles)
+        modelParParser.modifyInternalDictionary(**Kwargs)
+        modelParParser.writeNewInput(currentInputFiles,oriInputFiles)
+
+
       # add CSV output from depletion
       tree = ET.parse(currentInputFiles[self.typeDict['depletion_input']].getAbsFile())
       depletionRoot = tree.getroot()

--- a/framework/CodeInterfaces/PHISICS/phisicsdata.py
+++ b/framework/CodeInterfaces/PHISICS/phisicsdata.py
@@ -144,6 +144,7 @@ class phisicsdata():
         else:
           phisicsDict['matFluxLabelList'] = matFluxLabelList
           phisicsDict['matFluxList'] = matFluxList
+
         # collect data
         h, snapshoot = self.phisicsTimeStepData(phisicsDict, timeStepIndex, mrtauTimeSteps)
         if data is None:
@@ -174,7 +175,7 @@ class phisicsdata():
   def summedDictValues(self, nestedDict):
     """
       Sums the values from the deepest nest of a dictionary.
-      @ In, nestedDict, dictionary, nested dictionaries of intergers or floats
+      @ In, nestedDict, dictionary, nested dictionaries of integers or floats
       @ Out, summedDict, dictionary, dictionary of integer or float
     """
     summedDict = lambda: defaultdict(summedDict)
@@ -220,7 +221,7 @@ class phisicsdata():
     """
       Removes the file that RAVEN reads for postprocessing.
       @ In, jobTitle, string, job title name
-      @ In, bool, bool, True if mrtau is standalone, false otherwise
+      @ In, bool, bool, True if mrtau is stand alone, false otherwise
       @ Out, None
     """
     if not bool:
@@ -320,6 +321,7 @@ class phisicsdata():
     """
     count = 0
     timeSteps = []
+    nts = 0
     with open(os.path.join(self.workingDir, self.mrtauOutputFileMPI[0]),
               'r') as outfile:
       for line in outfile:
@@ -328,12 +330,14 @@ class phisicsdata():
         if count == 1:
           stringIsFloatNumber = self.isFloatNumber(line.split(','))
           if stringIsFloatNumber:
+            ts = float(line.split(',')[0])
+            if timeSteps and ts <= float(timeSteps[-1]):
+              break
             timeSteps.append(line.split(',')[0])
         if count > 1:
           break
-    timeSteps.pop(
-        0
-    )  # Removes the first time step, t=0, to make the number of time steps match with the number of time steps in INSTANT.
+    # Removes the first time step, t=0, to make the number of time steps match with the number of time steps in INSTANT.
+    timeSteps.pop(0)
     return timeSteps
 
   def getMrtauTimeSteps(self, atomsInp):
@@ -352,7 +356,7 @@ class phisicsdata():
 
   def getMrtauIsotopeList(self, atomsInp):
     """
-      Gets the isotope in the MRTAU standalone output.
+      Gets the isotope in the MRTAU stand alone output.
       @ In, atomsInp, string, path to file pointed by the node <atoms_csv> in the lib path file
       @ Out, None
     """
@@ -544,10 +548,10 @@ class phisicsdata():
     """
       Locates what the position number of the x, y, z coordinates and the first energy group are in the INSTANT csv output file.
       @ In, IDlist, list, list of all the parameter in the csv output
-      @ Out, xPositionInList, interger, position of the parameter x in the list
-      @ Out, yPositionInList, interger, position of the parameter y in the list
-      @ Out, zPositionInList, interger, position of the parameter z in the list
-      @ Out, firstGroupPositionInList, interger, position of the first energy parameter
+      @ Out, xPositionInList, integer, position of the parameter x in the list
+      @ Out, yPositionInList, integer, position of the parameter y in the list
+      @ Out, zPositionInList, integer, position of the parameter z in the list
+      @ Out, firstGroupPositionInList, integer, position of the first energy parameter
     """
     xPositionInList = None
     yPositionInList = None
@@ -703,7 +707,7 @@ class phisicsdata():
       Reads the INSTANT csv file to get the material density info relative to depletion.
       @ In, timeStepIndex, integer, timestep number
       @ In, matchedTimeSteps, list, list of time steps considered
-      @ In, numberOfMPI, interger, number of MPI used
+      @ In, numberOfMPI, integer, number of MPI used
       @ Out, depLabelList, list, list of labels relative to depletion
       @ Out, depList, list, list of values relative to depletion
     """
@@ -719,7 +723,7 @@ class phisicsdata():
         for line in outfile:
           line = re.sub(
               r' ', r'', line
-          )  # remove all spaces in a line. comma sperarated lines are parsed below
+          )  # remove all spaces in a line. comma separated lines are parsed below
           if re.search(r'TIME', line):
             line = line.rstrip()
             self.isotopeList = line.split(',')
@@ -778,7 +782,7 @@ class phisicsdata():
   def getCPUtime(self, numberOfMPI):
     """
       Gets the PHISICS CPU time.
-      @ In, numberOfMPI, interger, number of MPI user-selected
+      @ In, numberOfMPI, integer, number of MPI user-selected
       @ Out, cpuTime, list, cpu time (string) in a list
     """
     cpuTimes = []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
This PR contains the changes on the Phisics code interface that are part of the GA PR #1253.
These changes were made to increase RAVEN functionalities to parse phisics input file and retrieve data generated by phisics.

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

