### PR TITLE
Switching back to https instead of ssh.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "plugins/TEAL"]
 	path = plugins/TEAL
-	url = git@github.com:idaholab/TEAL.git
+	url = https://github.com/idaholab/TEAL.git
 [submodule "plugins/HERON"]
 	path = plugins/HERON
-	url = git@github.com:idaholab/HERON.git
+	url = https://github.com/idaholab/HERON.git
 [submodule "plugins/SR2ML"]
 	path = plugins/SR2ML
-	url = git@github.com:idaholab/SR2ML.git
+	url = https://github.com/idaholab/SR2ML.git
 [submodule "plugins/LOGOS"]
 	path = plugins/LOGOS
-	url = git@github.com:idaholab/LOGOS.git
+	url = https://github.com/idaholab/LOGOS.git
 [submodule "plugins/SRAW"]
 	path = plugins/SRAW
 	url = git@hpcgitlab.hpc.inl.gov:RAVEN_PLUGINS/SRAW.git
 [submodule "plugins/FARM"]
 	path = plugins/FARM
-	url = git@github.com:Argonne-National-Laboratory/FARM.git
+	url = https://github.com/Argonne-National-Laboratory/FARM.git


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
closes #1453 


##### What are the significant changes in functionality due to this change request?
This tests using https instead of ssh.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

