### PR TITLE
Standardize collectOutput method for PostProcessor

### DIFF
--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -140,7 +140,6 @@ class BasicStatistics(PostProcessor):
     self.sampleTag      = None  # Tag used to track samples
     self.pbPresent      = False # True if the ProbabilityWeight is available
     self.realizationWeight = None # The joint probabilities
-    self.outputDataset  = False # True if the user wants to dump the outputs to dataset
     self.steMetaIndex   = 'targets' # when Dataset is requested as output, the default index of ste metadata is ['targets', self.pivotParameter]
     self.multipleFeatures = True # True if multiple features are employed in linear regression as feature inputs
     self.sampleSize     = None # number of sample size

--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -1307,15 +1307,3 @@ class BasicStatistics(PostProcessor):
       @ Out, None
     """
     PostProcessor.collectOutput(self, finishedJob, output, options=options)
-    evaluation = finishedJob.getEvaluation()
-    outputRealization = evaluation[1]
-    if output.type in ['PointSet','HistorySet']:
-      if self.outputDataset:
-        self.raiseAnError(IOError, "DataSet output is required, but the provided type of DataObject is",output.type)
-      self.raiseADebug('Dumping output in data object named ' + output.name)
-      output.addRealization(outputRealization)
-    elif output.type in ['DataSet']:
-      self.raiseADebug('Dumping output in DataSet named ' + output.name)
-      output.load(outputRealization,style='dataset')
-    else:
-      self.raiseAnError(IOError, 'Output type ' + str(output.type) + ' unknown.')

--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -145,6 +145,7 @@ class BasicStatistics(PostProcessor):
     self.multipleFeatures = True # True if multiple features are employed in linear regression as feature inputs
     self.sampleSize     = None # number of sample size
     self.calculations   = {}
+    self.validDataType  = ['PointSet', 'HistorySet', 'DataSet'] # The list of accepted types of DataObject
 
   def inputToInternal(self, currentInp):
     """
@@ -1296,13 +1297,16 @@ class BasicStatistics(PostProcessor):
     outputSet = self.__runLocal(inputData)
     return outputSet
 
-  def collectOutput(self, finishedJob, output):
+  def collectOutput(self, finishedJob, output, options=None):
     """
       Function to place all of the computed data into the output object
       @ In, finishedJob, JobHandler External or Internal instance, A JobHandler object that is in charge of running this post-processor
       @ In, output, dataObjects, The object where we want to place our computed results
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
+    PostProcessor.collectOutput(self, finishedJob, output, options=options)
     evaluation = finishedJob.getEvaluation()
     outputRealization = evaluation[1]
     if output.type in ['PointSet','HistorySet']:

--- a/framework/Models/PostProcessors/DataClassifier.py
+++ b/framework/Models/PostProcessors/DataClassifier.py
@@ -220,8 +220,7 @@ class DataClassifier(PostProcessor):
       else:
         outputDict[self.label].append(np.asarray([label]*targetDict['historySizes'][i]))
     outputDict[self.label] = np.asarray(outputDict[self.label])
-    outputDict['dims'] = inputDict['target']['dims']
-
+    outputDict = {'data': outputDict, 'dims':inputDict['target']['dims']}
     return outputDict
 
   def collectOutput(self, finishedJob, output, options=None):

--- a/framework/Models/PostProcessors/DataClassifier.py
+++ b/framework/Models/PostProcessors/DataClassifier.py
@@ -196,7 +196,7 @@ class DataClassifier(PostProcessor):
       outputDict['historySizes'] = copy.copy(targetDict['historySizes'])
 
     numRlz = utils.first(targetDict['input'].values()).size
-    outputDict[self.label] = np.empty(numRlz)
+    outputDict[self.label] = []
     for i in range(numRlz):
       tempTargDict = {}
       for param, vals in targetDict['input'].items():
@@ -214,8 +214,12 @@ class DataClassifier(PostProcessor):
           labelIndex = labelIndex & set(inds)
       if len(labelIndex) != 1:
         self.raiseAnError(IOError, "The parameters", ",".join(tempTargDict.keys()), "with values", ",".join([str(el) for el in tempTargDict.values()]), "could not be put in any class!")
-      outputDict[self.label][i] = classifierDict['output'][self.label][list(labelIndex)[0]]
-
+      label = classifierDict['output'][self.label][list(labelIndex)[0]]
+      if outputType == 'PointSet':
+        outputDict[self.label].append(label)
+      else:
+        outputDict[self.label].append(np.asarray([label]*outputDict['historySizes'][i]))
+    outputDict[self.label] = np.asarray(outputDict[self.label])
     return outputDict
 
   def collectOutput(self, finishedJob, output):
@@ -235,34 +239,13 @@ class DataClassifier(PostProcessor):
       if inp.name == outputDict['dataFrom']:
         inputObject = inp
         break
-    if inputObject != output:
-      ## Copy any data you need from the input DataObject before adding new data
-      rlzs = inputObject.asDataset(outType='dict')['data']
-      if output.type == 'PointSet':
-        output.load(rlzs, style='dict')
-      elif output.type == 'HistorySet':
-        if inputObject.type != 'HistorySet':
-          self.raiseAnError(IOError, "Copying the data from input PointSet", inputObject.name, "to output HistorySet", output.name, "is currently not allowed!")
-        output.load(rlzs, style='dict', dims=inputObject.getDimensions())
 
+    ## Copy any data you need from the input DataObject before adding new data
+    rlzs = inputObject.asDataset(outType='dict')['data']
+    rlzs[self.label] = outputDict[self.label]
     if output.type == 'PointSet':
-      output.addVariable(self.label, copy.copy(outputDict[self.label]), classify='output')
+      output.load(rlzs, style='dict')
     elif output.type == 'HistorySet':
-      numRlzs = output.size
-      labelValues = np.zeros(numRlzs, dtype=object)
-      pivotParams = tuple(output.indexes)
-      slices = output.sliceByIndex('RAVEN_sample_ID')
-      coordList = []
-      for i in range(numRlzs):
-        coordDict = {}
-        for elem in pivotParams:
-          coordDict[elem] = slices[i].dropna(elem)[elem]
-        coordList.append(coordDict)
-
-      for i in range(numRlzs):
-        histSize = outputDict['historySizes'][i]
-        values = np.empty(histSize)
-        values.fill(outputDict[self.label][i])
-        xrArray = xr.DataArray(values, dims=pivotParams, coords=coordList[i])
-        labelValues[i] = xrArray
-      output.addVariable(self.label, labelValues, classify='output')
+      if inputObject.type != 'HistorySet':
+        self.raiseAnError(IOError, "Copying the data from input PointSet", inputObject.name, "to output HistorySet", output.name, "is currently not allowed!")
+      output.load(rlzs, style='dict', dims=inputObject.getDimensions())

--- a/framework/Models/PostProcessors/ETImporter.py
+++ b/framework/Models/PostProcessors/ETImporter.py
@@ -53,7 +53,11 @@ class ETImporter(PostProcessor):
     self.fileFormat = None # chosen format of the ET file
     self.allowedFormats = ['OpenPSA'] # ET formats that are supported
     self.validDataType = ['PointSet'] # The list of accepted types of DataObject
-
+    ## Currently, we have used both DataObject.addRealization and DataObject.load to
+    ## collect the PostProcessor returned outputs. DataObject.addRealization is used to
+    ## collect single realization, while DataObject.load is used to collect multiple realizations
+    ## However, the DataObject.load can not be directly used to collect single realization
+    self.outputMultipleRealizations = True
 
   @classmethod
   def getInputSpecification(cls):

--- a/framework/Models/PostProcessors/ETImporter.py
+++ b/framework/Models/PostProcessors/ETImporter.py
@@ -52,6 +52,8 @@ class ETImporter(PostProcessor):
                            # original tree
     self.fileFormat = None # chosen format of the ET file
     self.allowedFormats = ['OpenPSA'] # ET formats that are supported
+    self.validDataType = ['PointSet'] # The list of accepted types of DataObject
+
 
   @classmethod
   def getInputSpecification(cls):
@@ -95,35 +97,20 @@ class ETImporter(PostProcessor):
   def run(self, inputs):
     """
       This method executes the PostProcessor action.
-      @ In,  inputs, list, list of file objects
-      @ Out, None
+      @ In, inputs, list, list of file objects
+      @ Out, outputDict, dict, dictionary of outputs
     """
     eventTreeModel = ETStructure(self.expand, inputs)
-    return eventTreeModel.returnDict()
+    outputDict, variables = eventTreeModel.returnDict()
+    return outputDict
 
-  def collectOutput(self, finishedJob, output):
+  def collectOutput(self, finishedJob, output, options=None):
     """
       Function to place all of the computed data into the output object, (DataObjects)
       @ In, finishedJob, object, JobHandler object that is in charge of running this PostProcessor
       @ In, output, object, the object where we want to place our computed results
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
-    evaluation = finishedJob.getEvaluation()
-    outputDict ={}
-    outputDict['data'], variables = evaluation[1]
-    if not set(output.getVars('input')) == set(variables):
-      self.raiseAnError(RuntimeError, ' ETImporter: set of branching variables in the '
-                                      'ET ( ' + str(variables)  + ' ) is not identical to the'
-                                      ' set of input variables specified in the PointSet (' + str(output.getParaKeys('inputs')) +')')
-    # Output to file
-    if set(outputDict['data'].keys()) != set(output.getVars(subset='input')+output.getVars(subset='output')):
-      self.raiseAnError(RuntimeError, 'ETImporter failed: set of variables specified in the output '
-                                      'dataObject (' + str(set(outputDict['data'].keys())) + ') is different from the set of '
-                                      'variables specified in the ET (' + str(set(output.getVars(subset='input')+output.getVars(subset='output'))))
-    if output.type in ['PointSet']:
-      outputDict['dims'] = {}
-      for key in outputDict.keys():
-        outputDict['dims'][key] = []
-      output.load(outputDict['data'], style='dict', dims=outputDict['dims'])
-    else:
-        self.raiseAnError(RuntimeError, 'ETImporter failed: Output type ' + str(output.type) + ' is not supported.')
+    PostProcessor.collectOutput(self, finishedJob, output, options=options)

--- a/framework/Models/PostProcessors/ETImporter.py
+++ b/framework/Models/PostProcessors/ETImporter.py
@@ -106,6 +106,7 @@ class ETImporter(PostProcessor):
     """
     eventTreeModel = ETStructure(self.expand, inputs)
     outputDict, variables = eventTreeModel.returnDict()
+    outputDict = {'data': outputDict, 'dims':{}}
     return outputDict
 
   def collectOutput(self, finishedJob, output, options=None):

--- a/framework/Models/PostProcessors/FTImporter.py
+++ b/framework/Models/PostProcessors/FTImporter.py
@@ -63,6 +63,11 @@ class FTImporter(PostProcessor):
     self.FTFormat = None # chosen format of the FT file
     self.topEventID = None
     self.validDataType = ['PointSet'] # The list of accepted types of DataObject
+    ## Currently, we have used both DataObject.addRealization and DataObject.load to
+    ## collect the PostProcessor returned outputs. DataObject.addRealization is used to
+    ## collect single realization, while DataObject.load is used to collect multiple realizations
+    ## However, the DataObject.load can not be directly used to collect single realization
+    self.outputMultipleRealizations = True
 
   def initialize(self, runInfo, inputs, initDict) :
     """

--- a/framework/Models/PostProcessors/FTImporter.py
+++ b/framework/Models/PostProcessors/FTImporter.py
@@ -62,6 +62,7 @@ class FTImporter(PostProcessor):
     self.printTag = 'POSTPROCESSOR FT IMPORTER'
     self.FTFormat = None # chosen format of the FT file
     self.topEventID = None
+    self.validDataType = ['PointSet'] # The list of accepted types of DataObject
 
   def initialize(self, runInfo, inputs, initDict) :
     """
@@ -94,21 +95,13 @@ class FTImporter(PostProcessor):
     faultTreeModel = FTStructure(inputs, self.topEventID)
     return faultTreeModel.returnDict()
 
-  def collectOutput(self, finishedJob, output):
+  def collectOutput(self, finishedJob, output, options=None):
     """
       Function to place all of the computed data into the output object, (DataObjects)
-      @ In, finishedJob, object, JobHandler object that is in charge of running this postprocessor
+      @ In, finishedJob, object, JobHandler object that is in charge of running this PostProcessor
       @ In, output, object, the object where we want to place our computed results
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
-    evaluation = finishedJob.getEvaluation()
-    outputDict ={}
-    outputDict['data'] = evaluation[1]
-
-    outputDict['dims'] = {}
-    for key in outputDict['data'].keys():
-      outputDict['dims'][key] = []
-    if output.type in ['PointSet']:
-      output.load(outputDict['data'], style='dict', dims=outputDict['dims'])
-    else:
-      self.raiseAnError(RuntimeError, 'FTImporter failed: Output type ' + str(output.type) + ' is not supported.')
+    PostProcessor.collectOutput(self, finishedJob, output, options=options)

--- a/framework/Models/PostProcessors/FTImporter.py
+++ b/framework/Models/PostProcessors/FTImporter.py
@@ -95,10 +95,12 @@ class FTImporter(PostProcessor):
     """
       This method executes the postprocessor action.
       @ In,  inputs, list, list of file objects
-      @ Out, out, dict, dict containing the processed FT
+      @ Out, outputDict, dict, dict containing the processed FT
     """
     faultTreeModel = FTStructure(inputs, self.topEventID)
-    return faultTreeModel.returnDict()
+    outputDict = faultTreeModel.returnDict()
+    outputDict = {'data': outputDict, 'dims':{}}
+    return outputDict
 
   def collectOutput(self, finishedJob, output, options=None):
     """

--- a/framework/Models/PostProcessors/InterfacedPostProcessor.py
+++ b/framework/Models/PostProcessors/InterfacedPostProcessor.py
@@ -85,6 +85,11 @@ class InterfacedPostProcessor(PostProcessor):
     """
     PostProcessor.__init__(self, runInfoDict)
     self.methodToRun = None
+    ## Currently, we have used both DataObject.addRealization and DataObject.load to
+    ## collect the PostProcessor returned outputs. DataObject.addRealization is used to
+    ## collect single realization, while DataObject.load is used to collect multiple realizations
+    ## However, the DataObject.load can not be directly used to collect single realization
+    self.outputMultipleRealizations = True
 
   def initialize(self, runInfo, inputs, initDict):
     """
@@ -199,13 +204,13 @@ class InterfacedPostProcessor(PostProcessor):
       form = self.postProcessor.outputFormat
     return form
 
-  def collectOutput(self, finishedJob, output):
+  def collectOutput(self, finishedJob, output, options=None):
     """
-      Function to place all of the computed data into the output object
-      @ In, finishedJob, JobHandler External or Internal instance, A JobHandler object that is in charge of running this post-processor
-      @ In, output, dataObjects, The object where we want to place our computed results
+      Function to place all of the computed data into the output object, (DataObjects)
+      @ In, finishedJob, object, JobHandler object that is in charge of running this PostProcessor
+      @ In, output, object, the object where we want to place our computed results
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
-    evaluations = finishedJob.getEvaluation()
-    evaluation = evaluations[1]
-    output.load(evaluation['data'], style='dict', dims=evaluation['dims'])
+    PostProcessor.collectOutput(self, finishedJob, output, options=options)

--- a/framework/Models/PostProcessors/MCSimporter.py
+++ b/framework/Models/PostProcessors/MCSimporter.py
@@ -51,6 +51,11 @@ class MCSImporter(PostProcessor):
                            # all possible sequences are generated. Sequence label is maintained according to the
                            # original tree
     self.validDataType = ['PointSet'] # The list of accepted types of DataObject
+    ## Currently, we have used both DataObject.addRealization and DataObject.load to
+    ## collect the PostProcessor returned outputs. DataObject.addRealization is used to
+    ## collect single realization, while DataObject.load is used to collect multiple realizations
+    ## However, the DataObject.load can not be directly used to collect single realization
+    self.outputMultipleRealizations = True
 
   @classmethod
   def getInputSpecification(cls):

--- a/framework/Models/PostProcessors/MCSimporter.py
+++ b/framework/Models/PostProcessors/MCSimporter.py
@@ -144,7 +144,7 @@ class MCSImporter(PostProcessor):
       for be in mcs:
         mcsPointSet[be][counter] = 1.0
       counter = counter+1
-
+    mcsPointSet = {'data': mcsPointSet, 'dims': {}}
     return mcsPointSet
 
   def collectOutput(self, finishedJob, output, options=None):

--- a/framework/Models/PostProcessors/MCSimporter.py
+++ b/framework/Models/PostProcessors/MCSimporter.py
@@ -50,6 +50,7 @@ class MCSImporter(PostProcessor):
     self.expand    = None  # option that controls the structure of the ET. If True, the tree is expanded so that
                            # all possible sequences are generated. Sequence label is maintained according to the
                            # original tree
+    self.validDataType = ['PointSet'] # The list of accepted types of DataObject
 
   @classmethod
   def getInputSpecification(cls):
@@ -141,24 +142,16 @@ class MCSImporter(PostProcessor):
 
     return mcsPointSet
 
-  def collectOutput(self, finishedJob, output):
+  def collectOutput(self, finishedJob, output, options=None):
     """
       Function to place all of the computed data into the output object, (DataObjects)
       @ In, finishedJob, object, JobHandler object that is in charge of running this PostProcessor
       @ In, output, object, the object where we want to place our computed results
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
-    evaluation = finishedJob.getEvaluation()
-    outputDict ={}
-    outputDict['data'] = evaluation[1]
-
-    if output.type in ['PointSet']:
-      outputDict['dims'] = {}
-      for key in outputDict.keys():
-        outputDict['dims'][key] = []
-      output.load(outputDict['data'], style='dict', dims=outputDict['dims'])
-    else:
-        self.raiseAnError(RuntimeError, 'MCSImporter failed: Output type ' + str(output.type) + ' is not supported.')
+    PostProcessor.collectOutput(self, finishedJob, output, options=options)
 
 def mcsReader(mcsListFile):
   """

--- a/framework/Models/PostProcessors/ParetoFrontierPostProcessor.py
+++ b/framework/Models/PostProcessors/ParetoFrontierPostProcessor.py
@@ -163,7 +163,7 @@ class ParetoFrontier(PostProcessor):
     paretoFrontierDict = {}
     for index,varID in enumerate(sortedData.data_vars):
       paretoFrontierDict[varID] = paretoFrontierData[:,index]
-
+    paretoFrontierDict = {'data':paretoFrontierDict, 'dims':{}}
     return paretoFrontierDict
 
   def collectOutput(self, finishedJob, output, options=None):

--- a/framework/Models/PostProcessors/ParetoFrontierPostProcessor.py
+++ b/framework/Models/PostProcessors/ParetoFrontierPostProcessor.py
@@ -44,6 +44,8 @@ class ParetoFrontier(PostProcessor):
     self.costLimit  = None   # variable associated with the upper limit of the cost dimension
     self.invCost    = False  # variable which indicates if the cost dimension is inverted (e.g., it represents savings rather than costs)
     self.invValue   = False  # variable which indicates if the value dimension is inverted (e.g., it represents a lost value rather than value)
+    self.validDataType = ['PointSet'] # The list of accepted types of DataObject
+    self.outputMultipleRealizations = True # True indicate multiple realizations are returned
 
   @classmethod
   def getInputSpecification(cls):
@@ -164,22 +166,13 @@ class ParetoFrontier(PostProcessor):
 
     return paretoFrontierDict
 
-  def collectOutput(self, finishedJob, output):
+  def collectOutput(self, finishedJob, output, options=None):
     """
       Function to place all of the computed data into the output object
       @ In, finishedJob, JobHandler External or Internal instance, A JobHandler object that is in charge of running this post-processor
-      @ In, output, DataObject.DataObject, The object where we want to place our computed results
+      @ In, output, dataObjects, The object where we want to place our computed results
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
-    evaluation = finishedJob.getEvaluation()
-
-    outputDict ={}
-    outputDict['data'] = evaluation[1]
-
-    if output.type in ['PointSet']:
-      outputDict['dims'] = {}
-      for key in outputDict.keys():
-        outputDict['dims'][key] = []
-      output.load(outputDict['data'], style='dict', dims=outputDict['dims'])
-    else:
-        self.raiseAnError(RuntimeError, 'ParetoFrontier failed: Output type ' + str(output.type) + ' is not supported.')
+    PostProcessor.collectOutput(self, finishedJob, output, options=options)

--- a/framework/Models/PostProcessors/PostProcessor.py
+++ b/framework/Models/PostProcessors/PostProcessor.py
@@ -116,6 +116,8 @@ class PostProcessor(Model):
     ## collect the PostProcessor returned outputs. DataObject.addRealization is used to
     ## collect single realization, while DataObject.load is used to collect multiple realizations
     ## However, the DataObject.load can not be directly used to collect single realization
+    ## One possible solution is all postpocessors return a list of realizations, and we only
+    ## use addRealization method to add the collections into the DataObjects
     self.outputMultipleRealizations = False
 
   def _handleInput(self, paramInput):

--- a/framework/Models/PostProcessors/PostProcessor.py
+++ b/framework/Models/PostProcessors/PostProcessor.py
@@ -200,7 +200,7 @@ class PostProcessor(Model):
     kwargs['forceThreads'] = True
     Model.submit(self,myInput, samplerType, jobHandler,**kwargs)
 
-  def collectOutput(self,finishedjob,output,options=None):
+  def collectOutput(self,finishedJob,output,options=None):
     """
       Method that collects the outputs from the "run" method of the PostProcessor
       @ In, finishedJob, InternalRunner object, instance of the run just finished

--- a/framework/Models/PostProcessors/PostProcessor.py
+++ b/framework/Models/PostProcessors/PostProcessor.py
@@ -25,6 +25,7 @@ import copy
 #External Modules End--------------------------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------
+import Runners
 from Models import Model
 from Decorators.Parallelization import Parallel
 #Internal Modules End--------------------------------------------------------------------------------

--- a/framework/Models/PostProcessors/PostProcessor.py
+++ b/framework/Models/PostProcessors/PostProcessor.py
@@ -109,21 +109,19 @@ class PostProcessor(Model):
     self.action = None            # action
     self.workingDir = ''          # path for working directory
     self.printTag = 'POSTPROCESSOR MODEL'
-
-  # use BaseClass method provideExpectedMetaKeys and addMetaKeys to provide and modify metadata
+    self.validDataType = ['PointSet','HistorySet'] # The list of accepted types of DataObject
 
   def _handleInput(self, paramInput):
     """
       Function to handle the common parts of the model parameter input.
-      @ In, paramInput, ParameterInput, the already parsed input.
+      @ In, paramInput, InputData.ParameterInput, the already parsed input.
       @ Out, None
     """
     Model._handleInput(self, paramInput)
 
   def initialize(self, runInfo, inputs, initDict=None):
     """
-      this needs to be over written if a re initialization of the model is need it gets called at every beginning of a step
-      after this call the next one will be run
+      Method to initialize the PostProcessor
       @ In, runInfo, dict, it is the run info from the jobHandler
       @ In, inputs, list, it is a list containing whatever is passed with an input role in the step
       @ In, initDict, dict, optional, dictionary of all objects available in the step is using this model
@@ -135,12 +133,10 @@ class PostProcessor(Model):
       self.workingDir = runInfo['WorkingDir']
     self.inputCheckInfo = [(inp.name, inp.type) for inp in inputs]
 
-  def createNewInput(self,myInput,samplerType,**kwargs): # --> inputToInternal
+  def createNewInput(self,myInput,samplerType,**kwargs):
     """
-      This function will return a new input to be submitted to the model, it is called by the sampler.
-      here only a PointSet is accepted a local copy of the values is performed.
-      For a PointSet, only the last set of entries is copied
-      The copied values are returned as a dictionary back
+      This function will return a new input to be submitted to the postprocesor.
+      (Not used but required by model base class)
       @ In, myInput, list, the inputs (list) to start from to generate the new one
       @ In, samplerType, string, is the type of sampler that is calling to generate a new input
       @ In, **kwargs, dict,  is a dictionary that contains the information coming from the sampler,
@@ -152,7 +148,7 @@ class PostProcessor(Model):
   def inputToInternal(self, currentInput):
     """
       Method to convert an input object into the internal format that is
-      understandable by this pp.
+      understandable by the PostProcessor.
       @ In, currentInput, object, an object that needs to be converted
       @ Out, inputToInternal, list, list of current inputs
     """
@@ -206,12 +202,15 @@ class PostProcessor(Model):
 
   def collectOutput(self,finishedjob,output,options=None):
     """
-      Method that collects the outputs from the previous run
+      Method that collects the outputs from the "run" method of the PostProcessor
       @ In, finishedJob, InternalRunner object, instance of the run just finished
       @ In, output, "DataObjects" object, output where the results of the calculation needs to be stored
-      @ In, options, dict, optional, dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
+    if output.type not in self.validDataType:
+      self.raiseAnError(IOError, 'Output type', str(output.type), 'is not allowed!')
     outputCheckInfo = (output.name, output.type)
     if outputCheckInfo in self.inputCheckInfo:
       self.raiseAnError(IOError, 'DataObject',output.name,'is used as both input and output of', \
@@ -220,15 +219,13 @@ class PostProcessor(Model):
     evaluation = finishedJob.getEvaluation()
     if isinstance(evaluation, Runners.Error):
       self.raiseAnError(RuntimeError, "No available output to collect (run possibly not finished yet)")
-
     outputRealization = evaluation[1]
+
     if output.type in ['PointSet','HistorySet']:
       if self.outputDataset:
-        self.raiseAnError(IOError, "DataSet output is required, but the provided type of DataObject is",output.type)
+        self.raiseAnError(IOError, "DataSet output is required, but the provided type of DataObject is", output.type)
       self.raiseADebug('Dumping output in data object named ' + output.name)
       output.addRealization(outputRealization)
     elif output.type in ['DataSet']:
       self.raiseADebug('Dumping output in DataSet named ' + output.name)
       output.load(outputRealization,style='dataset')
-    else:
-      self.raiseAnError(IOError, 'Output type ' + str(output.type) + ' unknown.')

--- a/framework/Models/PostProcessors/PostProcessor.py
+++ b/framework/Models/PostProcessors/PostProcessor.py
@@ -111,6 +111,7 @@ class PostProcessor(Model):
     self.workingDir = ''          # path for working directory
     self.printTag = 'POSTPROCESSOR MODEL'
     self.validDataType = ['PointSet','HistorySet'] # The list of accepted types of DataObject
+    self.outputDataset  = False # True if the user wants to dump the outputs to dataset
 
   def _handleInput(self, paramInput):
     """

--- a/framework/Models/PostProcessors/PostProcessor.py
+++ b/framework/Models/PostProcessors/PostProcessor.py
@@ -236,10 +236,11 @@ class PostProcessor(Model):
       self.raiseADebug('Dumping output in data object named ' + output.name)
       if self.outputMultipleRealizations:
         if 'dims' in outputRealization:
-          dims = outputRealization.pop('dims')
+          dims = outputRealization['dims']
         else:
           dims = {}
-        output.load(outputRealization, style='dict', dims=dims)
+        print(outputRealization.keys())
+        output.load(outputRealization['data'], style='dict', dims=dims)
       else:
         output.addRealization(outputRealization)
     elif output.type in ['DataSet']:

--- a/framework/Models/PostProcessors/RealizationAverager.py
+++ b/framework/Models/PostProcessors/RealizationAverager.py
@@ -57,6 +57,8 @@ class RealizationAverager(PostProcessor):
     PostProcessor.__init__(self, runInfoDict)
     self.dynamic = True # from base class, indicates time-dependence is handled internally
     self.targets = None # string, variables to apply postprocessor to
+    self.validDataType = ['DataSet'] # The list of accepted types of DataObject
+    self.outputMultipleRealizations = True # True indicate multiple realizations are returned
 
   def _handleInput(self, paramInput):
     """
@@ -102,15 +104,13 @@ class RealizationAverager(PostProcessor):
     averaged['RAVEN_sample_ID'] = [0]
     return averaged
 
-
-  def collectOutput(self, finishedJob, output):
+  def collectOutput(self, finishedJob, output, options=None):
     """
       Function to place all of the computed data into the output object
       @ In, finishedJob, JobHandler External or Internal instance, A JobHandler object that is in charge of running this post-processor
-      @ In, output, DataObject.DataObject, The object where we want to place our computed results
+      @ In, output, dataObjects, The object where we want to place our computed results
+      @ In, options, dict, optional, not used in PostProcessor.
+        dictionary of options that can be passed in when the collect of the output is performed by another model (e.g. EnsembleModel)
       @ Out, None
     """
-    evaluation = finishedJob.getEvaluation()
-    result = evaluation[1]
-    self.raiseADebug('Sending output to DataSet "{name}"'.format(name=output.name))
-    output.load(result, style='dataset')
+    PostProcessor.collectOutput(self, finishedJob, output, options=options)

--- a/tests/framework/PostProcessors/DataClassifier/test_dataClassifier_postprocessor.xml
+++ b/tests/framework/PostProcessors/DataClassifier/test_dataClassifier_postprocessor.xml
@@ -150,7 +150,7 @@
     </PointSet>
     <PointSet name="sim_PS_out">
       <Input>ACC_status,time_LPI,time_LPR</Input>
-      <Output>out, LPI_status, LPR_status</Output>
+      <Output>out, LPI_status, LPR_status, sequence</Output>
     </PointSet>
   </DataObjects>
   

--- a/tests/framework/PostProcessors/DataClassifier/test_dataClassifier_postprocessor_HS.xml
+++ b/tests/framework/PostProcessors/DataClassifier/test_dataClassifier_postprocessor_HS.xml
@@ -151,7 +151,7 @@
     </HistorySet>
     <HistorySet name="sim_PS_out">
       <Input>ACC_sim,time_LPI,time_LPR</Input>
-      <Output>time, temp, out, ACC_status, LPI_status, LPR_status</Output>
+      <Output>time, temp, out, ACC_status, LPI_status, LPR_status, sequence</Output>
     </HistorySet>
   </DataObjects>
   


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
see #1451 

Standardize the collectOutput method for PostProcessors. In ideal case, all PostProcessors should call the collectOutput method from the PostProcessor Base class, and there is no need for the PostProcessor to implement its own collectOutput method. This will simplify the PostProcessors when there is a standard way to pass and retrieve data from PostProcessors.  

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

