### PR TITLE
PP factory fix

### DIFF
--- a/framework/Models/Factory.py
+++ b/framework/Models/Factory.py
@@ -56,22 +56,29 @@ from .PostProcessors import EconomicRatio
 try:
   from .PostProcessors.TopologicalDecomposition import QTopologicalDecomposition
   from .PostProcessors.DataMining import QDataMining
+  renaming = {'QTopologicalDecomposition': 'TopologicalDecomposition',
+              'QDataMining': 'DataMining'}
 except ImportError:
-  pass
+  renaming = {}
 
 __base = 'Model'
 __interFaceDict = {}
 
+
 for classObj in utils.getAllSubclasses(eval(__base)):
   key = classObj.__name__
+  key = renaming.get(key, key) # get alias if provided, else use key
   __interFaceDict[key] = classObj
 
-try:
-  __interFaceDict['TopologicalDecomposition' ] = QTopologicalDecomposition
-  __interFaceDict['DataMining'               ] = QDataMining
-except NameError:
-  ## The correct names should already be used for these classes otherwise
-  pass
+# NOTE the following causes QDataMining to be entered into the __interFaceDict a second time,
+#      which somehow passed the test machines but seg faulted on my machine. I don't think we need
+#      it in there twice, anyway. - talbpaul, 2021-3-11
+# try:
+#   __interFaceDict['TopologicalDecomposition' ] = QTopologicalDecomposition
+#   __interFaceDict['DataMining'               ] = QDataMining
+# except NameError:
+#   ## The correct names should already be used for these classes otherwise
+#   pass
 
 # #here the class methods are called to fill the information about the usage of the classes
 for classType in __interFaceDict.values():


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1472

##### What are the significant changes in functionality due to this change request?
Prevents duplicate entries for the QDataMining postprocessor when QT is present

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

