### PR TITLE
Adding Genetic Algorithm optimization functions to analytic_tests.tex

### DIFF
--- a/doc/tests/analytic_tests.tex
+++ b/doc/tests/analytic_tests.tex
@@ -249,6 +249,7 @@ showstringspaces=false            %
 \\Congjian Wang
 \\Diego Mandelli
 \\Joshua Cogliati
+\\Mohammad G. Abdo
 \\Cristian Rabiti
 }
 
@@ -262,7 +263,7 @@ showstringspaces=false            %
 %
 \SANDnum{INL/EXT-19-53843}
 \SANDprintDate{\today}
-\SANDauthor{Andrea Alfonsi, Paul W. Talbot, Diego Mandelli, Congjian Wang, Joshua Cogliati, Cristian Rabiti}
+\SANDauthor{Andrea Alfonsi, Paul W. Talbot, Diego Mandelli, Congjian Wang, Joshua Cogliati, Mohammad G. Abdo, Cristian Rabiti}
 \SANDreleaseType{Revision 0}
 
 

--- a/doc/tests/optimization_functions.tex
+++ b/doc/tests/optimization_functions.tex
@@ -130,14 +130,14 @@ which is usually outside the domain of exploration.
   \item Global Minimum: $f(\{1\}_N) = 0$
 \end{itemize}
 
-\subsubsection{Rosenbrock with cubic and linear constraints}
-Here the Rosenbrock is another two dimensional highly nonlinear function. The global maximum is on the intersection of the two constraints which renders this problem challenging for optimizers that uses random decisions for next points such as simulated annealing and genetic algorithms.
-\begin{itemize}
-	\item Objective Function: $f(x,y) = (1-x^2) + 100(y-x^2)^2$
-	\item Domain: $-1.5 \leq x \leq 1.5$ and $ -0.5 \leq y \leq 2.5$
-	\item Constraints: $(x-1)^3 - y +1 \leq 0$ and $x+y-2 \leq 0$
-	\item Global Maximum: $f(1.0,1.0) = 0$
-\end{itemize}
+% \subsubsection{Rosenbrock with cubic and linear constraints}
+% Here the Rosenbrock is another two dimensional highly nonlinear function. The global maximum is on the intersection of the two constraints which renders this problem challenging for optimizers that uses random decisions for next points such as simulated annealing and genetic algorithms.
+% \begin{itemize}
+% 	\item Objective Function: $f(x,y) = (1-x^2) + 100(y-x^2)^2$
+% 	\item Domain: $-1.5 \leq x \leq 1.5$ and $ -0.5 \leq y \leq 2.5$
+% 	\item Constraints: $(x-1)^3 - y +1 \leq 0$ and $x+y-2 \leq 0$
+% 	\item Global Maximum: $f(1.0,1.0) = 0$
+% \end{itemize}
 
 \subsubsection{Rosenbrock with a disk constraint}
 This is the same 2D function, but constrained to a disk. This constraint makes it a little easier than the previous function.

--- a/doc/tests/optimization_functions.tex
+++ b/doc/tests/optimization_functions.tex
@@ -9,7 +9,7 @@ Beale's function has a two-dimensional input space and a single global/local min
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 
 \begin{itemize}
-  \item Function: $f(x,y) = (1.5-x+xy)^2+(2.25-x+xy^2)^2+(2.625-x+xy^3)^2$
+  \item Objective Function: $f(x,y) = (1.5-x+xy)^2+(2.25-x+xy^2)^2+(2.625-x+xy^3)^2$
   \item Domain: $-4.5 \leq x,y \leq 4.5$
   \item Global Minimum: $f(3,0.5)=0$
 \end{itemize}
@@ -21,7 +21,7 @@ exists.  For four to seven inputs, there is one local minimum and one global max
 See \url{https://en.wikipedia.org/wiki/Rosenbrock_function}.
 
 \begin{itemize}
-  \item Function: $f(\vec x) = \sum_{i=1}^{n-1}\left[100\left(x_{i+1}-x_i^2\right)^2+\left(x_i-1)^2\right) \right]$
+  \item Objective Function: $f(\vec x) = \sum_{i=1}^{n-1}\left[100\left(x_{i+1}-x_i^2\right)^2+\left(x_i-1)^2\right) \right]$
   \item Domain: $ -\infty \leq x_i \leq \infty \hspace{10pt} \forall \hspace{10pt} 1\leq i \leq n$
   \item Global Minimum: $f(1,1,\cdots,1,1)=0$
   \item Local minimum ($n\geq4$): near $f(-1,1,\cdots,1)$
@@ -33,7 +33,7 @@ The Goldstein-Price function is a two-dimensional input function with a single g
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 
 \begin{itemize}
-  \item Function:
+  \item Objective Function:
     \begin{align}
       f(x,y) =& \left[1+(x+y+1)^2\left(19-14x+3x^2-14y+6xy+3y^2\right)\right] \\ \nonumber
         & \cdot\left[30+(2x-3y)^2(18-32x+12x^2+48y-36xy+27y^2)\right]
@@ -47,7 +47,7 @@ The McCormick function is a two-dimensional input function with a single global 
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 
 \begin{itemize}
-  \item Function: $f(x,y) = \sin(x+y) + (x-y)^2 - 1.5x + 2.5y + 1$
+  \item Objective Function: $f(x,y) = \sin(x+y) + (x-y)^2 - 1.5x + 2.5y + 1$
   \item Domain: $-1.5 \leq x \leq 4$, $-3 \leq y \leq 4$
   \item Global Minimum: $f(-0.54719,-1.54719) = -1.9133$
 \end{itemize}
@@ -56,7 +56,7 @@ See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 The two-dimensional canyon offers a low region surrounded by higher walls.
 
 \begin{itemize}
-  \item Function: $f(x,y) = xy\cos(x+y)$
+  \item Objective Function: $f(x,y) = xy\cos(x+y)$
   \item Domain: $0 \leq x,y \leq \pi$
   \item Global Minimum: $f(1.8218,1.8218)=-2.90946$
 \end{itemize}
@@ -65,7 +65,7 @@ The two-dimensional canyon offers a low region surrounded by higher walls.
 The stochastic three-dimensional diagonal valley offers a low region surrounded by higher walls.
 
 \begin{itemize}
-  \item Function: $f(x,y,stoch) = stoch * R + (x+0.5)^2 + (y-0.5)^2 + \sqrt{(x - \cfrac{x}{x-y})^2 + (y - \cfrac{y}{y-x})*^2} * 10, while R\sim ([-0.1,0.1])$
+  \item Objective Function: $f(x,y,stoch) = stoch * R + (x+0.5)^2 + (y-0.5)^2 + \sqrt{(x - \cfrac{x}{x-y})^2 + (y - \cfrac{y}{y-x})*^2} * 10, while R\sim ([-0.1,0.1])$
   \item Domain: $0 \leq x,y \leq 1$
   \item Global Minimum if $stoch =0$: $f(-0.5,0.5)=0$
 \end{itemize}
@@ -74,7 +74,7 @@ The stochastic three-dimensional diagonal valley offers a low region surrounded 
 The parabolic valley is dominated by distance from $x=y$ but secondarily motivated by $x+y$.
 
 \begin{itemize}
-  \item Function: $f(x,y) = 100 (x - y)^2 + (x + y)^2$
+  \item Objective Function: $f(x,y) = 100 (x - y)^2 + (x + y)^2$
   \item Domain: $-1 \leq x,y \leq 1$
   \item Global Minimum: $f(0,0)=0$
 \end{itemize}
@@ -83,7 +83,7 @@ The parabolic valley is dominated by distance from $x=y$ but secondarily motivat
 The elliptic paraboloid is a two-dimensional function with a single global minimum.
 
 \begin{itemize}
-  \item Function: $f(x,y) = 10(x+0.5)^2 + 10(y-0.5)^2 $
+  \item Objective Function: $f(x,y) = 10(x+0.5)^2 + 10(y-0.5)^2 $
   \item Domain: $-2 \leq x \leq 2$, $-2 \leq y \leq 2$
   \item Global Minimum: $f(-0.5,0.5) = 0$
 \end{itemize}
@@ -94,11 +94,19 @@ has a reduced magnitude as time increases. As such, the minimum is always found 
 $y$ values at low $t$ being more impactful than at later $t$, and $x$ as impactful as $y(t=0)$.
 
 \begin{itemize}
-  \item Function: $f(x,y,t) = x^2 + \sum_{t} (t-y)^2 \exp{-t}$
+  \item Objective Function: $f(x,y,t) = x^2 + \sum_{t} (t-y)^2 \exp{-t}$
   \item Domain: $-10 \leq x,y,t \leq 10$
   \item Global Minimum: $f(0,y=t,t) = 0$
 \end{itemize}
 
+\subsubsection{Eggholder}
+This is a 2D function with a plethora of local minima and maxima (i.e., non-convex). It is challenging for most optimizers to find the global minimum for such a function. Metaheuristic methods are prefered for their ability to avoid getting stuck in local optima.
+
+\begin{itemize}
+	\item Objective Function: $f(x,y,) =-(y+47) \sin(\sqrt{|\frac{x}{2}+(y+47)|}) - x\sin(\sqrt{|x - (y+47)|})$
+	\item Domain: $-512 \leq x,y \leq 512$
+	\item Global Minimum: $f(x=512, y=404.2319) = -959.6407$
+\end{itemize}
 
 \subsection{Constrained}
 \subsubsection{Mishra's Bird Function}
@@ -107,7 +115,7 @@ minimum.
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 
 \begin{itemize}
-  \item Function: $f(x,y) = \sin(y)\exp[1-\cos(x)]^2 + \cos(x)\exp[1-\sin(y)]^2 + (x-y)^2$
+  \item Objective Function: $f(x,y) = \sin(y)\exp[1-\cos(x)]^2 + \cos(x)\exp[1-\sin(y)]^2 + (x-y)^2$
   \item Constraint: $(x+5)^2 + (y+5)^2 < 25$
   \item Domain: $-10 \leq x \leq 0$, $-6.5 \leq y \leq 0$
   \item Global Minimum: $f(-3.1302468, -1.5821422) = -106.7645367$
@@ -117,7 +125,43 @@ See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 This trivial linear problem extends to arbitrary dimension and has optimal points at infinities,
 which is usually outside the domain of exploration.
 \begin{itemize}
-  \item Function: $f(\vec x) = 1 - \frac{1}{N}\sum_{x_i\in \vec x} x_i$
+  \item Objective Function: $f(\vec x) = 1 - \frac{1}{N}\sum_{x_i\in \vec x} x_i$
   \item Domain: $0 \leq x_i \leq 1 \forall x_i \in \vec x$
   \item Global Minimum: $f(\{1\}_N) = 0$
+\end{itemize}
+
+\subsubsection{Rosenbrock with cubic and linear constraints}
+Here the Rosenbrock is another two dimensional highly nonlinear function. The global maximum is on the intersection of the two constraints which renders this problem challenging for optimizers that uses random decisions for next points such as simulated annealing and genetic algorithms.
+\begin{itemize}
+	\item Objective Function: $f(x,y) = (1-x^2) + 100(y-x^2)^2$
+	\item Domain: $-1.5 \leq x \leq 1.5$ and $ -0.5 \leq y \leq 2.5$
+	\item Constraints: $(x-1)^3 - y +1 \leq 0$ and $x+y-2 \leq 0$
+	\item Global Maximum: $f(1.0,1.0) = 0$
+\end{itemize}
+
+\subsubsection{Rosenbrock with a disk constraint}
+This is the same 2D function, but constrained to a disk. This constraint makes it a little easier than the previous function.
+\begin{itemize}
+	\item Objective Function: $f(x,y) = (1-x^2) + 100(y-x^2)^2$
+	\item Domain: $-1.5 \leq x,y \leq 1.5$
+	\item Constraint: $x^2 + y^2 \leq 2$
+	\item Global Maximum: $f(1.0,1.0) = 0$
+\end{itemize}
+
+\subsubsection{Townsend}
+It is a highly nonlinear non convex function with multiple minima and maxima. The constraint is highly nonlinear and the y-domain is asymmetric.
+\begin{itemize}
+	\item Objective Function: $f(x,y) = -\left[\cos((x-0.1)y)\right]^2-x\sin(3x+y)$
+	\item Domain: $-2.25 \leq x \leq 2.25$ and $-2.5 \leq y \leq 1.75$
+	\item Constraint: $x^2 + y^2 \leq \left[2\cos(t)-\frac{1}{2}\cos(2t)-\frac{1}{4}\cos(3t) - \frac{1}{8}cos(4t) \right]^2+\left[2\sin(t)\right]^2 $;  \[ \text{where: } t=\arctan2(x,y) \]
+	\item Global Minimum: $f(2.0052938,1.1944509) = -2.0239884$
+\end{itemize}
+
+\subsubsection{Simionescu}
+An exteremly simple two dimensional nonlinear function formed from 45-degrees hyperbolas. Subjected to highly nonlinear constraint.
+\begin{itemize}
+	\item Objective Function: $f(x,y) = 0.1xy$
+	\item Domain: $-1.25 \leq x,y \leq 1.25$
+	\item Constraint: $x^2 + y^2 \leq \left[r_{\Gamma}+r_S\cos\left(n \arctan(\frac{x}{y})\right)\right]^2 $; \[ \text{where: } r_{\Gamma}=1, r_S = 0.2, \text{and } n=8 \]
+	\item Global Minimum: $f(\pm 0.84852813,\mp0.84852813) = -0.072$
 \end{itemize}

--- a/doc/tests/optimization_functions.tex
+++ b/doc/tests/optimization_functions.tex
@@ -1,10 +1,10 @@
 \section{Optimization Functions}
 
 The functions in this section are models with analytic optimal points.
-
-\subsection{General}
-
-\subsubsection{Beale's Function}
+\setcounter{tocdepth}{4}
+\subsection{Continuous}
+\subsubsection{Unconstrained}
+\paragraph{Beale's Function}
 Beale's function has a two-dimensional input space and a single global/local minimum.
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 
@@ -15,7 +15,7 @@ See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 \end{itemize}
 
 
-\subsubsection{Rosenbrock Function}
+\paragraph{Rosenbrock Function}
 The Rosenbrock function can take a varying number of inputs.  For up to three inputs, a single global minimum
 exists.  For four to seven inputs, there is one local minimum and one global maximum.
 See \url{https://en.wikipedia.org/wiki/Rosenbrock_function}.
@@ -28,7 +28,7 @@ See \url{https://en.wikipedia.org/wiki/Rosenbrock_function}.
 \end{itemize}
 
 
-\subsubsection{Goldstein-Price Function}
+\paragraph{Goldstein-Price Function}
 The Goldstein-Price function is a two-dimensional input function with a single global minimum.
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 
@@ -42,7 +42,7 @@ See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
   \item Global Minimum: $f(0,-1)=3$
 \end{itemize}
 
-\subsubsection{McCormick Function}
+\paragraph{McCormick Function}
 The McCormick function is a two-dimensional input function with a single global minimum.
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
 
@@ -52,7 +52,7 @@ See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
   \item Global Minimum: $f(-0.54719,-1.54719) = -1.9133$
 \end{itemize}
 
-\subsubsection{2D Canyon}
+\paragraph{2D Canyon}
 The two-dimensional canyon offers a low region surrounded by higher walls.
 
 \begin{itemize}
@@ -61,7 +61,7 @@ The two-dimensional canyon offers a low region surrounded by higher walls.
   \item Global Minimum: $f(1.8218,1.8218)=-2.90946$
 \end{itemize}
 
-\subsubsection{Stochastic Diagonal Valley}
+\paragraph{Stochastic Diagonal Valley}
 The stochastic three-dimensional diagonal valley offers a low region surrounded by higher walls.
 
 \begin{itemize}
@@ -70,7 +70,7 @@ The stochastic three-dimensional diagonal valley offers a low region surrounded 
   \item Global Minimum if $stoch =0$: $f(-0.5,0.5)=0$
 \end{itemize}
 
-\subsubsection{Parabolic Valley}
+\paragraph{Parabolic Valley}
 The parabolic valley is dominated by distance from $x=y$ but secondarily motivated by $x+y$.
 
 \begin{itemize}
@@ -79,7 +79,7 @@ The parabolic valley is dominated by distance from $x=y$ but secondarily motivat
   \item Global Minimum: $f(0,0)=0$
 \end{itemize}
 
-\subsubsection{Paraboloid}
+\paragraph{Paraboloid}
 The elliptic paraboloid is a two-dimensional function with a single global minimum.
 
 \begin{itemize}
@@ -88,7 +88,7 @@ The elliptic paraboloid is a two-dimensional function with a single global minim
   \item Global Minimum: $f(-0.5,0.5) = 0$
 \end{itemize}
 
-\subsubsection{Time-Parabola}
+\paragraph{Time-Parabola}
 This model features the sum of a parabola in both $x$ and $y$; however, the parabola in $y$ moves in time and
 has a reduced magnitude as time increases. As such, the minimum is always found at $x=0$ and at $(t-y)=0$, with
 $y$ values at low $t$ being more impactful than at later $t$, and $x$ as impactful as $y(t=0)$.
@@ -99,7 +99,7 @@ $y$ values at low $t$ being more impactful than at later $t$, and $x$ as impactf
   \item Global Minimum: $f(0,y=t,t) = 0$
 \end{itemize}
 
-\subsubsection{Eggholder}
+\paragraph{Eggholder}
 This is a 2D function with a plethora of local minima and maxima (i.e., non-convex). It is challenging for most optimizers to find the global minimum for such a function. Metaheuristic methods are prefered for their ability to avoid getting stuck in local optima.
 
 \begin{itemize}
@@ -108,8 +108,8 @@ This is a 2D function with a plethora of local minima and maxima (i.e., non-conv
 	\item Global Minimum: $f(x=512, y=404.2319) = -959.6407$
 \end{itemize}
 
-\subsection{Constrained}
-\subsubsection{Mishra's Bird Function}
+\subsubsection{Constrained}
+\paragraph{Mishra's Bird Function}
 The Mishra bird function offers a constrained problem with multiple peaks, local minima, and one steep global
 minimum.
 See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
@@ -121,7 +121,7 @@ See \url{https://en.wikipedia.org/wiki/Test_functions_for_optimization}.
   \item Global Minimum: $f(-3.1302468, -1.5821422) = -106.7645367$
 \end{itemize}
 
-\subsubsection{ND Slant}
+\paragraph{ND Slant}
 This trivial linear problem extends to arbitrary dimension and has optimal points at infinities,
 which is usually outside the domain of exploration.
 \begin{itemize}
@@ -130,7 +130,7 @@ which is usually outside the domain of exploration.
   \item Global Minimum: $f(\{1\}_N) = 0$
 \end{itemize}
 
-% \subsubsection{Rosenbrock with cubic and linear constraints}
+% \paragraph{Rosenbrock with cubic and linear constraints}
 % Here the Rosenbrock is another two dimensional highly nonlinear function. The global maximum is on the intersection of the two constraints which renders this problem challenging for optimizers that uses random decisions for next points such as simulated annealing and genetic algorithms.
 % \begin{itemize}
 % 	\item Objective Function: $f(x,y) = (1-x^2) + 100(y-x^2)^2$
@@ -139,7 +139,7 @@ which is usually outside the domain of exploration.
 % 	\item Global Maximum: $f(1.0,1.0) = 0$
 % \end{itemize}
 
-\subsubsection{Rosenbrock with a disk constraint}
+\paragraph{Rosenbrock with a disk constraint}
 This is the same 2D function, but constrained to a disk. This constraint makes it a little easier than the previous function.
 \begin{itemize}
 	\item Objective Function: $f(x,y) = (1-x^2) + 100(y-x^2)^2$
@@ -148,7 +148,7 @@ This is the same 2D function, but constrained to a disk. This constraint makes i
 	\item Global Maximum: $f(1.0,1.0) = 0$
 \end{itemize}
 
-\subsubsection{Townsend}
+\paragraph{Townsend}
 It is a highly nonlinear non convex function with multiple minima and maxima. The constraint is highly nonlinear and the y-domain is asymmetric.
 \begin{itemize}
 	\item Objective Function: $f(x,y) = -\left[\cos((x-0.1)y)\right]^2-x\sin(3x+y)$
@@ -157,11 +157,63 @@ It is a highly nonlinear non convex function with multiple minima and maxima. Th
 	\item Global Minimum: $f(2.0052938,1.1944509) = -2.0239884$
 \end{itemize}
 
-\subsubsection{Simionescu}
+\paragraph{Simionescu}
 An exteremly simple two dimensional nonlinear function formed from 45-degrees hyperbolas. Subjected to highly nonlinear constraint.
 \begin{itemize}
 	\item Objective Function: $f(x,y) = 0.1xy$
 	\item Domain: $-1.25 \leq x,y \leq 1.25$
 	\item Constraint: $x^2 + y^2 \leq \left[r_{\Gamma}+r_S\cos\left(n \arctan(\frac{x}{y})\right)\right]^2 $; \[ \text{where: } r_{\Gamma}=1, r_S = 0.2, \text{and } n=8 \]
 	\item Global Minimum: $f(\pm 0.84852813,\mp0.84852813) = -0.072$
+\end{itemize}
+\subsection{Discrete}
+\subsubsection{Unconstrained}
+\paragraph{Locally weighted sum without replacement}
+This function computes the sum of the input vector components weighted by the location in the vector (i.e., component/dimension number). The input vector is sampled from a disrete uniform distribution of intergers between an upper bound $ub$, and a lower bound $lb$ without replacement (i.e., if an integer is selected for one variable (a component in the $n$-th dimensional input vector it cannot be selected for the remaining components)).
+\begin{itemize}
+	\item Objective Function: $f(\vec{x}) = \sum_{i=1}^{G}i \times x_i$; where $G$ is the number of variables (aka dimension of search/design space or number of Genes in Genetic algorithms) 
+	\item Domain: $x_i \sim \mathcal{U}^{\text{Discrete int}}_{\text{w/o replacement}} (lb,ub)$
+	\item Global Minimum: $f(\vec{x}_{opt}|x_i = lb + G - i) = \sum_{i=1}^{G} (lb + G -i) \times i$
+	For instance, if $lb =1$, $ub=20$ , $G=6$, $\vec{x}_{opt} = [\vec{x}]_i | x_i = lb + G - i = 1+6-i = \begin{bmatrix}
+	6 & 5 & \dots & 1 \end{bmatrix}$ and the minimum will be $f_{min} = \sum_{i=1}^{G} (1 + 6 -i) \times i = \frac{G(G+1)}{6}[3lb+G-1] = 56$
+	\item Global Maximum: $f(\vec{x}_{opt}|x_i = ub - G + i) = \sum_{i=1}^{G} (ub - G +i) \times i$
+	For instance, if $lb =1$, $ub=20$ , $G=6$, $\vec{x}_{opt} = [\vec{x}]_i | x_i = ub - G + i = 20-6+i = \begin{bmatrix}
+	15 & 16 & \dots & 20 \end{bmatrix}$ and the maximum will be $f_{max} = \sum_{i=1}^{G} (20 - 6 +i) \times i = \frac{G(G+1)}{6}[3ub-G+1] = 385$
+\end{itemize}
+
+\paragraph{Locally weighted sum with replacement}
+This function computes the sum of the input vector components weighted by the location in the vector (i.e., component/dimension number). The input vector is sampled from a disrete uniform distribution of intergers between an upper bound $ub$, and a lower bound $lb$ with replacement (i.e., if an integer is selected for one variable, it can be selected again for any or all other variables).
+\begin{itemize}
+	\item Objective Function: $f(\vec{x}) = \sum_{i=1}^{G}i \times x_i$; where $G$ is the number of variables (aka dimension of search/design space or number of Genes in Genetic algorithms) 
+	\item Domain: $x_i \sim \mathcal{U}^{\text{Discrete int}}_{\text{w/ replacement}} (lb,ub)$
+	\item Global Minimum: $f(\vec{x}_{opt}|x_i = lb) = \sum_{i=1}^{G} lb \times i$
+	For instance, if $lb =1$, $ub=20$ , $G=6$, $\vec{x}_{opt} = [\vec{x}]_i | x_i = lb = 1 = \begin{bmatrix}
+	1 & 1 & \dots & 1 \end{bmatrix}$ and the minimum will be $f_{min} = \sum_{i=1}^{G} i = \frac{G(G+1)}{2}[lb] = 21$
+	\item Global Maximum: $f(\vec{x}_{opt}|x_i = ub) = \sum_{i=1}^{G} ub \times i$
+	For instance, if $lb =1$, $ub=20$ , $G=6$, $\vec{x}_{opt} = [\vec{x}]_i | x_i = ub = 20 = \begin{bmatrix}
+	20 & 20 & \dots & 20 \end{bmatrix}$ and the maximum will be $f_{max} = \sum_{i=1}^{G} 20 \times i = \frac{G(G+1)}{2}[ub] = 420$
+\end{itemize}
+
+\subsubsection{Constrained}
+\paragraph{Locally weighted sum with replacement linearly constrained}
+It uses the same function but adds a constraint.
+\begin{itemize}
+	\item Objective Function: $f(\vec{x}) = \sum_{i=1}^{G}i \times x_i$; where $G$ is the number of variables (aka dimension of search/design space or number of Genes in Genetic algorithms) 
+	\item Domain: $x_i \sim \mathcal{U}^{\text{Discrete int}}_{\text{w/o replacement}} (lb,ub)$
+	\item constraint $x_2 \leq 8.5 - 0.5 * x_1$
+	\item Global Minimum if $lb = 1, ub = 6, G =3$: $f(\vec{x}_{opt} = \begin{bmatrix}
+	1 & 1 & 1 \end{bmatrix}) = 6.0$
+	\item Global Maximum if $lb = 1, ub = 6, G =3$: $f(\vec{x}_{opt} = \begin{bmatrix}
+	6 & 5 & 6 \end{bmatrix} = 34.0$
+\end{itemize}
+
+\paragraph{Locally weighted sum with replacement sphere constrained}
+It uses the same function but adds a constraint.
+\begin{itemize}
+	\item Objective Function: $f(\vec{x}) = \sum_{i=1}^{G}i \times x_i$; where $G$ is the number of variables (aka dimension of search/design space or number of Genes in Genetic algorithms) 
+	\item Domain: $x_i \sim \mathcal{U}^{\text{Discrete int}}_{\text{w/o replacement}} (lb,ub)$
+	\item constraint $x^{2}_{1} + x^{2}_{2} \leq 72$
+	\item Global Minimum if $lb = 1, ub = 6, G =3$: $f(\vec{x}_{opt} = \begin{bmatrix}
+1 & 1 & 1 \end{bmatrix})= 6.0$
+\item Global Maximum if $lb = 1, ub = 6, G =3$: $f(\vec{x}_{opt} = \begin{bmatrix}
+6 & 5 & 6 \end{bmatrix} = 34.0$
 \end{itemize}

--- a/framework/Optimizers/GeneticAlgorithm.py
+++ b/framework/Optimizers/GeneticAlgorithm.py
@@ -141,10 +141,8 @@ class GeneticAlgorithm(RavenSampled):
         descr=r"""A node containing the criterion based on which the parents are selected. This can be a
                   fitness proportional selection such as:
                   a. \textbf{\textit{rouletteWheel}},
-                  b. \textbf{\textit{stochasticUniversalSampling}},
-                  c. \textbf{\textit{Tournament}},
-                  d. \textbf{\textit{Rank}}, or
-                  e. \textbf{\textit{randomSelection}}""")
+                  b. \textbf{\textit{tournamentSelection}},
+                  c. \textbf{\textit{rankSelection}}, or""")
     GAparams.addSub(parentSelection)
 
     # Reproduction
@@ -159,11 +157,9 @@ class GeneticAlgorithm(RavenSampled):
         contentType=InputTypes.StringType,
         printPriority=108,
         descr=r"""a subnode containing the implemented crossover mechanisms.
-                  This includes: a.    One Point Crossover,
-                                 b.    MultiPoint Crossover,
-                                 c.    Uniform Crossover,
-                                 d.    Whole Arithmetic Recombination, or
-                                 e.    Davis’ Order Crossover.""")
+                  This includes: a.    onePointCrossover,
+                                 b.    twoPointsCrossover,
+                                 c.    uniformCrossover.""")
     crossover.addParam("type", InputTypes.StringType, True,
                        descr="type of crossover operation to be used (e.g., OnePoint, MultiPoint, or Uniform)")
     crossoverPoint = InputData.parameterInputFactory('points', strictMode=True,
@@ -182,11 +178,10 @@ class GeneticAlgorithm(RavenSampled):
         contentType=InputTypes.StringType,
         printPriority=108,
         descr=r"""a subnode containing the implemented mutation mechanisms.
-                  This includes: a.    Bit Flip,
-                                 b.    Random Resetting,
-                                 c.    Swap,
-                                 d.    Scramble, or
-                                 e.    Inversion.""")
+                  This includes: a.    bitFlipMutation,
+                                 b.    swapMutation,
+                                 c.    scrambleMutation, or
+                                 d.    inversionMutation.""")
     mutation.addParam("type", InputTypes.StringType, True,
                       descr="type of mutation operation to be used (e.g., bit, swap, or scramble)")
     mutationLocs = InputData.parameterInputFactory('locs', strictMode=True,


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1669

##### What are the significant changes in functionality due to this change request?
The optimization benchmark functions used in the Genetic algorithms will be documented

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

