### PR TITLE
update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect-report.md
+++ b/.github/ISSUE_TEMPLATE/defect-report.md
@@ -3,7 +3,7 @@ name: Defect Report
 about: Report a DEFECT you experienced using the code
 title: "[DEFECT] Title Here"
 labels: defect, priority_normal
-assignees: PaulTalbot-INL, joshua-cogliati-inl, wangcj05, alfoa, mandd
+assignees: PaulTalbot-INL, joshua-cogliati-inl, wangcj05, mandd
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,8 @@ name: Feature request
 about: Suggest a new capability or addition you would like to see
 title: "[TASK] Title here"
 labels: priority_minor, task
-assignees: alfoa
+assignees: PaulTalbot-INL, joshua-cogliati-inl, wangcj05, mandd
+
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/under-discussion.md
+++ b/.github/ISSUE_TEMPLATE/under-discussion.md
@@ -4,7 +4,8 @@ about: This issue template is aimed to propose an item of discussion for new fea
   or similar
 title: "[UNDER-DISCUSSION] New Topic"
 labels: under-discussion
-assignees: alfoa, crisrab, mandd, PaulTalbot-INL, wangcj05
+assignees: PaulTalbot-INL, joshua-cogliati-inl, wangcj05, mandd
+
 
 ---
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1576 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

