### PR TITLE
SyntheticHistory abstractions to TSAUser

### DIFF
--- a/framework/SupervisedLearning/SyntheticHistory.py
+++ b/framework/SupervisedLearning/SyntheticHistory.py
@@ -21,11 +21,11 @@
 import numpy as np
 
 from utils import InputData, xmlUtils
-import TSA
+from TSA import TSAUser
 
 from .SupervisedLearning import supervisedLearning
 
-class SyntheticHistory(supervisedLearning):
+class SyntheticHistory(supervisedLearning, TSAUser):
   """
     Leverage TSA algorithms to train then generate synthetic signals.
   """
@@ -43,9 +43,7 @@ class SyntheticHistory(supervisedLearning):
         descr=r"""A ROM for characterizing and generating synthetic histories. This ROM makes use of
                a variety of TimeSeriesAnalysis (TSA) algorithms to characterize and generate new
                signals based on training signal sets. """)
-    for typ in TSA.factory.knownTypes():
-      c = TSA.factory.returnClass(typ) # TODO no message handler for second argument
-      specs.addSub(c.getInputSpecification())
+    cls.addTSASpecs(specs)
     return specs
 
   ### INHERITED METHODS ###
@@ -57,15 +55,9 @@ class SyntheticHistory(supervisedLearning):
     """
     # general infrastructure
     supervisedLearning.__init__(self, **kwargs)
+    TSAUser.__init__(self)
     self.printTag = 'SyntheticHistoryROM'
     self._dynamicHandling = True # This ROM is able to manage the time-series on its own.
-    # training storage
-    self.algoSettings = {}  # initialization settings for each algorithm
-    self.trainedParams = {} # holds results of training each algorithm
-    self.tsaAlgorithms = [] # list and order for tsa algorithms to use
-    # data manipulation
-    self.pivotParameterID = None      # string name for time-like pivot parameter
-    self.pivotParameterValues = None  # In here we store the values of the pivot parameter (e.g. Time)
 
     inputSpecs = kwargs['paramInput']
     self.readInputSpecs(inputSpecs)
@@ -76,19 +68,7 @@ class SyntheticHistory(supervisedLearning):
       @ In, inp, InputData.InputParams, input specifications
       @ Out, None
     """
-    self.pivotParameterID = inp.findFirst('pivotParameter').value # TODO does a base class do this?
-    foundTSAType = False
-    for sub in inp.subparts:
-      if sub.name in TSA.factory.knownTypes():
-        algo = TSA.factory.returnInstance(sub.name)
-        self.algoSettings[algo] = algo.handleInput(sub)
-        self.tsaAlgorithms.append(algo)
-        foundTSAType = True
-    if foundTSAType is False:
-      options = ', '.join(TSA.factory.knownTypes())
-      self.raiseAnError(IOError, f'No known TSA type found in input. Available options are: {options}')
-    if self.pivotParameterID not in self.target:
-      self.raiseAnError(IOError, 'The pivotParameter must be included in the target space.')
+    self.readTSAInput(inp)
 
   def __trainLocal__(self, featureVals, targetVals):
     """
@@ -98,49 +78,14 @@ class SyntheticHistory(supervisedLearning):
       @ Out, None
     """
     self.raiseADebug('Training...')
-    # TODO obtain pivot parameter
-    pivotName = self.pivotParameterID
-    pivotIndex = self.target.index(pivotName)
-    # TODO assumption: only one training signal
-    pivots = targetVals[0, :, pivotIndex]
-    self.pivotParameterValues = pivots[:] # TODO any way to avoid storing these?
-    residual = targetVals[:, :, :] # deep-ish copy, so we don't mod originals
-    numAlgo = len(self.tsaAlgorithms)
-    for a, algo in enumerate(self.tsaAlgorithms):
-      settings = self.algoSettings[algo]
-      targets = settings['target']
-      indices = tuple(self.target.index(t) for t in targets)
-      signal = residual[0, :, indices].T # using tuple "indices" transposes, so transpose back
-      params = algo.characterize(signal, pivots, targets, settings)
-      # store characteristics
-      self.trainedParams[algo] = params
-      # obtain residual; the part of the signal not characterized by this algo
-      # workaround: skip the last one, since it's often the ARMA and the residual isn't known for
-      #             the ARMA
-      if a < numAlgo - 1:
-        algoResidual = algo.getResidual(signal, params, pivots, settings)
-        residual[0, :, indices] = algoResidual.T # transpose, again because of indices
-      # TODO meta store signal, residual?
+    self.trainTSASequential(targetVals[0, :, :])
 
   def __evaluateLocal__(self, featureVals):
     """
       @ In, featureVals, float, a scalar feature value is passed as scaling factor
       @ Out, rlz, dict, realization dictionary of values for each target
     """
-    pivots = self.pivotParameterValues
-    result = np.zeros((self.pivotParameterValues.size, len(self.target) - 1)) # -1 is pivot
-    for algo in self.tsaAlgorithms[::-1]:
-      settings = self.algoSettings[algo]
-      targets = settings['target']
-      indices = tuple(self.target.index(t) for t in targets)
-      params = self.trainedParams[algo]
-      if not algo.canGenerate():
-        self.raiseAnError(IOError, "This TSA algorithm cannot generate synthetic histories.")
-      signal = algo.generate(params, pivots, settings)
-      result[:, indices] += signal
-    # RAVEN realization construction
-    rlz = dict((target, result[:, t]) for t, target in enumerate(self.target) if target != self.pivotParameterID)
-    rlz[self.pivotParameterID] = self.pivotParameterValues
+    rlz = self.evaluateTSASequential()
     return rlz
 
   def writePointwiseData(self, writeTo):
@@ -160,11 +105,7 @@ class SyntheticHistory(supervisedLearning):
       @ In, skip, list, optional, unused (kept for compatability)
       @ Out, None
     """
-    root = writeTo.getRoot()
-    for algo in self.tsaAlgorithms:
-      algoNode = xmlUtils.newNode(algo.name)
-      algo.writeXML(algoNode, self.trainedParams[algo])
-      root.append(algoNode)
+    self.writeTSAtoXML(writeTo)
 
   ### Segmenting and Clustering ###
   def isClusterable(self):

--- a/framework/SupervisedLearning/SyntheticHistory.py
+++ b/framework/SupervisedLearning/SyntheticHistory.py
@@ -78,7 +78,7 @@ class SyntheticHistory(supervisedLearning, TSAUser):
       @ Out, None
     """
     self.raiseADebug('Training...')
-    self.trainTSASequential(targetVals[0, :, :])
+    self.trainTSASequential(targetVals)
 
   def __evaluateLocal__(self, featureVals):
     """

--- a/framework/TSA/Factory.py
+++ b/framework/TSA/Factory.py
@@ -15,6 +15,7 @@
   Factory interface for returning classes and instances from the
   Time Series Analysis module.
 """
+from utils import InputData
 from EntityFactoryBase import EntityFactory
 
 from .TimeSeriesAnalyzer import TimeSeriesAnalyzer

--- a/framework/TSA/TSAUser.py
+++ b/framework/TSA/TSAUser.py
@@ -1,0 +1,136 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Created on August 3, 2021
+
+@author: talbpaul
+"""
+import numpy as np
+
+from utils import xmlUtils
+
+from .Factory import factory
+
+class TSAUser:
+  """
+    Add-on class for inheriting commonly-used TSA algorithms, such as reading in algorithms
+  """
+  @classmethod
+  def addTSASpecs(cls, spec):
+    """
+      Make input specs for TSA algorithm inclusion.
+      @ In, spec, InputData.parameterInput, input specs to which TSA algos should be added
+      @ Out, None
+    """
+    for typ in factory.knownTypes():
+      c = factory.returnClass(typ)
+      spec.addSub(c.getInputSpecification())
+
+  def __init__(self):
+    """
+      Constructor.
+      @ In, None
+      @ Out, None
+    """
+    # delay import of factory to assure linear imports
+    self._tsaAlgoSettings = {}       # initialization settings for each algorithm
+    self._tsaTrainedParams = {}      # holds results of training each algorithm
+    self._tsaAlgorithms = []         # list and order for TSA algorithms to use
+    self.pivotParameterID = None     # string name for time-like pivot parameter # TODO base class?
+    self.pivotParameterValues = None # values for the time-like pivot parameter  # TODO base class?
+
+  def readTSAInput(self, spec):
+    """
+      Read in TSA algorithms
+    """
+    self.pivotParameterID = spec.findFirst('pivotParameter').value # TODO does a base class do this?
+    for sub in spec.subparts:
+      if sub.name in factory.knownTypes():
+        algo = factory.returnInstance(sub.name)
+        self._tsaAlgoSettings[algo] = algo.handleInput(sub)
+        self._tsaAlgorithms.append(algo)
+        foundTSAType = True
+    if foundTSAType is False:
+      options = ', '.join(factory.knownTypes())
+      # NOTE this assumes that every TSAUser is also an InputUser!
+      self.raiseAnError(IOError, f'No known TSA type found in input. Available options are: {options}')
+    if self.pivotParameterID not in self.target:
+      # NOTE this assumes that every TSAUser is also an InputUser!
+      self.raiseAnError(IOError, 'The pivotParameter must be included in the target space.')
+
+  def trainTSASequential(self, targetVals):
+    """
+      Train TSA algorithms using a sequential removal-and-residual approach.
+      @ In, targetVals, array, shape = [n_timeStep, n_dimensions], array of time series data
+        NOTE: this should be a single history/realization, not an array of realizations
+      @ Out, None
+    """
+    pivotName = self.pivotParameterID
+    # NOTE assumption: self.target exists!
+    pivotIndex = self.target.index(pivotName)
+    # NOTE assumption: only one training signal (otherwise need a [0, ...] for the slicer)
+    pivots = targetVals[:, pivotIndex]
+    self.pivotParameterValues = pivots[:] # TODO any way to avoid storing these?
+    residual = targetVals[:, :] # deep-ish copy, so we don't mod originals
+    numAlgo = len(self.tsaAlgorithms)
+    for a, algo in enumerate(self.tsaAlgorithms):
+      settings = self.algoSettings[algo]
+      targets = settings['target']
+      indices = tuple(self.target.index(t) for t in targets)
+      signal = residual[:, indices].T # using tuple "indices" transposes, so transpose back
+      params = algo.characterize(signal, pivots, targets, settings)
+      # store characteristics
+      self.trainedParams[algo] = params
+      # obtain residual; the part of the signal not characterized by this algo
+      # workaround: skip the last one, since it's often the ARMA and the residual isn't known for
+      #             the ARMA
+      if a < numAlgo - 1:
+        algoResidual = algo.getResidual(signal, params, pivots, settings)
+        residual[0, :, indices] = algoResidual.T # transpose, again because of indices
+      # TODO meta store signal, residual?
+
+  def evaluateTSASequential(self):
+    """
+      Evaluate TSA algorithms using a sequential linear superposition approach
+      @ In, featureVals, float, a scalar feature value is passed as scaling factor
+      @ Out, rlz, dict, realization dictionary of values for each target
+    """
+    pivots = self.pivotParameterValues
+    # NOTE assumption: self.target exists!
+    result = np.zeros((self.pivotParameterValues.size, len(self.target) - 1)) # -1 is pivot
+    for algo in self.tsaAlgorithms[::-1]:
+      settings = self.algoSettings[algo]
+      targets = settings['target']
+      indices = tuple(self.target.index(t) for t in targets)
+      params = self.trainedParams[algo]
+      if not algo.canGenerate():
+        self.raiseAnError(IOError, "This TSA algorithm cannot generate synthetic histories.")
+      signal = algo.generate(params, pivots, settings)
+      result[:, indices] += signal
+    # RAVEN realization construction
+    rlz = dict((target, result[:, t]) for t, target in enumerate(self.target) if target != self.pivotParameterID)
+    rlz[self.pivotParameterID] = self.pivotParameterValues
+    return rlz
+
+  def writeTSAtoXML(self, xml):
+    """
+      Write properties of TSA algorithms to XML
+      @ In, xml, xmlUtils.StaticXmlElement, entity to write to
+      @ Out, None
+    """
+    root = xml.getRoot()
+    for algo in self.tsaAlgorithms:
+      algoNode = xmlUtils.newNode(algo.name)
+      algo.writeXML(algoNode, self.trainedParams[algo])
+      root.append(algoNode)

--- a/framework/TSA/__init__.py
+++ b/framework/TSA/__init__.py
@@ -20,10 +20,11 @@
 
 from __future__ import absolute_import
 
-# These lines ensure that we do not have to do something like:
 from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
 
 from .Fourier import Fourier
 from .ARMA import ARMA
 
 from .Factory import factory
+
+from .TSAUser import TSAUser # needs to be imported AFTER factory!

--- a/framework/TSA/__init__.py
+++ b/framework/TSA/__init__.py
@@ -18,8 +18,6 @@
   @author: talbpaul
 """
 
-from __future__ import absolute_import
-
 from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
 
 from .Fourier import Fourier


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Leads toward #1627

##### What are the significant changes in functionality due to this change request?
Moves many features that are commonly needed among all TSA users into a TSA base class that other entities can inherit from.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

