### PR TITLE
Fix typo due to YAML parsing error

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect-report.yml
+++ b/.github/ISSUE_TEMPLATE/defect-report.yml
@@ -28,14 +28,14 @@ body:
     id: steps-to-reproduce
     attributes:
       label: Steps to Reproduce
-      description: Describe how to reproduce
+      description: Describe how to reproduce the defect.
     validations:
       required: true
   - type: textarea
     id: expected-behavior
     attributes:
       label: Expected Behavior
-      description: A clear and concise description of what you expected to happen
+      description: A clear and concise description of what you expected to happen.
     validations:
       required: true
   - type: textarea
@@ -65,9 +65,9 @@ body:
     validations:
       required: false
   - type: dropdown
-    id: which-os
+    id: which-package-manager
     attributes:
-      label: dependency-manager
+      label: Dependency Manager
       description: Which Dependency Manager are you using?
       options:
         - PIP
@@ -77,22 +77,22 @@ body:
   - type: checkboxes
     id: issue-review
     attributes:
-      label: For Change Control Board: Issue Review
-      description: This review should occur before any development is performed as a response to this issue.
+      label: "For Change Control Board: Issue Review"
+      description: "This review should occur before any development is performed as a response to this issue."
       options:
-        - label: Is it tagged with a type: defect or task?
-        - label: Is it tagged with a priority: critical, normal or minor?
-        - label: If it will impact requirements or requirements tests, is it tagged with requirements?
-        - label: If it is a defect, can it cause wrong results for users? If so an email needs to be sent to the users.
-        - label: Is a rationale provided? (Such as explaining why the improvement is needed or why current code is wrong.)
+        - label: "Is it tagged with a type: defect or task?"
+        - label: "Is it tagged with a priority: critical, normal or minor?"
+        - label: "If it will impact requirements or requirements tests, is it tagged with requirements?"
+        - label: "If it is a defect, can it cause wrong results for users? If so an email needs to be sent to the users."
+        - label: "Is a rationale provided? (Such as explaining why the improvement is needed or why current code is wrong.)"
   - type: checkboxes
     id: issue-closure
     attributes:
-      label: For Change Control Board: Issue Closure
-      description: This review should occur when the issue is imminently going to be closed.
+      label: "For Change Control Board: Issue Closure"
+      description: "This review should occur when the issue is imminently going to be closed."
       options:
-        - label: If the issue is a defect, is the defect fixed?
-        - label: If the issue is a defect, is the defect tested for in the regression test system?  (If not explain why not.)
-        - label: If the issue can impact users, has an email to the users group been written (the email should specify if the defect impacts stable or master)?
-        - label: If the issue is a defect, does it impact the latest release branch? If yes, is there any issue tagged with release (create if needed)?
-        - label: If the issue is being closed without a pull request, has an explanation of why it is being closed been provided?
+        - label: "If the issue is a defect, is the defect fixed?"
+        - label: "If the issue is a defect, is the defect tested for in the regression test system?  (If not explain why not.)"
+        - label: "If the issue can impact users, has an email to the users group been written (the email should specify if the defect impacts stable or master)?"
+        - label: "If the issue is a defect, does it impact the latest release branch? If yes, is there any issue tagged with release (create if needed)?"
+        - label: "If the issue is being closed without a pull request, has an explanation of why it is being closed been provided?"


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Closes #1696 again


##### What are the significant changes in functionality due to this change request?

There were a few typos and parsing problems that weren't visible before. They should all be fixed now. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

