### PR TITLE
Closes #1530

### DIFF
--- a/framework/CodeInterfaces/RELAP5/RELAPparser.py
+++ b/framework/CodeInterfaces/RELAP5/RELAPparser.py
@@ -77,7 +77,7 @@ class RELAPparser():
         self.presentStopTrip[self.maxNumberOfDecks] = copy.deepcopy(pStop)
         pStop = None
         prevDeckLineNum = lineNum + 1
-      elif line.strip().startswith("600"):
+      elif line.strip().startswith("600 "):
         pStop = [el.strip() for el in line.strip()[3:].split()]
         lines[lineNum] = "*"
 

--- a/tests/framework/CodeInterfaceTests/RELAP5/RELAP5interfaceTest/snc01.i
+++ b/tests/framework/CodeInterfaceTests/RELAP5/RELAP5interfaceTest/snc01.i
@@ -2021,4 +2021,7 @@ $   space independent reactor kinetics data
 390050000  2   1.0
 390050010  rktpow 0 0.5 0
 390050020  rktpow 0 0.5 0
+* the line below has been added just to test that there
+* are not issues with the radiation cards
+60000000 1
 .

--- a/tests/framework/CodeInterfaceTests/RELAP5/gold/RELAP5interfaceTest/testDummyStep/1/snc01.i
+++ b/tests/framework/CodeInterfaceTests/RELAP5/gold/RELAP5interfaceTest/testDummyStep/1/snc01.i
@@ -2029,4 +2029,7 @@ $   space independent reactor kinetics data
 390050000  2   1.0
 390050010  rktpow 0 0.5 0
 390050020  rktpow 0 0.5 0
+* the line below has been added just to test that there
+* are not issues with the radiation cards
+60000000 1
 .

--- a/tests/framework/CodeInterfaceTests/RELAP5/gold/RELAP5interfaceTest/testDummyStep/2/snc01.i
+++ b/tests/framework/CodeInterfaceTests/RELAP5/gold/RELAP5interfaceTest/testDummyStep/2/snc01.i
@@ -2029,4 +2029,7 @@ $   space independent reactor kinetics data
 390050000  2   1.0
 390050010  rktpow 0 0.5 0
 390050020  rktpow 0 0.5 0
+* the line below has been added just to test that there
+* are not issues with the radiation cards
+60000000 1
 .


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1530

##### What are the significant changes in functionality due to this change request?
It addressed the issue 1530. The radiation card was split in the perturbed file. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

