### PR TITLE
Testing: update library handler and add prophet

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -63,8 +63,9 @@ Note all install methods after "main" take
     <!-- <ete3 optional='True'/> -->
     <pywavelets optional='True'>1.1</pywavelets>
     <xmlschema source="pip"/>
-    <pystan source="pip">2.19.1.1</pystan>
-    <prophet source="pip"/>
+    <!-- <pystan source="pip">2.19.1.1</pystan> -->
+    <!-- <prophet source="pip"/> -->
+    <prophet/>
   </main>
   <alternate name="pip">
     <hdf5>remove</hdf5>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,7 +53,7 @@ Note all install methods after "main" take
     <pyside2/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray os="mac,linux" source="pip">1.8</ray>
+    <ray os="mac,linux" source="pip"/>
     <!-- <ray os="mac,linux" source="pip">1.3</ray> -->
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -53,15 +53,18 @@ Note all install methods after "main" take
     <pyside2/>
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
-    <ray os="mac,linux" source="pip">1.3</ray>
+    <ray os="mac,linux" source="pip">1.8</ray>
+    <!-- <ray os="mac,linux" source="pip">1.3</ray> -->
     <!-- ray is not compatible with aioredis 2.0
       https://github.com/ray-project/ray/issues/17475 -->
-    <aioredis os="mac,linux" source="pip">1.3</aioredis>
+    <!-- <aioredis os="mac,linux" source="pip">1.3</aioredis> -->
     <pillow optional='True'>6.0</pillow>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->
     <pywavelets optional='True'>1.1</pywavelets>
     <xmlschema source="pip"/>
+    <pystan source="pip">2.19.1.1</pystan>
+    <prophet source="pip"/>
   </main>
   <alternate name="pip">
     <hdf5>remove</hdf5>

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -142,7 +142,7 @@ function create_libraries()
     # ${COMMAND}
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
-    local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
+    local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create --subset forge)`
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
     ${COMMAND}
     # pip only

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -104,9 +104,9 @@ function install_libraries()
   if [[ $ECE_VERBOSE == 0 ]]; then echo Installing libraries ...; fi
   if [[ "$INSTALL_MANAGER" == "CONDA" ]];
   then
-    local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install)`
-    if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda command: \"${COMMAND}\"; fi
-    ${COMMAND}
+    # local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install)`
+    # if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda command: \"${COMMAND}\"; fi
+    # ${COMMAND}
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
@@ -137,9 +137,9 @@ function create_libraries()
   if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries ...; fi
   if [[ "$INSTALL_MANAGER" == "CONDA" ]];
   then
-    local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create)`
-    if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda command: ${COMMAND}; fi
-    ${COMMAND}
+    # local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create)`
+    # if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda command: ${COMMAND}; fi
+    # ${COMMAND}
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -441,7 +441,7 @@ def _readLibNode(libNode, config, toRemove, opSys, addOptional, limitSources, re
   # check limited sources
   libSource = libNode.attrib.get('source', None)
   if libSource is None:
-    libSource = 'conda' # DEFAULT
+    libSource = 'forge' # DEFAULT
   if limitSources is not None and libSource not in limitSources:
     return # nothing to do
   # otherwise, we have a valid request to handle
@@ -576,17 +576,17 @@ if __name__ == '__main__':
       equals = '='
       actionArgs = '--name {env} -y {src}'
       # which part of the install are we doing?
-      if args.subset == 'core':
+      if args.subset == 'core' or args.subset == 'forge':
         # from defaults
         src = '-c conda-forge'
         addOptional = args.addOptional
-        limit = ['conda']
-      elif args.subset == 'forge':
-        # take libs from conda-forge
-        src = '-c conda-forge '
-        addOptional = args.addOptional
         limit = ['forge']
-        sys.stderr.write("WARNING: conda-forge is used by default, do not need to request\n")
+      #elif args.subset == 'forge':
+      #  # take libs from conda-forge
+      #  src = '-c conda-forge '
+      #  addOptional = args.addOptional
+      #  limit = ['forge']
+      #  sys.stderr.write("WARNING: conda-forge is used by default, do not need to request\n")
       elif args.subset == 'pip':
         src = ''
         installer = 'pip'


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

