### PR TITLE
Add check to ensure TSA algo type exists

### DIFF
--- a/framework/SupervisedLearning/SyntheticHistory.py
+++ b/framework/SupervisedLearning/SyntheticHistory.py
@@ -77,11 +77,16 @@ class SyntheticHistory(supervisedLearning):
       @ Out, None
     """
     self.pivotParameterID = inp.findFirst('pivotParameter').value # TODO does a base class do this?
+    foundTSAType = False
     for sub in inp.subparts:
       if sub.name in TSA.factory.knownTypes():
         algo = TSA.factory.returnInstance(sub.name)
         self.algoSettings[algo] = algo.handleInput(sub)
         self.tsaAlgorithms.append(algo)
+        foundTSAType = True
+    if foundTSAType is False:
+      options = ', '.join(TSA.factory.knownTypes())
+      self.raiseAnError(IOError, f'No known TSA type found in input. Available options are: {options}')
     if self.pivotParameterID not in self.target:
       self.raiseAnError(IOError, 'The pivotParameter must be included in the target space.')
 

--- a/framework/TSA/Factory.py
+++ b/framework/TSA/Factory.py
@@ -21,6 +21,7 @@ from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
 from .Fourier import Fourier
 from .ARMA import ARMA
 from .Wavelet import Wavelet
+from .PolynomialRegression import PolynomialRegression
 
 factory = EntityFactory('TimeSeriesAnalyzer')
 # TODO map lower case to upper case, because of silly ROM namespace problems


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Refs #1443 

##### What are the significant changes in functionality due to this change request?
We want to make sure that a TSA algorithm is available and specified for any given `SythethicHistory` ROM. This adds a check to make sure a TSA algo is found in the input specification and produces IOError if not found. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

