### PR TITLE
get-set state bypass for external ROM loader

### DIFF
--- a/scripts/externalROMloader.py
+++ b/scripts/externalROMloader.py
@@ -66,6 +66,17 @@ class ravenROMexternal(object):
       @ In, whereFrameworkIs, str, the location of RAVEN framework (path)
       @ Out, None
     """
+    self._binaryLoc = binaryFileName
+    self._frameworkLoc = whereFrameworkIs
+    self._load(binaryFileName, whereFrameworkIs)
+
+  def _load(self, binaryFileName, whereFrameworkIs):
+    """
+      Load the ROM.
+      @ In, binaryFileName, str, the location of the serialized (pickled) ROM that needs to be imported
+      @ In, whereFrameworkIs, str, the location of RAVEN framework (path)
+      @ Out, None
+    """
     # find the RAVEN framework
     frameworkDir = os.path.abspath(whereFrameworkIs)
     if not os.path.exists(frameworkDir):
@@ -87,6 +98,26 @@ class ravenROMexternal(object):
     if not os.path.exists(serializedROMlocation):
       raise IOError('The serialized (binary) file has not been found in location "' + str(serializedROMlocation)+'" !')
     self.rom = pickle.load(open(serializedROMlocation, mode='rb'))
+
+  def __getstate__(self):
+    """
+      Deep copy.
+      @ In, None
+      @ Out, d, dict, self representation
+    """
+    d = {'binaryFileName': self._binaryLoc,
+         'whereFrameworkIs': self._frameworkLoc}
+    return d
+
+  def __setstate__(self, d):
+    """
+      Deep paste.
+      @ In, d, dict, self representation
+      @ Out, None
+    """
+    self._binaryLoc = d['binaryFileName']
+    self._frameworkLoc = d['whereFrameworkIs']
+    self._load(self._binaryLoc, self._frameworkLoc)
 
   def evaluate(self,request):
     """

--- a/tests/framework/ROM/pickleTests/script_rom_loader.py
+++ b/tests/framework/ROM/pickleTests/script_rom_loader.py
@@ -1,0 +1,76 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+
+import numpy as np
+import dill as pk
+
+# add romLoader to path
+here = os.path.abspath(os.path.dirname(__file__))
+frameworkPath = os.path.abspath(os.path.join(here, *['..']*4, 'framework'))
+sys.path.append(os.path.abspath(os.path.join(frameworkPath, '..', 'scripts')))
+import externalROMloader
+
+results = {'pass': 0, 'fail': 0}
+
+def check(comment, value, expected, tol=1e-10, update=True):
+  """
+    Compare two floats given a certain tolerance
+    @ In, comment, string, a comment printed out if it fails
+    @ In, value, float, the value to compare
+    @ In, expected, float, the expected value
+    @ In, tol, float, optional, the tolerance
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if same
+  """
+  if np.isnan(value) and np.isnan(expected):
+    res = True
+  elif np.isnan(value) or np.isnan(expected):
+    res = False
+  else:
+    res = abs(value - expected) <= tol
+  if update:
+    if not res:
+      print("checking float",comment,'|',value,"!=",expected)
+      results["fail"] += 1
+    else:
+      results["pass"] += 1
+  return res
+
+#
+# create
+#
+targetFile = os.path.join(here, 'StochasticPolyPickleTest', 'ROMpk')
+runner = externalROMloader.ravenROMexternal(targetFile, frameworkPath)
+#
+# serialize
+#
+x = pk.dumps(runner)
+results['pass'] += 1 # success for pickling
+pk.loads(x)
+results['pass'] += 1 # success for upickling
+#
+# run
+#
+inp = {'x1': [3], 'x2': [5]}
+res = runner.evaluate(inp)[0]
+check('Evaluate x[-1]', res['ans'][-1], 8)
+
+
+#
+# results
+#
+print(results)
+sys.exit(results['fail'])

--- a/tests/framework/ROM/pickleTests/script_rom_loader.py
+++ b/tests/framework/ROM/pickleTests/script_rom_loader.py
@@ -15,7 +15,7 @@ import os
 import sys
 
 import numpy as np
-import dill as pk
+import cloudpickle as pk
 
 # add romLoader to path
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tests/framework/ROM/pickleTests/tests
+++ b/tests/framework/ROM/pickleTests/tests
@@ -29,4 +29,9 @@
     output = 'output_load_ROM_externally.xml'
     prereq = stochPolyPickleTest
   [../]
+  [./script_rom_loader]
+    type = 'RavenPython'
+    input = 'script_rom_loader.py'
+    prereq = stochPolyPickleTest
+  [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1559

##### What are the significant changes in functionality due to this change request?
Allows the external ROM loader to serialize regardless of the ROM it carries.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

