### PR TITLE
Create RWD Documentation

### DIFF
--- a/doc/user_manual/tsa.tex
+++ b/doc/user_manual/tsa.tex
@@ -115,10 +115,31 @@ In addition, any number of the following TSA algorithms may be included as subno
     \end{itemize}
     \xmlNode{ARMA} further has the following subnodes:
     \begin{itemize}
-      \item \xmlNode{SignalLag}, \xmlDesc{integer, required field}, number of signal lag terms to
-        include in the autoregression term.
-      \item \xmlNode{NoiseLag}, \xmlDesc{integer, required field}, number of noise lag terms to
-        include in the moving average term.
+    \item \xmlNode{SignalLag}, \xmlDesc{integer, required field}, number of signal
+      lag terms to include in the autoregression term.
+    \item \xmlNode{NoiseLag}, \xmlDesc{integer, required field}, number of noise
+      lag terms to include in the moving average term.
     \end{itemize}
+    \item \xmlNode{RWD} characterizes the signal using Randomized Window
+      Decomposition. This algorithm leverages the \xmlNode{PostProcessor} subtype
+      \xmlAttr{TSACharacterizer}. This algorithm can only characterize, it cannot
+      generate data.
+      \xmlNode{RWD} has the following parameters:
+      \begin{itemize}
+      \item \xmlNode{signatureWindowLength} \xmlDesc{integer, required field} the
+        size of signature window, which represents as a snapshot for a certain
+        time step; typically represented as $w$ in literature.
+      \item \xmlNode{featureIndex} \xmlDesc{integer, required field} Index used
+        for feature selection, which requires pre-analysis for now, will be
+        addresses via other non human work required method.
+      \item \xmlNode{sampleType} \xmlDesc{integer, required field} Determines the
+        type of sampling to perform indicated by an integer value given ranging from $0$ to $2$.
+        \begin{itemize}
+        \item $0 = \text{Sequential Sampling}$
+        \item $1 = \text{Random Sampling}$
+        \item $2 = \text{Piecewise Sampling}$
+        \end{itemize}
+        \item \xmlNode{seed} \xmlDesc{integer} Indicating the random seed.
+      \end{itemize}
 \end{itemize}
 }


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Closes #1698

##### What are the significant changes in functionality due to this change request?

Just added documentation

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

