### PR TITLE
Adding a ranking utility to sort/rank fronts

### DIFF
--- a/framework/utils/frontUtils.py
+++ b/framework/utils/frontUtils.py
@@ -14,7 +14,7 @@
 """
   Repository of utils for non-dominated and Pareto frontier methods
   Created  Feb 18, 2020
-  @authors: Diego Mandelli
+  @authors: Diego Mandelli and Mohammad Abdo
 """
 # External Imports
 import numpy as np
@@ -58,3 +58,30 @@ def nonDominatedFrontier(data, returnMask):
     return isEfficientMask
   else:
     return isEfficient
+
+def rankNonDominatedFrontiers(data):
+  """
+    This method ranks the non dominated fronts by omitting thr first front from the data
+    and searching the remaining data for a new one recursively.
+    @ In, data, np.array, data matrix (nPoints, nObjectives) containing the multi-objective
+                          evaluations of each point/individual, element (i,j)
+                          means jth objective function at the ith point/individual
+    @ out, nonDominatedRank, list, a list of length nPoints that has the ranking
+                                  of the front passing through each point
+  """
+  nonDominatedRank = np.zeros(data.shape[0],dtype=int)
+  rank = 0
+  indicesDominated = list(np.arange(data.shape[0]))
+  indicesNonDominated = []
+  rawData = data
+  while np.shape(data)[0] > 0:
+    rank += 1
+    indicesNonDominated = list(nonDominatedFrontier(data, False))
+    if rank > 1:
+      for i in range(len(indicesNonDominated)):
+        indicesNonDominated[i] = indicesDominated[indicesNonDominated[i]]
+    indicesDominated = list(set(indicesDominated)-set(indicesNonDominated))
+    data = rawData[indicesDominated]
+    nonDominatedRank[indicesNonDominated] = rank
+  nonDominatedRank = list(nonDominatedRank)
+  return nonDominatedRank

--- a/tests/framework/unit_tests/utils/testRankFrontUtils.py
+++ b/tests/framework/unit_tests/utils/testRankFrontUtils.py
@@ -1,0 +1,74 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+  This Module performs Unit Tests for the frontUtils.rankNonDominantFrontiers methods
+"""
+
+
+import os,sys
+import numpy as np
+frameworkDir = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])),os.pardir,os.pardir,os.pardir,os.pardir,'framework'))
+sys.path.append(frameworkDir)
+from utils import utils
+utils.find_crow(frameworkDir)
+from utils import frontUtils
+
+randomENG = utils.findCrowModule("randomENG")
+
+print (frontUtils)
+
+results = {"pass":0,"fail":0}
+
+def checkArray(comment,check,expected,tol=1e-7):
+  """
+    This method is aimed to compare two arrays of floats given a certain tolerance
+    @ In, comment, string, a comment printed out if it fails
+    @ In, check, list, the value to compare
+    @ In, expected, list, the expected value
+    @ In, tol, float, optional, the tolerance
+    @ Out, None
+  """
+  same=True
+  if len(check) != len(expected):
+    same=False
+  else:
+    for i in range(len(check)):
+      same = same*checkAnswer(comment+'[%i]'%i,check[i],expected[i],tol,False)
+  if not same:
+    print("checking array",comment,"did not match!")
+    results['fail']+=1
+    return False
+  else:
+    results['pass']+=1
+    return True
+
+test = np.array([[ 0.21573114, -0.92937786,  0.29952775],
+                 [ 0.94716548, -0.31085637, -0.07903087],
+                 [ 0.6485263,  -0.72106429,  0.24388507],
+                 [ 0.3466882,  -0.78716832,  0.51007189],
+                 [ 0.15463182, -0.18730138,  0.97005525],
+                 [ 0.02937279, -0.91175393,  0.40968525],
+                 [0.35039731,  0.54889384,  0.80057772],
+                 [ 0.06213356,  0.28552822, -0.95635404],
+                 [-0.20190017,  0.66695686, -0.71722024],
+                 [-0.62399932, -0.22858416,  0.74724436]])
+
+rankedFrontiers = frontUtils.rankNonDominatedFrontiers(test)
+answerRanking = [1, 1, 1, 2, 2, 1, 3, 1, 1, 1]
+checkArray('nonDominatedFrontier with indexes', rankedFrontiers, answerRanking)
+
+print(results)
+
+sys.exit(results["fail"])
+


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
closes #1475

##### What are the significant changes in functionality due to this change request?
enables ranking non dominated fronts recursively

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

