### PR TITLE
fixing manual/latex issues

### DIFF
--- a/framework/Optimizers/GeneticAlgorithm.py
+++ b/framework/Optimizers/GeneticAlgorithm.py
@@ -216,13 +216,15 @@ class GeneticAlgorithm(RavenSampled):
         contentType=InputTypes.StringType,
         printPriority=108,
         descr=r"""a subnode containing the implemented fitness functions.
-                  This includes: a.    invLinear: $fitness = -a \\times obj - b \\times \\Sum_{j=1}^{nConstraint} max(0,-penalty_j)$.
-                                 b.    logistic: $fitness = \\frac{1}{1+e^{a \\times (obj-b)}}$.
-                                 c.    feasibleFirst: $fitness = \[ \\begin{cases}
-                                                                      -obj & g_j(x)\\geq 0 \\forall j \\
-                                                                      -obj_{worst} - \\Sigma_{j=1}^{J}<g_j(x)> & otherwise \\
-                                                                    \\end{cases}
-                                                                \]$""")
+                  This includes:\\
+                                 a.    invLinear: \[fitness = -a \times obj - b \times \sum_{j=1}^{nConstraint} max(0,-g_j(x)).\]
+                                 b.    logistic: \[fitness = \frac{1}{1+e^{a \times (obj-b)}}.\]
+                                 c.    feasibleFirst: \[fitness = \begin{cases}
+                                                                      -obj & g_j(x) \geq 0 \ \forall j \in \{1 .. nConstraint\} \\
+                                                                      -obj_{worst} - \sum_{j=1}^{nConstraint} max(0,-g_j(x)) & otherwise;
+                                                                  \end{cases}
+                                                                \]
+                                                      where $g_j(x)$ is the $j^{th}$ constraint function written as $g_j(x) > 0$, i.e., positive if no violation occurres and negative otherwise.""")
     fitness.addParam("type", InputTypes.StringType, True,
                      descr=r"""[invLin, logistic, feasibleFirst]""")
     objCoeff = InputData.parameterInputFactory('a', strictMode=True,

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -556,7 +556,7 @@ class ParameterInput(object):
       @ In, recDepth, int, optional, recursion depth of printing
       @ Out, msg, str, LaTeX string representation of user manual entry
     """
-    name = cls.name
+    name = cls.name#name = re.sub(r'(?<!\\)_', r'\_', cls.name)
     desc = wrapText(cls.description, indent=doDent(recDepth, 1))
     msg = ''
     # if this is a main entity, use subsection instead of itemizing
@@ -584,9 +584,9 @@ class ParameterInput(object):
         msg += '\n{sub}'.format(sub=sub.generateLatex(recDepth=recDepth+2))
       msg += '{i}\\end{{itemize}}\n'.format(i=doDent(recDepth, 1))
     # TODO is this a good idea? -> disables underscores in math mode :(
-    if recDepth == 0:
-      # assure underscore is escaped, but not doubly
-      msg = re.sub(r'(?<!\\)_', r'\_', msg)
+    #if recDepth == 0:
+      ## assure underscore is escaped, but not doubly
+      #msg = re.sub(r'(?<!\\)_', r'\_', msg)
     return msg
 
   @classmethod

--- a/framework/utils/InputData.py
+++ b/framework/utils/InputData.py
@@ -556,7 +556,7 @@ class ParameterInput(object):
       @ In, recDepth, int, optional, recursion depth of printing
       @ Out, msg, str, LaTeX string representation of user manual entry
     """
-    name = cls.name#name = re.sub(r'(?<!\\)_', r'\_', cls.name)
+    name = re.sub(r'(?<!\\)_', r'\_', cls.name)
     desc = wrapText(cls.description, indent=doDent(recDepth, 1))
     msg = ''
     # if this is a main entity, use subsection instead of itemizing


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
This PR addresses the `_` in the latex manual generation. This closes #1614 

##### What are the significant changes in functionality due to this change request?
underscores are only escaped out of the math mode.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

