### PR TITLE
Handle PermissionError when trying to access executable

### DIFF
--- a/framework/Models/Code.py
+++ b/framework/Models/Code.py
@@ -429,47 +429,50 @@ class Code(Model):
     executable = commandSplit[0]
 
     if os.path.exists(executable):
-      with open(executable, "r+b") as executableFile:
-        firstTwoChars = executableFile.read(2)
-        if firstTwoChars == "#!":
-          realExecutable = shlex.split(executableFile.readline())
-          self.raiseAMessage("reading #! to find executable:" + repr(realExecutable))
-          # The below code should work, and would be better than findMsys,
-          # but it doesn't work.
-          # winExecutable = subprocess.check_output(['cygpath','-w',realExecutable[0]],shell=True).rstrip()
-          # print("winExecutable",winExecutable)
-          # realExecutable[0] = winExecutable
-          def findMsys():
-            """
-              Function to try and figure out where the MSYS64 is.
-              @ In, None
-              @ Out, dir, String, If not None, the directory where msys is.
-            """
-            dir = os.getcwd()
-            head, tail = os.path.split(dir)
-            while True:
-              if tail.lower().startswith("msys"):
-                return dir
-              dir = head
-              head, tail = os.path.split(dir)
-            return None
-          msysDir = findMsys()
-          if msysDir is not None:
-            beginExecutable = realExecutable[0]
-            if beginExecutable.startswith("/"):
-              beginExecutable = beginExecutable.lstrip("/")
-            winExecutable = os.path.join(msysDir, beginExecutable)
-            self.raiseAMessage("winExecutable " + winExecutable)
-            if not os.path.exists(winExecutable) and not os.path.exists(winExecutable + ".exe") and winExecutable.endswith("bash"):
-              #msys64 stores bash in /usr/bin/bash instead of /bin/bash, so try that
-              maybeWinExecutable = winExecutable.replace("bin/bash","usr/bin/bash")
-              if os.path.exists(maybeWinExecutable) or os.path.exists(maybeWinExecutable + ".exe"):
-                winExecutable = maybeWinExecutable
-            realExecutable[0] = winExecutable
-          else:
-            self.raiseAWarning("Could not find msys in "+os.getcwd())
-          commandSplit = realExecutable + [executable] + commandSplit[1:]
-          return commandSplit
+        try:
+          with open(executable, "r+b") as executableFile:
+            firstTwoChars = executableFile.read(2)
+            if firstTwoChars == "#!":
+              realExecutable = shlex.split(executableFile.readline())
+              self.raiseAMessage("reading #! to find executable:" + repr(realExecutable))
+              # The below code should work, and would be better than findMsys,
+              # but it doesn't work.
+              # winExecutable = subprocess.check_output(['cygpath','-w',realExecutable[0]],shell=True).rstrip()
+              # print("winExecutable",winExecutable)
+              # realExecutable[0] = winExecutable
+              def findMsys():
+                """
+                  Function to try and figure out where the MSYS64 is.
+                  @ In, None
+                  @ Out, dir, String, If not None, the directory where msys is.
+                """
+                dir = os.getcwd()
+                head, tail = os.path.split(dir)
+                while True:
+                  if tail.lower().startswith("msys"):
+                    return dir
+                  dir = head
+                  head, tail = os.path.split(dir)
+                return None
+              msysDir = findMsys()
+              if msysDir is not None:
+                beginExecutable = realExecutable[0]
+                if beginExecutable.startswith("/"):
+                  beginExecutable = beginExecutable.lstrip("/")
+                winExecutable = os.path.join(msysDir, beginExecutable)
+                self.raiseAMessage("winExecutable " + winExecutable)
+                if not os.path.exists(winExecutable) and not os.path.exists(winExecutable + ".exe") and winExecutable.endswith("bash"):
+                  #msys64 stores bash in /usr/bin/bash instead of /bin/bash, so try that
+                  maybeWinExecutable = winExecutable.replace("bin/bash","usr/bin/bash")
+                  if os.path.exists(maybeWinExecutable) or os.path.exists(maybeWinExecutable + ".exe"):
+                    winExecutable = maybeWinExecutable
+                realExecutable[0] = winExecutable
+              else:
+                self.raiseAWarning("Could not find msys in "+os.getcwd())
+              commandSplit = realExecutable + [executable] + commandSplit[1:]
+              return commandSplit
+        except PermissionError as e:
+            self.raiseAWarning("Permission denied to open executable ! Skipping!")
     return origCommand
 
   @Parallel()


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Issue running Dymola in parallel

##### What are the significant changes in functionality due to this change request?
Able to run Dymola in parallel

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

