### PR TITLE
Remove deep copy in DataSet.addRealization

### DIFF
--- a/framework/DataObjects/DataSet.py
+++ b/framework/DataObjects/DataSet.py
@@ -162,13 +162,13 @@ class DataSet(DataObject):
       ## TODO check structure?
       self._meta[tag] = node
 
-  def addRealization(self, rlz):
+  def addRealization(self, rlzIn):
     """
       Adds a "row" (or "sample") to this data object.
       This is the method to add data to this data object.
       Note that rlz can include many more variables than this data object actually wants.
       Before actually adding the realization, data is formatted for this data object.
-      @ In, rlz, dict, {var:val} format where
+      @ In, rlzIn, dict, {var:val} format where
                          "var" is the variable name as a string,
                          "val" is a np.ndarray of values.
       @ Out, None
@@ -198,15 +198,15 @@ class DataSet(DataObject):
     #  Yours truly, talbpw, May 2019
     #########
     # protect against back-changing realization
-    rlz = copy.deepcopy(rlz)
+    # rlz = copy.deepcopy(rlz)
     # if index map was included, remove that now before checking variables
-    indexMap = rlz.pop('_indexMap', None)
+    indexMap = rlzIn.get('_indexMap', None)
     if indexMap is not None:
       # keep only those parts of the indexMap that correspond to variables we care about.
       indexMap = dict((key, val) for key, val in indexMap[0].items() if key in self.getVars()) # [0] because everything is nested in a list by now, it seems
     # clean out entries that aren't desired
     try:
-      rlz = dict((var, rlz[var]) for var in self.getVars() + self.indexes)
+      rlz = dict((var, rlzIn[var]) for var in self.getVars() + self.indexes)
     except KeyError as e:
       self.raiseAWarning('Variables provided:',rlz.keys())
       self.raiseAnError(KeyError,'Provided realization does not have all requisite values for object "{}": "{}"'.format(self.name,e.args[0]))

--- a/framework/DataObjects/DataSet.py
+++ b/framework/DataObjects/DataSet.py
@@ -197,14 +197,13 @@ class DataSet(DataObject):
     #
     #  Yours truly, talbpw, May 2019
     #########
-    # protect against back-changing realization
-    # rlz = copy.deepcopy(rlz)
     # if index map was included, remove that now before checking variables
     indexMap = rlzIn.get('_indexMap', None)
     if indexMap is not None:
       # keep only those parts of the indexMap that correspond to variables we care about.
       indexMap = dict((key, val) for key, val in indexMap[0].items() if key in self.getVars()) # [0] because everything is nested in a list by now, it seems
     # clean out entries that aren't desired
+    rlz = {}
     try:
       rlz = dict((var, rlzIn[var]) for var in self.getVars() + self.indexes)
     except KeyError as e:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
see #1567 
The deep copy in DataSet.addRealization could take a lot of time when we have a large number of samples. It seems we can remove it. 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

