### PR TITLE
ClearRunDir must be set to False if interfaceCheck is activated

### DIFF
--- a/framework/Steps/Step.py
+++ b/framework/Steps/Step.py
@@ -22,6 +22,7 @@
 
 #External Modules------------------------------------------------------------------------------------
 import abc
+import os
 #External Modules End--------------------------------------------------------------------------------
 
 #Internal Modules------------------------------------------------------------------------------------
@@ -164,7 +165,10 @@ class Step(utils.metaclass_insert(abc.ABCMeta, BaseEntity, InputDataUser)):
           self.raiseAnError(IOError,printString.format(self.type,self.name,self.initSeed,'re-seeding'))
     if 'sleepTime' in paramInput.parameterValues:
       self.sleepTime = paramInput.parameterValues['sleepTime']
-    self._clearRunDir = paramInput.parameterValues.get('clearRunDir', True)
+    if os.environ['RAVENinterfaceCheck'] == 'True':
+      self._clearRunDir = False
+    else:
+      self._clearRunDir = paramInput.parameterValues.get('clearRunDir', True)
     for child in paramInput.subparts:
       classType = child.parameterValues['class']
       classSubType = child.parameterValues['type']

--- a/tests/framework/CodeInterfaceTests/RELAP5/test_relap5_code_interface.xml
+++ b/tests/framework/CodeInterfaceTests/RELAP5/test_relap5_code_interface.xml
@@ -19,6 +19,7 @@
       <revision author="alfoa" date="2018-10-01">This is a requirement test now. Req. R-SI-1</revision>
       <revision author="alfoa" date="2019-12-05">Modified to check we can handle multiple words in the same card.</revision>
       <revision author="alfoa" date="2020-10-31">Added csv xml node in the Code block for showing how to use it.</revision>
+      <revision author="alfoa" date="2021-10-21">Removed clearRunDir flag since in case of interfaceCheck this is set to False automatically (see issue #1688)</revision>
     </revisions>
     <requirements>R-SI-1</requirements>
   </TestInfo>
@@ -115,7 +116,7 @@
   </Samplers>
 
   <Steps>
-    <MultiRun name="testDummyStep" re-seeding="1" clearRunDir="False">
+    <MultiRun name="testDummyStep" re-seeding="1">
       <Input class="Files" type="">snc01.i</Input>
       <Input class="Files" type="">tpfh2o</Input>
       <Model class="Models" type="Code">MyRELAP</Model>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1688

##### What are the significant changes in functionality due to this change request?
This is using the same functionality is used in the CodeInterfaceBase class (environment variable) to decide
if the **clearRunDir** must be set to False automatically

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

