### PR TITLE
[WIP] Implement ROM API Interface structure

### DIFF
--- a/framework/SupervisedLearning/DynamicModeDecomposition.py
+++ b/framework/SupervisedLearning/DynamicModeDecomposition.py
@@ -168,6 +168,16 @@ class DynamicModeDecomposition(supervisedLearning):
     # Default timesteps (even if the time history is not equally spaced in time, we "trick" the dmd to think it).
     self.timeScales = dict.fromkeys( ['training','dmd'],{'t0': 0, 'intervals': ts - 1, 'dt': 1})
 
+  def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
   def __evaluateLocal__(self,featureVals):
     """
       This method is used to inquire the DMD to evaluate (after normalization that in

--- a/framework/SupervisedLearning/GaussPolynomialRom.py
+++ b/framework/SupervisedLearning/GaussPolynomialRom.py
@@ -419,6 +419,16 @@ class GaussPolynomialRom(supervisedLearning):
     tot*=self.norm
     return tot
 
+  def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
   def __evaluateLocal__(self,featureVals):
     """
       Evaluates a point.

--- a/framework/SupervisedLearning/MSR.py
+++ b/framework/SupervisedLearning/MSR.py
@@ -250,6 +250,17 @@ class MSR(NDinterpolatorRom):
     self.__amsc             = []
     self.__trainLocal__(self.X,self.Y)
 
+  def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
+
   def __trainLocal__(self,featureVals,targetVals):
     """
       Perform training on samples in featureVals with responses y.

--- a/framework/SupervisedLearning/NDinterpolatorRom.py
+++ b/framework/SupervisedLearning/NDinterpolatorRom.py
@@ -77,6 +77,16 @@ class NDinterpolatorRom(supervisedLearning):
     if self.amITrained:
       self.__trainLocal__(self.featv,self.targv)
 
+  def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
   def __trainLocal__(self,featureVals,targetVals):
     """
       Perform training on samples in featureVals with responses y.

--- a/framework/SupervisedLearning/NDsplineRom.py
+++ b/framework/SupervisedLearning/NDsplineRom.py
@@ -51,6 +51,16 @@ class NDsplineRom(NDinterpolatorRom):
     for _ in range(len(self.target)):
       self.interpolator.append(interpolationND.NDSpline())
 
+    def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
   def __trainLocal__(self,featureVals,targetVals):
     """
       Perform training on samples. This is a specialization of the

--- a/framework/SupervisedLearning/NDsplineRom.py
+++ b/framework/SupervisedLearning/NDsplineRom.py
@@ -52,14 +52,14 @@ class NDsplineRom(NDinterpolatorRom):
       self.interpolator.append(interpolationND.NDSpline())
 
     def run(self, *args, **kwargs):
+      """
+        Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+        algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+        local format the interface with the kernels requires.
+        @ In, edict, dict, evaluation dictionary
+        @ Out, evaluate, dict, {target: evaluated points}
     """
-      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
-      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
-      local format the interface with the kernels requires.
-      @ In, edict, dict, evaluation dictionary
-      @ Out, evaluate, dict, {target: evaluated points}
-    """
-    pass
+      pass
 
   def __trainLocal__(self,featureVals,targetVals):
     """

--- a/framework/SupervisedLearning/PolyExponential.py
+++ b/framework/SupervisedLearning/PolyExponential.py
@@ -198,14 +198,14 @@ class PolyExponential(supervisedLearning):
     self.featureVals = featureVals
 
     def run(self, *args, **kwargs):
-    """
+      """
       Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
       algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
       local format the interface with the kernels requires.
       @ In, edict, dict, evaluation dictionary
       @ Out, evaluate, dict, {target: evaluated points}
-    """
-    pass
+      """
+      pass
 
   def __evaluateLocal__(self,featureVals):
     """

--- a/framework/SupervisedLearning/PolyExponential.py
+++ b/framework/SupervisedLearning/PolyExponential.py
@@ -197,6 +197,16 @@ class PolyExponential(supervisedLearning):
         self.model[target].__class__.__trainLocal__(self.model[target],featureVals,expTermCoeff)
     self.featureVals = featureVals
 
+    def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
   def __evaluateLocal__(self,featureVals):
     """
       This method is used to inquire the PolyExponential to evaluate (after normalization that in

--- a/framework/SupervisedLearning/ROMCollection.py
+++ b/framework/SupervisedLearning/ROMCollection.py
@@ -85,6 +85,17 @@ class Collection(supervisedLearning):
     pass
 
   @abc.abstractmethod
+  def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
+  @abc.abstractmethod
   def evaluate(self, edict):
     """
       Method to evaluate a point or set of points via surrogate.

--- a/framework/SupervisedLearning/SupervisedLearning.py
+++ b/framework/SupervisedLearning/SupervisedLearning.py
@@ -295,7 +295,7 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta), BaseInterface, Mes
 
   # compatibility with BaseInterface requires having a "run" method
   # TODO during SVL rework, "run" should probably replace "evaluate", maybe?
-  @abc.abstractmethod
+  # @abc.abstractmethod
   def run(self, *args, **kwargs):
     """
       Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
@@ -305,7 +305,7 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta), BaseInterface, Mes
       @ Out, evaluate, dict, {target: evaluated points}
     """
 
-  def evaluate(self, edict):
+  def evaluate(self, featureValues):
     """
       DEPRECATED IN FAVOR OF RUN().
 
@@ -320,26 +320,26 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta), BaseInterface, Mes
       "The 'evaluate' method is deprecated. All future supervisedLearning engines must implement a 'run' method instead",
       tag="DeprecationWarning"
     )
-    if type(edict) != dict:
-      self.raiseAnError(
-        IOError,
-        'method "evaluate". The evaluate request/s need/s to be provided through a dictionary. Type of the in-object is ' + str(type(edict))
-      )
-    names, values  = list(edict.keys()), list(edict.values())
-    for index in range(len(values)):
-      resp = self.checkArrayConsistency(values[index], self.isDynamic())
-      if not resp[0]:
-        self.raiseAnError(IOError,'In evaluate request for feature '+names[index]+':'+resp[1])
-    # construct the evaluation matrix
-    featureValues = np.zeros(shape=(values[0].size,len(self.features)))
-    for cnt, feat in enumerate(self.features):
-      if feat not in names:
-        self.raiseAnError(IOError,'The feature sought '+feat+' is not in the evaluate set')
-      else:
-        resp = self.checkArrayConsistency(values[names.index(feat)], self.isDynamic())
-        if not resp[0]:
-          self.raiseAnError(IOError,'In training set for feature '+feat+':'+resp[1])
-        featureValues[:,cnt] = ((values[names.index(feat)] - self.muAndSigmaFeatures[feat][0]))/self.muAndSigmaFeatures[feat][1]
+    # if type(edict) != dict:
+    #   self.raiseAnError(
+    #     IOError,
+    #     'method "evaluate". The evaluate request/s need/s to be provided through a dictionary. Type of the in-object is ' + str(type(edict))
+    #   )
+    # names, values  = list(edict.keys()), list(edict.values())
+    # for index in range(len(values)):
+    #   resp = self.checkArrayConsistency(values[index], self.isDynamic())
+    #   if not resp[0]:
+    #     self.raiseAnError(IOError,'In evaluate request for feature '+names[index]+':'+resp[1])
+    # # construct the evaluation matrix
+    # featureValues = np.zeros(shape=(values[0].size,len(self.features)))
+    # for cnt, feat in enumerate(self.features):
+    #   if feat not in names:
+    #     self.raiseAnError(IOError,'The feature sought '+feat+' is not in the evaluate set')
+    #   else:
+    #     resp = self.checkArrayConsistency(values[names.index(feat)], self.isDynamic())
+    #     if not resp[0]:
+    #       self.raiseAnError(IOError,'In training set for feature '+feat+':'+resp[1])
+    #     featureValues[:,cnt] = ((values[names.index(feat)] - self.muAndSigmaFeatures[feat][0]))/self.muAndSigmaFeatures[feat][1]
     return self.__evaluateLocal__(featureValues)
 
   def reset(self):

--- a/framework/SupervisedLearning/SupervisedLearning.py
+++ b/framework/SupervisedLearning/SupervisedLearning.py
@@ -35,10 +35,10 @@ import numpy as np
 
 #Internal Modules------------------------------------------------------------------------------------
 from utils import utils, mathUtils, xmlUtils
-from BaseClasses import MessageUser
+from BaseClasses import MessageUser, BaseInterface
 #Internal Modules End--------------------------------------------------------------------------------
 
-class supervisedLearning(utils.metaclass_insert(abc.ABCMeta), MessageUser):
+class supervisedLearning(utils.metaclass_insert(abc.ABCMeta), BaseInterface, MessageUser):
   """
     This is the general interface to any supervisedLearning learning method.
     Essentially it contains a train method and an evaluate method
@@ -295,26 +295,35 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta), MessageUser):
 
   # compatibility with BaseInterface requires having a "run" method
   # TODO during SVL rework, "run" should probably replace "evaluate", maybe?
-  def run(self, edict):
+  def run(self, *args, **kwargs):
     """
-      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning algorithm
-      NB.the supervisedLearning object is committed to convert the dictionary that is passed (in), into the local format
-      the interface with the kernels requires.
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
       @ In, edict, dict, evaluation dictionary
       @ Out, evaluate, dict, {target: evaluated points}
     """
-    return self.evaluate(edict)
 
-  def evaluate(self,edict):
+  def evaluate(self, edict):
     """
-      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning algorithm
-      NB.the supervisedLearning object is committed to convert the dictionary that is passed (in), into the local format
-      the interface with the kernels requires.
+      DEPRECATED IN FAVOR OF RUN().
+
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+
       @ In, edict, dict, evaluation dictionary
       @ Out, evaluate, dict, {target: evaluated points}
     """
+    self.raiseAWarning(
+      "The 'evaluate' method is deprecated. All future supervisedLearning engines must implement a 'run' method instead",
+      tag="DeprecationWarning"
+    )
     if type(edict) != dict:
-      self.raiseAnError(IOError,'method "evaluate". The evaluate request/s need/s to be provided through a dictionary. Type of the in-object is ' + str(type(edict)))
+      self.raiseAnError(
+        IOError,
+        'method "evaluate". The evaluate request/s need/s to be provided through a dictionary. Type of the in-object is ' + str(type(edict))
+      )
     names, values  = list(edict.keys()), list(edict.values())
     for index in range(len(values)):
       resp = self.checkArrayConsistency(values[index], self.isDynamic())

--- a/framework/SupervisedLearning/SupervisedLearning.py
+++ b/framework/SupervisedLearning/SupervisedLearning.py
@@ -295,6 +295,7 @@ class supervisedLearning(utils.metaclass_insert(abc.ABCMeta), BaseInterface, Mes
 
   # compatibility with BaseInterface requires having a "run" method
   # TODO during SVL rework, "run" should probably replace "evaluate", maybe?
+  @abc.abstractmethod
   def run(self, *args, **kwargs):
     """
       Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning

--- a/framework/SupervisedLearning/SyntheticHistory.py
+++ b/framework/SupervisedLearning/SyntheticHistory.py
@@ -90,6 +90,16 @@ class SyntheticHistory(supervisedLearning):
     if self.pivotParameterID not in self.target:
       self.raiseAnError(IOError, 'The pivotParameter must be included in the target space.')
 
+  def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
   def __trainLocal__(self, featureVals, targetVals):
     """
       Perform training on input database stored in featureVals.

--- a/framework/SupervisedLearning/pickledROM.py
+++ b/framework/SupervisedLearning/pickledROM.py
@@ -47,6 +47,17 @@ class pickledROM(supervisedLearning):
     # pickledROM doesn't read anything in, as it's a placeholder
     pass
 
+  def run(self, *args, **kwargs):
+    """
+      Method to perform the evaluation of a point or a set of points through the previous trained supervisedLearning
+      algorithm NB. The supervisedLearning object is committed to convert the dictionary that is passed (in), into the
+      local format the interface with the kernels requires.
+      @ In, edict, dict, evaluation dictionary
+      @ Out, evaluate, dict, {target: evaluated points}
+    """
+    pass
+
+
   def __confidenceLocal__(self,featureVals):
     """
       This should return an estimation of the quality of the prediction.


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

See PR #1432 


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

