### PR TITLE
added check for a None soln export

### DIFF
--- a/framework/Optimizers/Optimizer.py
+++ b/framework/Optimizers/Optimizer.py
@@ -172,6 +172,7 @@ class Optimizer(AdaptiveSampler):
     self._initSampler = None    # sampler to use for picking initial seeds
     self._constraintFunctions = [] # list of constraint functions
     self._impConstraintFunctions = [] # list of implicit constraint functions
+    self._requireSolnExport = True # optimizers only produce result in solution export
     # __private
     # additional methods
     self.addAssemblerObject('Constraint', InputData.Quantity.zero_to_infinity)      # Explicit (input-based) constraints

--- a/framework/Samplers/AdaptiveSampler.py
+++ b/framework/Samplers/AdaptiveSampler.py
@@ -63,6 +63,7 @@ class AdaptiveSampler(Sampler):
     self._inputIdentifiers = {}         # identifiers for a single realization
     self._targetEvaluation = None       # data object with feedback from sample realizations
     self._solutionExport = None         # data object for solution printing
+    self._requireSolnExport = False     # if this object requires a solution export
     # NOTE TargetEvaluations consider all the Step <Output> DataObjects as candidates, so requiring
     # exactly one TargetEvaluation forces only having one <Output> DataObject in AdaptiveSampling
     # MultiRun Steps. For now, we leave it as "n".
@@ -76,8 +77,8 @@ class AdaptiveSampler(Sampler):
       @ Out, None
     """
     self._targetEvaluation = self.assemblerDict['TargetEvaluation'][0][3]
-    if solutionExport is None:
-      self.raiseAnError('No <SolutionExport> found this step! Required for adaptive sampling.')
+    if self._requireSolnExport and solutionExport is None:
+      self.raiseAnError(IOError, 'No <SolutionExport> found this step! Required for this sampling strategy.')
     self._solutionExport = solutionExport
     Sampler.initialize(self, externalSeeding=externalSeeding, solutionExport=solutionExport)
     self._validateSolutionExportVariables(solutionExport)

--- a/framework/Samplers/AdaptiveSampler.py
+++ b/framework/Samplers/AdaptiveSampler.py
@@ -76,6 +76,8 @@ class AdaptiveSampler(Sampler):
       @ Out, None
     """
     self._targetEvaluation = self.assemblerDict['TargetEvaluation'][0][3]
+    if solutionExport is None:
+      self.raiseAnError('No <SolutionExport> found this step! Required for adaptive sampling.')
     self._solutionExport = solutionExport
     Sampler.initialize(self, externalSeeding=externalSeeding, solutionExport=solutionExport)
     self._validateSolutionExportVariables(solutionExport)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1474

##### What are the significant changes in functionality due to this change request?
Adds a check for adaptive samplers that the SolutionExport is not None when initialized

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

