### PR TITLE
RWD TSA Algo

### DIFF
--- a/framework/TSA/Factory.py
+++ b/framework/TSA/Factory.py
@@ -23,10 +23,12 @@ from .Fourier import Fourier
 from .ARMA import ARMA
 from .Wavelet import Wavelet
 from .PolynomialRegression import PolynomialRegression
+from .RWD import RWD
 
 factory = EntityFactory('TimeSeriesAnalyzer')
 # TODO map lower case to upper case, because of silly ROM namespace problems
 aliases = {'Fourier': 'fourier',
            'ARMA': 'arma',
+           'RWD': 'rwd',
            'Wavelet': 'wavelet'}
 factory.registerAllSubtypes(TimeSeriesAnalyzer, alias=aliases)

--- a/framework/TSA/RWD.py
+++ b/framework/TSA/RWD.py
@@ -1,0 +1,211 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+  Randomized Window Decomposition
+"""
+
+import collections
+import numpy as np
+import scipy as sp
+np.random.default_rng(seed=42)
+
+import Decorators
+
+import string
+import numpy.linalg as LA
+import pandas as pd
+import copy as cp
+from math import*
+
+from utils import InputData, InputTypes, randomUtils, xmlUtils, mathUtils, importerUtils
+statsmodels = importerUtils.importModuleLazy('statsmodels', globals())
+
+import Distributions
+from .TimeSeriesAnalyzer import TimeSeriesGenerator, TimeSeriesCharacterizer
+
+
+
+# utility methods
+class RWD(TimeSeriesCharacterizer):
+  r"""
+    Randomized Window Decomposition
+  """
+  # class attribute
+  ## define the clusterable features for this trainer.
+
+
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    specs = super(RWD, cls).getInputSpecification()
+    specs.name = 'RWD' # NOTE lowercase because ARMA already has Fourier and no way to resolve right now
+    specs.description = r"""TimeSeriesAnalysis algorithm for sliding window snapshots to generate features"""
+
+    specs.addSub(InputData.parameterInputFactory('SignatureWindowLength', contentType=InputTypes.FloatType,
+                 descr=r"""the size of signature window, which represents as a snapshot for a certain time step;
+                       typically represented as $w$ in literature, or $w_sig$ in the code."""))
+    specs.addSub(InputData.parameterInputFactory('FeatureIndex', contentType=InputTypes.FloatType,
+                 descr=r""" Index used for feature selection, which requires pre-analysis for now, will be addresses 
+                 via other non human work required method """))
+    specs.addSub(InputData.parameterInputFactory('SampleType', contentType=InputTypes.FloatType,
+                 descr=r"""Indicating the type of sampling."""))
+    return specs
+
+
+  #
+  # API Methods
+  #
+  def __init__(self, *args, **kwargs):
+    """
+      A constructor that will appropriately intialize a supervised learning object
+      @ In, args, list, an arbitrary list of positional values
+      @ In, kwargs, dict, an arbitrary dictionary of keywords and values
+      @ Out, None
+    """
+    # general infrastructure
+    super().__init__(*args, **kwargs)
+    self._minBins = 20 # this feels arbitrary; used for empirical distr. of data
+
+  def handleInput(self, spec):
+    """
+      Reads user inputs into this object.
+      @ In, inp, InputData.InputParams, input specifsications
+      @ In, SampleType, integer = 0, 1, 2
+      @     SampleType = 0: Sequentially Sampling
+      @     SampleType = 1: Randomly Sampling
+      @     SampleType = 2: Piecewise Sampling
+      @ Out, settings, dict, initialization settings for this algorithm
+    """
+    settings = super().handleInput(spec)
+    settings['SignatureWindowLength'] = spec.findFirst('SignatureWindowLength').value
+    settings['FeatureIndex'] = spec.findFirst('FeatureIndex').value
+    settings['SampleType'] = spec.findFirst('SampleType').value
+
+
+    return settings
+
+  def setDefaults(self, settings):
+    """
+      Fills default values for settings with default values.
+      @ In, settings, dict, existing settings
+      @ Out, settings, dict, modified settings
+    """
+    settings = super().setDefaults(settings)
+    if 'SignatureWindowLength' not in settings:
+      settings['SignatureWindowLength'] = 105#len(history)//10
+      settings['SampleType'] = 1
+
+    return settings #### 
+
+  def characterize(self, signal, pivot, targets, settings):
+    """
+      Determines the charactistics of the signal based on this algorithm.
+      @ In, signal, np.ndarray, time series with dims [time, target]
+      @ In, pivot, np.1darray, time-like parameter values
+      @ In, targets, list(str), names of targets in same order as signal
+      @ In, settings, dict, settings for this ROM
+      @ Out, params, dict of list: 1st is the uvectors, 2nd is params (LOC, HOC)
+    """
+    # lazy import statsmodels
+    import statsmodels.api
+    # settings:
+    #   SignatureWindowLength, int,  Signature window length
+    #   FeatureIndex, list of int,  The index that contains differentiable params
+
+    params = {}
+    for tg, target in enumerate(targets):
+      history = signal[:, tg]
+      SignatureWindowLength = settings['SignatureWindowLength']
+      fi = settings['FeatureIndex']
+      SampleType = settings['SampleType']
+      AllWindowNumber = len(history)-SignatureWindowLength+1
+      SignatureMatrix = np.zeros((SignatureWindowLength, AllWindowNumber))
+      for i in range(AllWindowNumber):
+        SignatureMatrix[:,i] = np.copy(history[i:i+SignatureWindowLength])
+      
+      # Sequential sampling
+      if SampleType == 0:
+        BaseMatrix = np.copy(SignatureMatrix)
+
+      # Randomized sampling
+      elif SampleType == 1:
+        sampleLimit = len(history)-SignatureWindowLength
+        
+        WindowNumber = sampleLimit//4
+        sampleIndex = np.random.randint(sampleLimit, size=WindowNumber)
+        BaseMatrix = np.zeros((SignatureWindowLength, WindowNumber))
+        for i in range(WindowNumber):
+          WindowIndex = sampleIndex[i]
+          BaseMatrix[:,i] = np.copy(history[WindowIndex:WindowIndex+SignatureWindowLength])
+        #print('sampleIndex: ',sampleIndex)
+      # Piecewise Sampling
+      else:
+        WindowNumber = len(history)//SignatureWindowLength
+        BaseMatrix = np.zeros((SignatureWindowLength, WindowNumber))
+        for i in range(WindowNumber-1):
+          BaseMatrix[:,i] = np.copy(history[i*SignatureWindowLength:(i+1)*SignatureWindowLength])
+
+
+      U,s,V = mathUtils.computeTruncatedSingularValueDecomposition(BaseMatrix,0)
+      print('SignatureMatrix ',SignatureMatrix.shape)
+
+      FeatureMatrix = U.T @ SignatureMatrix
+      print('FeatureMatrix ',FeatureMatrix.shape)
+      
+      
+      params[target] = [U, FeatureMatrix]
+      
+        
+        
+    return params 
+
+
+  def generate(self, params, pivot, settings):
+    """
+      Generates a synthetic history from fitted parameters.
+      @ In, params, dict, characterization such as otained from self.characterize()
+      @ In, pivot, np.array(float), pivot parameter values
+      @ In, settings, dict, additional settings specific to algorithm
+      @ Out, synthetic, np.array(float), synthetic estimated model signal
+    """
+    
+    synthetic = np.zeros((len(pivot), len(params)))
+    for t, (target, _) in enumerate(params.items()):
+      SigMat_synthetic = params[target][0] @ params[target][1]
+      synthetic[:, t] = np.hstack((SigMat_synthetic[0,:-1], SigMat_synthetic[:,-1]))
+
+    return synthetic
+
+############## problems
+  def writeXML(self, writeTo, features):
+    """
+      Allows the engine to put whatever it wants into an XML to print to file.
+      @ In, writeTo, xmlUtils.StaticXmlElement, entity to write to
+      @ In, features, dict, features from as from self.characterize
+      @ Out, None
+    """
+    for target, info in features.items():
+      base = xmlUtils.newNode(target)
+      writeTo.append(base)
+      base.append(xmlUtils.newNode('constant', text=f'{float(info["rwd"]["const"]):1.9e}'))
+      for p, ar in enumerate(info['rwd']['UVec']):
+        base.append(xmlUtils.newNode(f'AR_{p}', text=f'{float(ar):1.9e}'))
+
+      base.append(xmlUtils.newNode('variance', text=f'{float(info["rwd"]["var"]):1.9e}'))
+      

--- a/framework/TSA/__init__.py
+++ b/framework/TSA/__init__.py
@@ -22,6 +22,7 @@ from .TimeSeriesAnalyzer import TimeSeriesAnalyzer
 
 from .Fourier import Fourier
 from .ARMA import ARMA
+from .RWD import RWD
 
 from .Factory import factory
 

--- a/tests/framework/unit_tests/TSA/testRWD.py
+++ b/tests/framework/unit_tests/TSA/testRWD.py
@@ -1,0 +1,332 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+  This Module performs Unit Tests for the TSA.Fourier class.
+  It can not be considered part of the active code but of the regression test system
+"""
+import os
+import sys
+import copy
+import numpy as np
+np.random.seed(42)
+
+rng = np.random.default_rng(seed=42)
+
+# add RAVEN to path
+frameworkDir = os.path.abspath(os.path.join(*([os.path.dirname(__file__)] + [os.pardir]*4 + ['framework'])))
+if frameworkDir not in sys.path:
+  sys.path.append(frameworkDir)
+
+from utils.utils import find_crow
+find_crow(frameworkDir)
+import numpy.linalg as LA
+
+from utils import xmlUtils
+
+from TSA import RWD
+
+plot = False
+
+print('Module undergoing testing:')
+print(RWD)
+print('')
+
+results = {"pass":0,"fail":0}
+
+def checkFloat(comment, value, expected, tol=1e-10, update=True):
+  """
+    This method is aimed to compare two floats given a certain tolerance
+    @ In, comment, string, a comment printed out if it fails
+    @ In, value, float, the value to compare
+    @ In, expected, float, the expected value
+    @ In, tol, float, optional, the tolerance
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if same
+  """
+  if np.isnan(value) and np.isnan(expected):
+    res = True
+  elif np.isnan(value) or np.isnan(expected):
+    res = False
+  else:
+    res = abs(value - expected) <= tol
+  if update:
+    if not res:
+      print("checking float",comment,'|',value,"!=",expected)
+      results["fail"] += 1
+    else:
+      results["pass"] += 1
+  return res
+
+def checkTrue(comment, res, update=True):
+  """
+    This method is a pass-through for consistency and updating
+    @ In, comment, string, a comment printed out if it fails
+    @ In, res, bool, the tested value
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if test
+  """
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      print("checking bool",comment,'|',res,'is not True!')
+      results["fail"] += 1
+  return res
+
+def checkSame(comment, value, expected, update=True):
+  """
+    This method is aimed to compare two identical things
+    @ In, comment, string, a comment printed out if it fails
+    @ In, value, float, the value to compare
+    @ In, expected, float, the expected value
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if same
+  """
+  res = value == expected
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      print("checking string",comment,'|',value,"!=",expected)
+      results["fail"] += 1
+  return res
+
+def checkArray(comment, first, second, dtype, tol=1e-10, update=True):
+  """
+    This method is aimed to compare two arrays
+    @ In, comment, string, a comment printed out if it fails
+    @ In, value, float, the value to compare
+    @ In, expected, float, the expected value
+    @ In, tol, float, optional, the tolerance
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if same
+  """
+  res = True
+  if len(first) != len(second):
+    res = False
+    print("checking answer",comment,'|','lengths do not match:',len(first),len(second))
+  else:
+    for i in range(len(first)):
+      if dtype == float:
+        pres = checkFloat('',first[i],second[i],tol,update=False)
+      elif dtype in (str,unicode):
+        pres = checkSame('',first[i],second[i],update=False)
+      if not pres:
+        print('checking array',comment,'|','entry "{}" does not match: {} != {}'.format(i,first[i],second[i]))
+        res = False
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      results["fail"] += 1
+  return res
+
+def checkNone(comment, entry, update=True):
+  """
+    Checks if entry is None.
+    @ In, comment, string, a comment printed out if it fails
+    @ In, entry, object, to test if against None
+    @ In, update, bool, optional, if False then don't update results counter
+    @ Out, res, bool, True if None
+  """
+  res = entry is None
+  if update:
+    if res:
+      results["pass"] += 1
+    else:
+      print("checking answer",comment,'|','"{}" is not None!'.format(entry))
+      results["fail"] += 1
+
+def checkFails(comment, errstr, function, update=True, args=None, kwargs=None):
+  """
+    Checks if expected error occurs
+    @ In, comment, string, a comment printed out if it fails
+    @ In, errstr, str, expected fail message
+    @ In, function, method, method to run to test for failure
+    @ In, update, bool, optional, if False then don't update results counter
+    @ In, args, list, arguments to pass to function
+    @ In, kwargs, dict, keyword arguments to pass to function
+    @ Out, res, bool, True if failed as expected
+  """
+  print('Error testing ...')
+  if args is None:
+    args = []
+  if kwargs is None:
+    kwargs = {}
+  try:
+    function(*args,**kwargs)
+    res = False
+    msg = 'Function call did not error!'
+  except Exception as e:
+    res = checkSame('',e.args[0],errstr,update=False)
+    if not res:
+      msg = 'Unexpected error message.  \n    Received: "{}"\n    Expected: "{}"'.format(e.args[0],errstr)
+  if update:
+    if res:
+      results["pass"] += 1
+      print(' ... end Error testing (PASSED)')
+    else:
+      print("checking error",comment,'|',msg)
+      results["fail"] += 1
+      print(' ... end Error testing (FAILED)')
+  print('')
+  return res
+
+
+######################################
+#            CONSTRUCTION            #
+######################################
+def createRWDXML(targets, SignatureWindowLength, FeatureIndex, SampleType):
+  xml = xmlUtils.newNode('RWD', attrib={'target':','.join(targets)})
+  xml.append(xmlUtils.newNode('SignatureWindowLength', text=f'{SignatureWindowLength}'))
+  xml.append(xmlUtils.newNode('FeatureIndex', text=f'{FeatureIndex}'))
+  xml.append(xmlUtils.newNode('SampleType', text=f'{SampleType}'))
+  return xml
+
+def createFromXML(xml):
+  rwd = RWD.RWD()
+  inputSpec = rwd.getInputSpecification()()
+  inputSpec.parseNode(xml)
+  rwd.handleInput(inputSpec)
+  return rwd
+
+def createRWD(targets, SignatureWindowLength, FeatureIndex, SampleType):
+  xml = createRWDXML(targets, SignatureWindowLength, FeatureIndex, SampleType)
+  print('createRWDXML passed')
+  rwd = createFromXML(xml)
+  print('createFromXML passed')
+  return rwd
+
+'''
+def createRWDSignal(time_series, pivot, intercept=0, plot=False):
+  if plot:
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots()
+  signal = np.zeros(len(pivot)) + intercept
+
+  # moving average: random noise lag
+  for q, theta in enumerate(noise):
+    signal[q+1:] += theta * noise[:-(q+1)]
+  # autoregressive: signal lag
+  for t, time in enumerate(pivot):
+    for p, phi in enumerate(time_series):
+      if t > p:
+        signal[t] += phi * signal[t - p - 1]
+  if plot:
+
+    ax.plot(pivot, signal, 'g.-')
+    plt.show()
+  return signal
+'''
+
+###################
+#  Simple         #
+###################
+# generate signal
+targets = ['A'] #, 'B', 'C']
+pivot = np.linspace(0, 100, 1000)
+N = len(pivot)
+s = np.linspace(-10,10,1000)
+time_series = 3.5*s+s**2+10
+#noise = rng.random((1000,))*0.02
+#signalA, noise = createRWDSignal(time_series, noise, pivot, plot=plot)
+
+signals = np.zeros((len(pivot), 1))
+signals[:, 0] = time_series
+
+##########
+# Simplest reasonable case
+#
+rwd = createRWD(targets, 105, 3,0)
+settings = {'SignatureWindowLength':105, 'FeatureIndex': 3, 'SampleType' : 0}
+if 'SignatureWindowLength' not in settings:
+  print('SignatureWindowLength not in settings')
+settings = rwd.setDefaults(settings)
+params = rwd.characterize(signals, pivot, targets, settings)
+check = params['A']#['rwd']
+
+
+
+# code to generate answer
+SignatureWindowLength = 105
+history = np.copy(time_series)
+sampleLimit = len(history)-SignatureWindowLength
+WindowNumber = sampleLimit//4
+#print(sampleLimit)
+print('WindowNumber',WindowNumber)
+sampleIndex = np.random.randint(sampleLimit, size=WindowNumber)
+#print('sampleIndex', sampleIndex)
+BaseMatrix = np.zeros((SignatureWindowLength, WindowNumber))
+for i in range(WindowNumber):
+  WindowIndex = sampleIndex[i]
+  BaseMatrix[:,i] = np.copy(history[WindowIndex:WindowIndex+SignatureWindowLength])
+
+AllWindowNumber = len(history)-SignatureWindowLength+1
+SignatureMatrix = np.zeros((SignatureWindowLength, AllWindowNumber))
+
+for i in range(AllWindowNumber):
+  SignatureMatrix[:,i] = np.copy(history[i:i+SignatureWindowLength])
+
+BaseMatrix = np.copy(SignatureMatrix)
+U,S,V = LA.svd(BaseMatrix,full_matrices=False)
+assert np.allclose(BaseMatrix, np.dot(U, np.dot(np.diag(S), V)))
+
+
+F = U.T @ SignatureMatrix  
+
+okay_basis = U[:,0]
+okay_feature = F[0:3,0]
+######
+#print('SignatureMatrix ',SignatureMatrix.shape)
+#print(check[0][:,0].any()) #true
+##print(okay_basis)
+#print('len(check)',len(check))
+#print((check[0]).shape)
+#print((check[1]).shape)
+#print(len(check[0][:,0]))
+
+checkArray('Simple RWD Basis', okay_basis, check[0][:,0], float, tol=1e-3)
+checkArray('Simple RWD Features', okay_feature, check[1][0:3,0], float, tol=1e-3)
+
+
+
+checkTrue("RWD can characterize", rwd.canCharacterize())
+
+'''
+# predict
+np.random.seed(42) # forces MLE in statsmodels to be deterministic
+new = arma.generate(params, pivot, settings)[:, 0]
+
+# spot check a few values -> could we check full arrays?
+checkFloat('Simple generate 0', -1.0834098074509528, new[0], tol=1e-6)
+checkFloat('Simple generate 250', -3.947707011147049, new[250], tol=1e-6)
+checkFloat('Simple generate 500', -1.4304498185153571, new[500], tol=1e-6)
+checkFloat('Simple generate 999', -1.7825760423361088, new[999], tol=1e-6)
+# now do it again, but set the params how we want to
+params['A']['arma']['const'] = 0
+params['A']['arma']['AR'] = time_series
+params['A']['arma']['MA'] = noise
+params['A']['arma']['var'] = 1
+np.random.seed(42) # forces MLE in statsmodels to be deterministic
+new = arma.generate(params, pivot, settings)[:, 0]
+checkFloat('Simple picked 0', 2.3613260219896035, new[0], tol=1e-6)
+checkFloat('Simple picked 250', -1.4007530275511393, new[250], tol=1e-6)
+checkFloat('Simple picked 500', 0.7956991243820065, new[500], tol=1e-6)
+checkFloat('Simple picked 999', 0.7196164370698425, new[999], tol=1e-6)
+'''
+
+print(results)
+
+sys.exit(results["fail"])
+


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Add RWD for cybersecurity LDRD #1443


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

