### PR TITLE
changing default raven_lib_name

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -8,7 +8,7 @@
 
 # ENVIRONMENT VARIABLES
 # location of conda definitions: CONDA_DEFS (defaults if not set based on OS)
-# name for raven libraries: RAVEN_LIBS_NAME (defaults to raven_libraries if not set)
+# name for raven libraries: RAVEN_LIBS_NAME (defaults to raven_libraries_alt if not set)
 
 ECE_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 RAVEN_LIB_HANDLER=${ECE_SCRIPT_DIR}/library_handler.py
@@ -176,7 +176,7 @@ function display_usage()
 	echo '    establish_conda_env.sh'
 	echo ''
 	echo '  Description:'
-	echo '      This loads the RAVEN conda environment specified in \$RAVEN_LIBS_NAME \(default raven_libraries\).'
+	echo '      This loads the RAVEN conda environment specified in \$RAVEN_LIBS_NAME \(default raven_libraries_alt\).'
 	echo '      This script is also used for installing these libraries\; see options below.'
 	echo '  ------------------------------------------'
 	echo ''
@@ -206,11 +206,11 @@ function display_usage()
 	echo '      Additionally installs optional libraries used in some RAVEN workflows.  Requires --install.'
 	echo ''
 	echo '    --py3'
-	echo '    When installing, make raven_libraries use Python 3'
+	echo '    When installing, make raven_libraries_alt use Python 3'
 	echo ''
     echo ''
     echo '    --py2'
-    echo '    DEPRECATED: When installing, make raven_libraries use Python 2'
+    echo '    DEPRECATED: When installing, make raven_libraries_alt use Python 2'
     echo ''
     echo ''
 	echo '    --quiet'
@@ -351,12 +351,13 @@ then
     echo ... Using Python command ${PYTHON_COMMAND}
 fi
 
+RAVEN_LIBS_NAME=raven_libraries_alt
 # set raven libraries environment name, if not set
 if [ -z $RAVEN_LIBS_NAME ];
 then
   # check the RC file first
   export RAVEN_LIBS_NAME=$(read_ravenrc "RAVEN_LIBS_NAME")
-  # if not found through the RC file, will be empty string, so default to raven_libraries
+  # if not found through the RC file, will be empty string, so default to raven_libraries_alt
   if [[ ${#RAVEN_LIBS_NAME} == 0 ]];
   then
     RAVEN_LIBS_NAME=raven_libraries_alt

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -359,7 +359,7 @@ then
   # if not found through the RC file, will be empty string, so default to raven_libraries
   if [[ ${#RAVEN_LIBS_NAME} == 0 ]];
   then
-    RAVEN_LIBS_NAME=raven_libraries
+    RAVEN_LIBS_NAME=raven_libraries_alt
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... \"${RAVEN_LIBS_NAME}\" not found in global variables or ravenrc, defaulting to ${RAVEN_LIBS_NAME}; fi
   # verbosity to print library name findings in RC file
   else


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 


##### What are the significant changes in functionality due to this change request?
just changes library name because of brokenness on cluster.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

