### PR TITLE
GA deepCopy cleaning

### DIFF
--- a/framework/Optimizers/GeneticAlgorithm.py
+++ b/framework/Optimizers/GeneticAlgorithm.py
@@ -382,7 +382,7 @@ class GeneticAlgorithm(RavenSampled):
   # Run Methods #
   ###############
 
-  def _useRealization(self, info, rlz1):
+  def _useRealization(self, info, rlz):
     """
       Used to feedback the collected runs into actionable items within the sampler.
       This is called by localFinalizeActualSampling, and hence should contain the main skeleton.
@@ -396,8 +396,6 @@ class GeneticAlgorithm(RavenSampled):
       self._closeTrajectory(t, 'cancel', 'Currently GA is single trajectory',0)#, None
     self.incrementIteration(traj)
     info['step'] = self.counter
-
-    rlz=copy.deepcopy(rlz1)
 
     # Developer note: each algorithm step is indicated by a number followed by the generation number
     # e.g., '5 @ n-1' refers to step 5 for generation n-1 (i.e., previous generation)
@@ -452,7 +450,7 @@ class GeneticAlgorithm(RavenSampled):
       if needsRepair:
         children = self._repairInstance(childrenMutated,variables=list(self.toBeSampled),distInfo=self.distDict)
       else:
-        children = copy.deepcopy(childrenMutated)
+        children = childrenMutated
       # Make sure no children are exactly similar to parents
       flag = True
       counter = 0
@@ -482,7 +480,7 @@ class GeneticAlgorithm(RavenSampled):
         newRlz={}
         for _,var in enumerate(self.toBeSampled.keys()):
           newRlz[var] = float(daChildren.loc[i,var].values)
-        self._submitRun(copy.deepcopy(newRlz), traj, self.getIteration(traj))
+        self._submitRun(newRlz, traj, self.getIteration(traj))
 
   def _datasetToDataArray(self,rlzDataset):
     """

--- a/framework/Optimizers/GeneticAlgorithm.py
+++ b/framework/Optimizers/GeneticAlgorithm.py
@@ -29,7 +29,6 @@ import numpy as np
 from scipy.special import comb
 from collections import deque, defaultdict
 import xarray as xr
-import copy
 #External Modules End--------------------------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------

--- a/framework/Optimizers/crossOverOperators/crossovers.py
+++ b/framework/Optimizers/crossOverOperators/crossovers.py
@@ -22,9 +22,7 @@
 
 import numpy as np
 import xarray as xr
-import copy
 from utils import randomUtils
-from copy import deepcopy
 from scipy.special import comb
 from itertools import combinations
 

--- a/framework/Optimizers/crossOverOperators/crossovers.py
+++ b/framework/Optimizers/crossOverOperators/crossovers.py
@@ -69,10 +69,10 @@ def onePointCrossover(parents,**kwargs):
       for i in range(nGenes):
         if len(point)>1:
           raise ValueError('In one Point Crossover a single crossover location should be provided!')
-        children[2*ind:2*ind+2,i] = copy.deepcopy(parent[np.arange(0,2)*(i<point[0])+np.arange(-1,-3,-1)*(i>=point[0]),i])
+        children[2*ind:2*ind+2,i] = parent[np.arange(0,2)*(i<point[0])+np.arange(-1,-3,-1)*(i>=point[0]),i]
     else:
       # Each child is just a copy of the parents
-      children[2*ind:2*ind+2,:] = copy.deepcopy(parent)
+      children[2*ind:2*ind+2,:] = parent
 
   return children
 
@@ -102,8 +102,8 @@ def uniformCrossover(parents,**kwargs):
     parent1 = parentPair[0].values
     parent2 = parentPair[1].values
     children1,children2 = uniformCrossoverMethod(parent1,parent2,crossoverProb)
-    children[index]   = copy.deepcopy(children1)
-    children[index+1] = copy.deepcopy(children2)
+    children[index]   = children1
+    children[index+1] = children2
     index = index + 1
   return children
 
@@ -150,8 +150,8 @@ def twoPointsCrossover(parents, parentIndexes,**kwargs):
     parent2 = parents[couples[1]].values
     children1,children2 = twoPointsCrossoverMethod(parent1,parent2,locL,locU)
 
-    children[index]=copy.deepcopy(children1)
-    children[index+1]=copy.deepcopy(children2)
+    children[index]   = children1
+    children[index+1] = children2
     index = index + 2
 
   return children
@@ -189,8 +189,8 @@ def twoPointsCrossoverMethod(parent1,parent2,locL,locU):
     @ Out, children1: first generated array
     @ Out, children2: second generated array
   """
-  children1 = copy.deepcopy(parent1)
-  children2 = copy.deepcopy(parent2)
+  children1 = parent1
+  children2 = parent2
 
   seqB1 = parent1.values[locL:locU+1]
   seqB2 = parent2.values[locL:locU+1]

--- a/framework/Optimizers/mutators/mutators.py
+++ b/framework/Optimizers/mutators/mutators.py
@@ -54,7 +54,7 @@ def swapMutator(offSprings, distDict, **kwargs):
                           coords={'chromosome': np.arange(np.shape(offSprings)[0]),
                                   'Gene':kwargs['variables']})
   for i in range(np.shape(offSprings)[0]):
-    children[i] = copy.deepcopy(offSprings[i])
+    children[i] = offSprings[i]
     ## TODO What happens if loc1 or 2 is out of range?! should we raise an error?
     if randomUtils.random(dim=1,samples=1)<=kwargs['mutationProb']:
       # convert loc1 and loc2 in terms on cdf values
@@ -97,7 +97,7 @@ def scrambleMutator(offSprings, distDict, **kwargs):
       children[i,j] = distDict[offSprings[i].coords['Gene'].values[j]].cdf(float(offSprings[i,j].values))
 
   for i in range(np.shape(offSprings)[0]):
-    children[i] = copy.deepcopy(offSprings[i])
+    children[i] = offSprings[i]
     for ind,element in enumerate(locs):
       if randomUtils.random(dim=1,samples=1)< kwargs['mutationProb']:
         children[i,locs[0]:locs[-1]+1] = randomUtils.randomPermutation(list(offSprings.data[i,locs[0]:locs[-1]+1]),None)

--- a/framework/Optimizers/mutators/mutators.py
+++ b/framework/Optimizers/mutators/mutators.py
@@ -26,7 +26,6 @@ import numpy as np
 import xarray as xr
 from operator import itemgetter
 from utils import utils, randomUtils
-import copy
 
 def swapMutator(offSprings, distDict, **kwargs):
   """

--- a/framework/Optimizers/parentSelectors/parentSelectors.py
+++ b/framework/Optimizers/parentSelectors/parentSelectors.py
@@ -24,7 +24,6 @@
 
 import numpy as np
 import xarray as xr
-import copy
 from utils import randomUtils
 
 # For mandd: to be updated with RAVEN official tools

--- a/framework/Optimizers/parentSelectors/parentSelectors.py
+++ b/framework/Optimizers/parentSelectors/parentSelectors.py
@@ -42,8 +42,8 @@ def rouletteWheel(population,**kwargs):
     @ Out, selectedParents, xr.DataArray, selected parents, i.e. np.shape(selectedParents) = nParents x nGenes.
   """
   # Arguments
-  pop = copy.deepcopy(population)
-  fitness = copy.deepcopy(kwargs['fitness'])
+  pop = population
+  fitness = kwargs['fitness']
   nParents= kwargs['nParents']
   # if nparents = population size then do nothing (whole population are parents)
   if nParents == pop.shape[0]:
@@ -84,9 +84,9 @@ def tournamentSelection(population,**kwargs):
           variables, list, variable names
     @ Out, newPopulation, xr.DataArray, selected parents,
   """
-  fitness = copy.deepcopy(kwargs['fitness'])
+  fitness = kwargs['fitness']
   nParents= kwargs['nParents']
-  pop = copy.deepcopy(population)
+  pop = population
 
   popSize = population.values.shape[0]
 
@@ -124,8 +124,8 @@ def rankSelection(population,**kwargs):
           nParents, int, number of required parents.
     @ Out, newPopulation, xr.DataArray, selected parents,
   """
-  fitness = copy.deepcopy(kwargs['fitness'])
-  pop = copy.deepcopy(population)
+  fitness = kwargs['fitness']
+  pop = population
 
   index = np.arange(0,pop.shape[0])
   rank = np.arange(0,pop.shape[0])

--- a/framework/Optimizers/repairOperators/repair.py
+++ b/framework/Optimizers/repairOperators/repair.py
@@ -34,7 +34,7 @@ def replacementRepair(offSprings,**kwargs):
     @ Out, children, np.array, children resulting from the crossover. Shape is nParents x len(chromosome) i.e, number of Genes/Vars
   """
   nChildren,nGenes = np.shape(offSprings)
-  children = copy.deepcopy(offSprings)
+  children = offSprings
   # read distribution info
   distInfo = kwargs['distInfo']
 

--- a/framework/Optimizers/repairOperators/repair.py
+++ b/framework/Optimizers/repairOperators/repair.py
@@ -21,7 +21,6 @@
 """
 
 import numpy as np
-import copy
 
 # @profile
 def replacementRepair(offSprings,**kwargs):

--- a/framework/Optimizers/survivorSelectors/survivorSelectors.py
+++ b/framework/Optimizers/survivorSelectors/survivorSelectors.py
@@ -57,9 +57,9 @@ def ageBased(newRlz,**kwargs):
   # sort population, popFitness according to age
   sortedAge,sortedPopulation,sortedFitness = zip(*[[x,y,z] for x,y,z in sorted(zip(popAge,population,popFitness),key=lambda x: (x[0], -x[2]))])# if equal age then use descending fitness
   sortedAge,sortedPopulation,sortedFitness = list(sortedAge),np.atleast_1d(list(sortedPopulation)),np.atleast_1d(list(sortedFitness))
-  newPopulation = copy.deepcopy(sortedPopulation)
-  newFitness    = copy.deepcopy(sortedFitness)
-  newAge = list(map(lambda x:x+1, copy.deepcopy(sortedAge)))
+  newPopulation = sortedPopulation
+  newFitness    = sortedFitness
+  newAge = list(map(lambda x:x+1, sortedAge))
   newPopulation[-1:-np.shape(offSprings)[0]-1:-1] = offSprings
   newFitness[-1:-np.shape(offSprings)[0]-1:-1] = offSpringsFitness
   newAge[-1:-np.shape(offSprings)[0]-1:-1] = [0]*np.shape(offSprings)[0]
@@ -102,9 +102,9 @@ def fitnessBased(newRlz,**kwargs):
   population = np.atleast_2d(kwargs['population'].data)
   popFitness = np.atleast_1d(kwargs['fitness'].data)
 
-  newPopulation = copy.deepcopy(population)
-  newFitness = copy.deepcopy(popFitness)
-  newAge = list(map(lambda x:x+1, copy.deepcopy(popAge)))
+  newPopulation = population
+  newFitness = popFitness
+  newAge = list(map(lambda x:x+1, popAge))
   newPopulationMerged = np.concatenate([newPopulation,offSprings])
   newFitness = np.concatenate([newFitness,offSpringsFitness])
   newAge.extend([0]*len(offSpringsFitness))

--- a/framework/Optimizers/survivorSelectors/survivorSelectors.py
+++ b/framework/Optimizers/survivorSelectors/survivorSelectors.py
@@ -24,7 +24,6 @@
 
 import numpy as np
 import xarray as xr
-import copy
 
 # @profile
 def ageBased(newRlz,**kwargs):


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1579 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

