### PR TITLE
Adding rllib to the dependencies

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -54,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray os="mac,linux" source="pip">1.6</ray>
-    <ray-rllib source="pip"/>1.6</ray-rllib>
+    <ray-rllib source="pip">1.6</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -38,6 +38,7 @@ Note all install methods after "main" take
     <xarray>0.16</xarray>
     <netcdf4>1.5</netcdf4>
     <matplotlib source='forge'>3.2</matplotlib>
+    <ray-rllib source='forge'>1.6.0</ray-rllib>
     <statsmodels/>
     <cloudpickle>1.6</cloudpickle>
     <tensorflow>2.0</tensorflow>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,7 +53,8 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray[rllib] source="pip">1.6</ray[rllib]>
+    <ray source="pip">1.6</ray>
+    <ray[rllib] source="pip"/>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -54,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray os="mac,linux" source="pip">1.3</ray>
-    <ray-rllib/>
+    <ray-rllib source="pip"/>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -54,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray os="mac,linux" source="pip">1.3</ray>
-    <ray-rllib source='forge'>1.3</ray-rllib>
+    <ray-rllib source='forge'/>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -54,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray source="pip">1.6</ray>
-    <ray[rllib] source="pip"/>
+    <ray[rllib] source="pip">1.6</ray[rllib]>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,7 +53,7 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray source="forge">1.6</ray>
+    <ray-core source="forge">1.6</ray-core>
     <ray-rllib source="forge" skip_check='True'>1.6</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,8 +53,7 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray os="mac,linux" source="pip">1.6</ray>
-    <ray-rllib source="pip">1.6</ray-rllib>
+    <ray[rllib] source="pip">1.6</ray[rllib]>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,9 +53,9 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray source="pip" skip_check='True'>1.3</ray>
-    <gym source="pip" skip_check='True'/>
-    <rllib source="pip" skip_check='True'/>
+    <ray source="pip" os="mac,linux">1.3</ray>
+    <gym source="pip" os="mac,linux" skip_check='True'/>
+    <rllib source="pip" os="mac,linux" skip_check='True'/>
     <!-- <ray-rllib source="forge" skip_check='True'>1.6</ray-rllib> -->
     <!-- <ray-rllib source="forge" skip_check='True'/> -->
     <!-- ray is not compatible with aioredis 2.0

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -38,7 +38,6 @@ Note all install methods after "main" take
     <xarray>0.16</xarray>
     <netcdf4>1.5</netcdf4>
     <matplotlib source='forge'>3.2</matplotlib>
-    <!-- <ray-rllib source='forge'>1.6.0</ray-rllib> -->
     <statsmodels/>
     <cloudpickle>1.6</cloudpickle>
     <tensorflow>2.0</tensorflow>
@@ -55,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray os="mac,linux" source="pip">1.3</ray>
-    <ray[rllib] source="pip">1.6.0</ray[rllib]>
+    <ray-rllib source='forge'>1.6</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,7 +53,7 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray-core source="forge">1.6</ray-core>
+    <ray-core source="forge" skip_check='True'>1.6</ray-core>
     <ray-rllib source="forge" skip_check='True'>1.6</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -54,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray source="pip">1.6</ray>
-    <ray[rllib] source="pip">1.6</ray[rllib]>
+    <ray-rllib source="forge">1.6</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,8 +53,8 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray source="pip">1.6</ray>
-    <ray-rllib source="forge">1.6</ray-rllib>
+    <ray source="forge">1.6</ray>
+    <ray-rllib source="forge" skip_check='True'>1.6</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -38,7 +38,7 @@ Note all install methods after "main" take
     <xarray>0.16</xarray>
     <netcdf4>1.5</netcdf4>
     <matplotlib source='forge'>3.2</matplotlib>
-    <ray-rllib source='forge'>1.6.0</ray-rllib>
+    <!-- <ray-rllib source='forge'>1.6.0</ray-rllib> -->
     <statsmodels/>
     <cloudpickle>1.6</cloudpickle>
     <tensorflow>2.0</tensorflow>
@@ -55,6 +55,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray os="mac,linux" source="pip">1.3</ray>
+    <ray[rllib] source="pip">1.6.0</ray[rllib]>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -54,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray os="mac,linux" source="pip">1.3</ray>
-    <ray-rllib source='forge'>1.6</ray-rllib>
+    <ray-rllib source='forge'>1.3</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -54,7 +54,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <ray os="mac,linux" source="pip">1.3</ray>
-    <ray-rllib source='forge'/>
+    <ray-rllib/>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,8 +53,8 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray os="mac,linux" source="pip">1.3</ray>
-    <ray-rllib source="pip"/>
+    <ray os="mac,linux" source="pip">1.6</ray>
+    <ray-rllib source="pip"/>1.6</ray-rllib>
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,8 +53,11 @@ Note all install methods after "main" take
     <pyside2 source='forge'/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray-core source="forge" skip_check='True'>1.6</ray-core>
-    <ray-rllib source="forge" skip_check='True'>1.6</ray-rllib>
+    <ray source="pip" skip_check='True'>1.3</ray>
+    <gym source="pip" skip_check='True'/>
+    <rllib source="pip" skip_check='True'/>
+    <!-- <ray-rllib source="forge" skip_check='True'>1.6</ray-rllib> -->
+    <!-- <ray-rllib source="forge" skip_check='True'/> -->
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
     <aioredis os="mac,linux" source="pip">1.3</aioredis>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1659

##### What are the significant changes in functionality due to this change request?
Raven can interface with ray-rllib to be able to tackle reinforcement learning problems

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

