### PR TITLE
Add modular inheritence structure for TSA module

### DIFF
--- a/framework/SupervisedLearning/SyntheticHistory.py
+++ b/framework/SupervisedLearning/SyntheticHistory.py
@@ -134,6 +134,8 @@ class SyntheticHistory(supervisedLearning):
       targets = settings['target']
       indices = tuple(self.target.index(t) for t in targets)
       params = self.trainedParams[algo]
+      if not algo.canGenerate():
+        self.raiseAnError(IOError, "This TSA algorithm cannot generate synthetic histories.")
       signal = algo.generate(params, pivots, settings)
       result[:, indices] += signal
     # RAVEN realization construction

--- a/framework/TSA/ARMA.py
+++ b/framework/TSA/ARMA.py
@@ -25,11 +25,11 @@ from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, impor
 statsmodels = importerUtils.importModuleLazy('statsmodels', globals())
 
 import Distributions
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
+from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesGenerator, TimeSeriesCharacterizer
 
 
 # utility methods
-class ARMA(TimeSeriesAnalyzer):
+class ARMA(TimeSeriesGenerator, TimeSeriesCharacterizer):
   r"""
     AutoRegressive Moving Average time series analyzer algorithm
   """
@@ -76,7 +76,7 @@ class ARMA(TimeSeriesAnalyzer):
       @ Out, None
     """
     # general infrastructure
-    TimeSeriesAnalyzer.__init__(self, *args, **kwargs)
+    super().__init__(self, *args, **kwargs)
     self._minBins = 20 # this feels arbitrary; used for empirical distr. of data
 
   def handleInput(self, spec):

--- a/framework/TSA/ARMA.py
+++ b/framework/TSA/ARMA.py
@@ -25,7 +25,7 @@ from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, impor
 statsmodels = importerUtils.importModuleLazy('statsmodels', globals())
 
 import Distributions
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesGenerator, TimeSeriesCharacterizer
+from .TimeSeriesAnalyzer import TimeSeriesGenerator, TimeSeriesCharacterizer
 
 
 # utility methods
@@ -85,7 +85,7 @@ class ARMA(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ In, inp, InputData.InputParams, input specifications
       @ Out, settings, dict, initialization settings for this algorithm
     """
-    settings = TimeSeriesAnalyzer.handleInput(self, spec)
+    settings = super().handleInput(spec)
     settings['P'] = spec.findFirst('SignalLag').value
     settings['Q'] = spec.findFirst('NoiseLag').value
     settings['reduce_memory'] = spec.parameterValues.get('reduce_memory', settings['reduce_memory'])

--- a/framework/TSA/ARMA.py
+++ b/framework/TSA/ARMA.py
@@ -98,7 +98,7 @@ class ARMA(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ In, settings, dict, existing settings
       @ Out, settings, dict, modified settings
     """
-    settings = TimeSeriesAnalyzer.setDefaults(self, settings)
+    settings = super().setDefaults(settings)
     if 'gaussianize' not in settings:
       settings['gaussianize'] = True
     if 'engine' not in settings:

--- a/framework/TSA/ARMA.py
+++ b/framework/TSA/ARMA.py
@@ -76,7 +76,7 @@ class ARMA(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ Out, None
     """
     # general infrastructure
-    super().__init__(self, *args, **kwargs)
+    super().__init__(*args, **kwargs)
     self._minBins = 20 # this feels arbitrary; used for empirical distr. of data
 
   def handleInput(self, spec):

--- a/framework/TSA/Fourier.py
+++ b/framework/TSA/Fourier.py
@@ -21,11 +21,11 @@ import numpy as np
 import sklearn.linear_model
 
 from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, utils
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
+from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesGenerator, TimeSeriesCharacterizer
 
 
 # utility methods
-class Fourier(TimeSeriesAnalyzer):
+class Fourier(TimeSeriesGenerator, TimeSeriesCharacterizer):
   """
     Perform Fourier analysis; note this is not Fast Fourier, where all Fourier modes are used to fit a
     signal. Instead, detect the presence of specifically-requested Fourier bases.
@@ -66,7 +66,7 @@ class Fourier(TimeSeriesAnalyzer):
       @ Out, None
     """
     # general infrastructure
-    TimeSeriesAnalyzer.__init__(self, *args, **kwargs)
+    super().__init__(self, *args, **kwargs)
 
   def handleInput(self, spec):
     """

--- a/framework/TSA/Fourier.py
+++ b/framework/TSA/Fourier.py
@@ -21,7 +21,7 @@ import numpy as np
 import sklearn.linear_model
 
 from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, utils
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesGenerator, TimeSeriesCharacterizer
+from .TimeSeriesAnalyzer import TimeSeriesGenerator, TimeSeriesCharacterizer
 
 
 # utility methods
@@ -74,7 +74,7 @@ class Fourier(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ In, inp, InputData.InputParams, input specifications
       @ Out, settings, dict, initialization settings for this algorithm
     """
-    settings = TimeSeriesAnalyzer.handleInput(self, spec)
+    settings = super().handleInput(spec)
     settings['periods'] = spec.findFirst('periods').value
     return settings
 

--- a/framework/TSA/Fourier.py
+++ b/framework/TSA/Fourier.py
@@ -66,7 +66,7 @@ class Fourier(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ Out, None
     """
     # general infrastructure
-    super().__init__(self, *args, **kwargs)
+    super().__init__(*args, **kwargs)
 
   def handleInput(self, spec):
     """

--- a/framework/TSA/PolynomialRegression.py
+++ b/framework/TSA/PolynomialRegression.py
@@ -20,10 +20,10 @@ import utils.importerUtils
 statsmodels = utils.importerUtils.importModuleLazy("statsmodels", globals())
 
 from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, utils
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
+from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesCharacterizer, TimeSeriesGenerator
 
 
-class PolynomialRegression(TimeSeriesAnalyzer):
+class PolynomialRegression(TimeSeriesGenerator, TimeSeriesCharacterizer):
   """
   """
 
@@ -53,7 +53,7 @@ class PolynomialRegression(TimeSeriesAnalyzer):
       @ Out, None
     """
     # general infrastructure
-    TimeSeriesAnalyzer.__init__(self, *args, **kwargs)
+    super().__init__(self, *args, **kwargs)
 
   def handleInput(self, spec):
     """

--- a/framework/TSA/PolynomialRegression.py
+++ b/framework/TSA/PolynomialRegression.py
@@ -36,7 +36,7 @@ class PolynomialRegression(TimeSeriesGenerator, TimeSeriesCharacterizer):
         specifying input of cls.
     """
     specs = super(PolynomialRegression, cls).getInputSpecification()
-    specs.name = 'regression'
+    specs.name = 'PolynomialRegression'
     specs.description = """TimeSeriesAnalysis algorithm for fitting data of degree one or greater."""
     specs.addSub(InputData.parameterInputFactory('degree', contentType=InputTypes.IntegerType,
                                                  descr="Specifies the degree polynomial to fit the data with."))
@@ -53,7 +53,7 @@ class PolynomialRegression(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ Out, None
     """
     # general infrastructure
-    super().__init__(self, *args, **kwargs)
+    super().__init__(*args, **kwargs)
 
   def handleInput(self, spec):
     """

--- a/framework/TSA/PolynomialRegression.py
+++ b/framework/TSA/PolynomialRegression.py
@@ -20,7 +20,7 @@ import utils.importerUtils
 statsmodels = utils.importerUtils.importModuleLazy("statsmodels", globals())
 
 from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, utils
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesCharacterizer, TimeSeriesGenerator
+from .TimeSeriesAnalyzer import TimeSeriesCharacterizer, TimeSeriesGenerator
 
 
 class PolynomialRegression(TimeSeriesGenerator, TimeSeriesCharacterizer):
@@ -61,7 +61,7 @@ class PolynomialRegression(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ In, inp, InputData.InputParams, input specifications
       @ Out, settings, dict, initialization settings for this algorithm
     """
-    settings = TimeSeriesAnalyzer.handleInput(self, spec)
+    settings = super().handleInput(spec)
     settings['degree'] = spec.findFirst('degree').value
     return settings
 

--- a/framework/TSA/TimeSeriesAnalyzer.py
+++ b/framework/TSA/TimeSeriesAnalyzer.py
@@ -35,6 +35,7 @@ class TimeSeriesAnalyzer(utils.metaclass_insert(abc.ABCMeta, object)):
     """
     A predicate function to determine if object instance inherits from TimeSeriesGenerator.
 
+    @ In, None
     @ Out, boolean, True if instance can generate
     """
     return isinstance(self, TimeSeriesGenerator)
@@ -43,6 +44,7 @@ class TimeSeriesAnalyzer(utils.metaclass_insert(abc.ABCMeta, object)):
     """
     A predicate function to determine if object instance inherits from TimeSeriesCharacterizer.
 
+    @ In, None
     @ Out, boolean, True if instance can characterize
     """
     return isinstance(self, TimeSeriesCharacterizer)
@@ -127,15 +129,6 @@ class TimeSeriesGenerator(TimeSeriesAnalyzer):
   Act as an identifying class for algorithms that can generate synthetic time histories.
   """
 
-  def __init__(self, *args, **kwargs):
-    """
-      A constructor that will appropriately intialize a supervised learning object
-      @ In, args, list, an arbitrary list of positional values
-      @ In, kwargs, dict, an arbitrary dictionary of keywords and values
-      @ Out, None
-    """
-    self.name = self.__class__.__name__ # the name the class shall be known by during its RAVEN life
-
   @abc.abstractmethod
   def generate(self, params, pivot, settings):
     """
@@ -152,15 +145,6 @@ class TimeSeriesCharacterizer(TimeSeriesAnalyzer):
   """
   Act as an identifying class for algorithms that can generate characterize time-dependent signals.
   """
-
-  def __init__(self, *args, **kwargs):
-    """
-      A constructor that will appropriately intialize a supervised learning object
-      @ In, args, list, an arbitrary list of positional values
-      @ In, kwargs, dict, an arbitrary dictionary of keywords and values
-      @ Out, None
-    """
-    self.name = self.__class__.__name__ # the name the class shall be known by during its RAVEN life
 
   @abc.abstractmethod
   def characterize(self, signal, pivot, targets, settings):

--- a/framework/TSA/TimeSeriesAnalyzer.py
+++ b/framework/TSA/TimeSeriesAnalyzer.py
@@ -54,6 +54,7 @@ class TimeSeriesAnalyzer(utils.metaclass_insert(abc.ABCMeta, object)):
     """
       Method to get a reference to a class that specifies the input data for class cls.
 
+      @ In, None
       @ Out, specs, InputData.ParameterInput, class to use for specifying input of cls.
     """
     specs = InputData.parameterInputFactory(cls.__name__, ordered=False, strictMode=True)

--- a/framework/TSA/Wavelet.py
+++ b/framework/TSA/Wavelet.py
@@ -17,11 +17,11 @@
 import numpy as np
 
 from utils import InputData, InputTypes, xmlUtils
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
+from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesGenerator, TimeSeriesCharacterizer
 
 
 # utility methods
-class Wavelet(TimeSeriesAnalyzer):
+class Wavelet(TimeSeriesGenerator, TimeSeriesCharacterizer):
   """
     Perform Discrete Wavelet Transformation on time-dependent data.
   """
@@ -77,7 +77,7 @@ class Wavelet(TimeSeriesAnalyzer):
       @ Out, None
     """
     # general infrastructure
-    TimeSeriesAnalyzer.__init__(self, *args, **kwargs)
+    super().__init__(self, *args, **kwargs)
 
 
   def handleInput(self, spec):

--- a/framework/TSA/Wavelet.py
+++ b/framework/TSA/Wavelet.py
@@ -17,7 +17,7 @@
 import numpy as np
 
 from utils import InputData, InputTypes, xmlUtils
-from .TimeSeriesAnalyzer import TimeSeriesAnalyzer, TimeSeriesGenerator, TimeSeriesCharacterizer
+from .TimeSeriesAnalyzer import TimeSeriesGenerator, TimeSeriesCharacterizer
 
 
 # utility methods
@@ -86,7 +86,7 @@ class Wavelet(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ In, spec, InputData.InputParams, input specifications
       @ Out, settings, dict, initialization settings for this algorithm
     """
-    settings = TimeSeriesAnalyzer.handleInput(self, spec)
+    settings = super().handleInput(spec)
     settings['family'] = spec.findFirst('family').value
     return settings
 

--- a/framework/TSA/Wavelet.py
+++ b/framework/TSA/Wavelet.py
@@ -77,7 +77,7 @@ class Wavelet(TimeSeriesGenerator, TimeSeriesCharacterizer):
       @ Out, None
     """
     # general infrastructure
-    super().__init__(self, *args, **kwargs)
+    super().__init__(*args, **kwargs)
 
 
   def handleInput(self, spec):

--- a/tests/framework/unit_tests/TSA/testARMA.py
+++ b/tests/framework/unit_tests/TSA/testARMA.py
@@ -282,6 +282,9 @@ checkFloat('Simple ARMA variance', 0.9532563046953576, check['var'], tol=1e-3)
 # #ax.plot(pivot, res, '.:')
 # plt.show()
 
+checkTrue("arma can generate", arma.canGenerate())
+checkTrue("arma can characterize", arma.canCharacterize())
+
 # predict
 np.random.seed(42) # forces MLE in statsmodels to be deterministic
 new = arma.generate(params, pivot, settings)[:, 0]

--- a/tests/framework/unit_tests/TSA/testFourier.py
+++ b/tests/framework/unit_tests/TSA/testFourier.py
@@ -244,6 +244,9 @@ fourier = createFourier(targets, periods)
 settings = {'periods': periods}
 params = fourier.characterize(signals, pivot, targets, settings)
 
+checkTrue("fourier can generate", fourier.canGenerate())
+checkTrue("fourier can characterize", fourier.canCharacterize())
+
 # intercepts
 checkFloat('Signal A intercept', params['A']['intercept'], 0)
 checkFloat('Signal B intercept', params['B']['intercept'], 0)

--- a/tests/framework/unit_tests/TSA/testPolynomialRegression.py
+++ b/tests/framework/unit_tests/TSA/testPolynomialRegression.py
@@ -244,6 +244,9 @@ check = params['A']['model']
 for title, real, pred in zip(coef_titles, okay_coefs, check):
   checkFloat(title, real, check[pred], tol=1e-1)
 
+checkTrue("model can generate", model.canGenerate())
+checkTrue("model can characterize", model.canCharacterize())
+
 ############################
 # Simple w/ Random Noise   #
 ############################

--- a/tests/framework/unit_tests/TSA/testWavelet.py
+++ b/tests/framework/unit_tests/TSA/testWavelet.py
@@ -243,11 +243,16 @@ settings = transform.setDefaults(settings)
 params = transform.characterize(signals, pivot, targets, settings)
 check = params['A']['results']
 
+checkTrue("wavelet can generate", transform.canGenerate())
+checkTrue("wavelet can characterize", transform.canCharacterize())
+
 for real_a, pred_a in zip(true_a, check['coeff_a']):
   checkFloat(titles[0], real_a, pred_a, tol=1e-8)
 
 for real_d, pred_d in zip(true_d, check['coeff_d']):
   checkFloat(titles[1], real_d, pred_d, tol=1e-8)
+
+print(results)
 
 sys.exit(results["fail"])
 """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Refs #1443 #1485 #1404

##### What are the significant changes in functionality due to this change request?

* Add TimeSeriesGenerator class
* Add TimeSeriesCharacterizer class
* Add predicate functions to base TSA class
* Modify unit-tests

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

