### PR TITLE
Mandd/dist mutators

### DIFF
--- a/framework/Optimizers/GeneticAlgorithm.py
+++ b/framework/Optimizers/GeneticAlgorithm.py
@@ -436,7 +436,7 @@ class GeneticAlgorithm(RavenSampled):
 
       # 3 @ n: Mutation
       # perform random directly on childrenCoordinates
-      childrenMutated = self._mutationInstance(offSprings=childrenXover,locs = self._mutationLocs, mutationProb=self._mutationProb,variables=list(self.toBeSampled))
+      childrenMutated = self._mutationInstance(offSprings=childrenXover, distDict = self.distDict,locs = self._mutationLocs, mutationProb=self._mutationProb,variables=list(self.toBeSampled))
 
       # 4 @ n: repair/replacement
       # repair should only happen if multiple genes in a single chromosome have the same values (),
@@ -465,7 +465,7 @@ class GeneticAlgorithm(RavenSampled):
               repeated.append(j)
         repeated = list(set(repeated))
         if repeated:
-          newChildren = self._mutationInstance(offSprings=children[repeated,:],locs = self._mutationLocs, mutationProb=self._mutationProb,variables=list(self.toBeSampled))
+          newChildren = self._mutationInstance(offSprings=children[repeated,:], distDict = self.distDict, locs = self._mutationLocs, mutationProb=self._mutationProb,variables=list(self.toBeSampled))
           children.data[repeated,:] = newChildren.data
         else:
           flag = False

--- a/framework/Optimizers/mutators/mutators.py
+++ b/framework/Optimizers/mutators/mutators.py
@@ -40,8 +40,6 @@ def swapMutator(offSprings, distDict, **kwargs):
           variables, list, variables names.
     @ Out, children, xr.DataArray, the mutated chromosome, i.e., the child.
   """
-  print(distDict)
-  print(offSprings)
   if kwargs['locs'] == None:
     locs = list(set(randomUtils.randomChoice(list(np.arange(offSprings.data.shape[1])),size=2,replace=False)))
     loc1 = locs[0]
@@ -64,9 +62,7 @@ def swapMutator(offSprings, distDict, **kwargs):
       cdf2 = distDict[offSprings.coords['Gene'].values[loc2]].cdf(float(offSprings[i,loc2].values))
       children[i,loc1] = distDict[offSprings.coords['Gene'].values[loc1]].ppf(cdf2)
       children[i,loc2] = distDict[offSprings.coords['Gene'].values[loc2]].ppf(cdf1)
-      
-      #children[i,loc1] = offSprings[i,loc2]
-      #children[i,loc2] = offSprings[i,loc1]
+
   return children
 
 # @profile

--- a/framework/Optimizers/mutators/mutators.py
+++ b/framework/Optimizers/mutators/mutators.py
@@ -70,7 +70,7 @@ def swapMutator(offSprings, distDict, **kwargs):
   return children
 
 # @profile
-def scrambleMutator(offSprings,**kwargs):
+def scrambleMutator(offSprings, distDict, **kwargs):
   """
     This method performs the scramble mutator. For each child, a subset of genes is chosen
     and their values are shuffled randomly.
@@ -90,16 +90,27 @@ def scrambleMutator(offSprings,**kwargs):
       l = randomUtils.randomIntegers(0,offSprings.sizes['Gene']-1,None)
       locs.append(l)
     locs = list(set(locs))
-    # initializing children
+  
+  # initializing children
   children = xr.DataArray(np.zeros((np.shape(offSprings))),
                           dims=['chromosome','Gene'],
                           coords={'chromosome': np.arange(np.shape(offSprings)[0]),
                                   'Gene':kwargs['variables']})
+  
+  for i in range(np.shape(offSprings)[0]):
+    for j in range(np.shape(offSprings)[1]):
+      children[i,j] = distDict[offSprings[i].coords['Gene'].values[j]].cdf(float(offSprings[i,j].values))
+      
   for i in range(np.shape(offSprings)[0]):
     children[i] = copy.deepcopy(offSprings[i])
     for ind,element in enumerate(locs):
       if randomUtils.random(dim=1,samples=1)< kwargs['mutationProb']:
         children[i,locs[0]:locs[-1]+1] = randomUtils.randomPermutation(list(offSprings.data[i,locs[0]:locs[-1]+1]),None)
+  
+  for i in range(np.shape(offSprings)[0]):
+    for j in range(np.shape(offSprings)[1]):
+      children[i,j] = distDict[offSprings.coords['Gene'].values[j]].ppf(children[i,j])
+        
   return children
 
 def bitFlipMutator(offSprings,**kwargs):

--- a/framework/Optimizers/mutators/mutators.py
+++ b/framework/Optimizers/mutators/mutators.py
@@ -47,7 +47,7 @@ def swapMutator(offSprings, distDict, **kwargs):
   else:
     loc1 = kwargs['locs'][0]
     loc2 = kwargs['locs'][1]
-  
+
   # initializing children
   children = xr.DataArray(np.zeros((np.shape(offSprings))),
                           dims=['chromosome','Gene'],
@@ -86,27 +86,27 @@ def scrambleMutator(offSprings, distDict, **kwargs):
       l = randomUtils.randomIntegers(0,offSprings.sizes['Gene']-1,None)
       locs.append(l)
     locs = list(set(locs))
-  
+
   # initializing children
   children = xr.DataArray(np.zeros((np.shape(offSprings))),
                           dims=['chromosome','Gene'],
                           coords={'chromosome': np.arange(np.shape(offSprings)[0]),
                                   'Gene':kwargs['variables']})
-  
+
   for i in range(np.shape(offSprings)[0]):
     for j in range(np.shape(offSprings)[1]):
       children[i,j] = distDict[offSprings[i].coords['Gene'].values[j]].cdf(float(offSprings[i,j].values))
-      
+
   for i in range(np.shape(offSprings)[0]):
     children[i] = copy.deepcopy(offSprings[i])
     for ind,element in enumerate(locs):
       if randomUtils.random(dim=1,samples=1)< kwargs['mutationProb']:
         children[i,locs[0]:locs[-1]+1] = randomUtils.randomPermutation(list(offSprings.data[i,locs[0]:locs[-1]+1]),None)
-  
+
   for i in range(np.shape(offSprings)[0]):
     for j in range(np.shape(offSprings)[1]):
       children[i,j] = distDict[offSprings.coords['Gene'].values[j]].ppf(children[i,j])
-        
+
   return children
 
 def bitFlipMutator(offSprings,**kwargs):
@@ -170,11 +170,11 @@ def inversionMutator(offSprings, distDict, **kwargs):
         locU=loc2
       ##############
       # select sequence to be mirrored and mirror it
-      seq=child.values[locL:locU+1]   
+      seq=child.values[locL:locU+1]
       for elem in seq:
         elem = distDict[child.coords['Gene'].values[elem]].cdf(float(child[elem].values))
-      
-      mirrSeq = seq[::-1]    
+
+      mirrSeq = seq[::-1]
       for elem in mirrSeq:
         elem = distDict[child.coords['Gene'].values[elem]].ppf(elem)
       ##############


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1551 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

