### PR TITLE
Fixing pylints.

### DIFF
--- a/rook/Tester.py
+++ b/rook/Tester.py
@@ -179,7 +179,7 @@ class Differ:
   def __init__(self, _name, params, test_dir):
     """
       Initializer for the class.
-      @ In, name, string, name of class
+      @ In, _name, string, name of class (currently unused)
       @ In, params, dictionary, dictionary of parameters
       @ In, test_dir, string, path to test directory
       @ Out, None
@@ -369,7 +369,7 @@ class Tester:
   def __init__(self, _name, params):
     """
       Initializer for the class.  Takes a String name and a dictionary params
-      @ In, name, string, name of the class
+      @ In, _name, string, name of the class (currently unused)
       @ In, params, dictionary, the parameters for this class to use.
       @ Out, None
     """

--- a/rook/Tester.py
+++ b/rook/Tester.py
@@ -176,7 +176,7 @@ class Differ:
     params.add_param('gold_files', '', 'Gold filenames')
     return params
 
-  def __init__(self, name, params, test_dir):
+  def __init__(self, _name, params, test_dir):
     """
       Initializer for the class.
       @ In, name, string, name of class
@@ -184,7 +184,6 @@ class Differ:
       @ In, test_dir, string, path to test directory
       @ Out, None
     """
-    #self.__name = name
     self.__test_dir = test_dir
     valid_params = self.get_valid_params()
     self.specs = valid_params.get_filled_dict(params)
@@ -367,14 +366,13 @@ class Tester:
     params.add_param('output_wait_time', '-1', 'Number of seconds to wait for output')
     return params
 
-  def __init__(self, name, params):
+  def __init__(self, _name, params):
     """
       Initializer for the class.  Takes a String name and a dictionary params
       @ In, name, string, name of the class
       @ In, params, dictionary, the parameters for this class to use.
       @ Out, None
     """
-    #self.__name = name
     valid_params = self.get_valid_params()
     self.specs = valid_params.get_filled_dict(params)
     self.results = TestResult()

--- a/rook/Tester.py
+++ b/rook/Tester.py
@@ -184,7 +184,7 @@ class Differ:
       @ In, test_dir, string, path to test directory
       @ Out, None
     """
-    self.__name = name
+    #self.__name = name
     self.__test_dir = test_dir
     valid_params = self.get_valid_params()
     self.specs = valid_params.get_filled_dict(params)
@@ -374,7 +374,7 @@ class Tester:
       @ In, params, dictionary, the parameters for this class to use.
       @ Out, None
     """
-    self.__name = name
+    #self.__name = name
     valid_params = self.get_valid_params()
     self.specs = valid_params.get_filled_dict(params)
     self.results = TestResult()

--- a/rook/XMLDiff.py
+++ b/rook/XMLDiff.py
@@ -194,8 +194,8 @@ def compare_unordered_element(a_element, b_element, **kwargs):
         del matchvals[a_entry]
         del diffs[a_entry]
         #since we found the match, remove from other near matches
-        for close_key in diffs:
-          if b_entry in diffs[close_key].keys():
+        for close_key, diff_value in diffs.items():
+          if b_entry in diff_value.keys():
             del diffs[close_key][b_entry]
             del matchvals[close_key][b_entry]
         break

--- a/rook/XMLDiff.py
+++ b/rook/XMLDiff.py
@@ -196,7 +196,7 @@ def compare_unordered_element(a_element, b_element, **kwargs):
         #since we found the match, remove from other near matches
         for close_key, diff_value in diffs.items():
           if b_entry in diff_value.keys():
-            del diffs[close_key][b_entry]
+            del diff_value[b_entry]
             del matchvals[close_key][b_entry]
         break
       matchvals[a_entry][b_entry] = matchval

--- a/rook/main.py
+++ b/rook/main.py
@@ -393,10 +393,10 @@ if __name__ == "__main__":
       print()
 
   tester_params = {}
-  for tester in testers:
+  for tester_key, tester_value in testers.items():
     #Note as a side effect, testers can add run types to
     # the tester.
-    tester_params[tester] = testers[tester].get_valid_params()
+    tester_params[tester_key] = tester_value.get_valid_params()
 
   Tester.initialize_current_run_type()
   if args.add_run_types is not None:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #1600 

##### What are the significant changes in functionality due to this change request?
Fixes some pylint warnings.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

