### PR TITLE
Update Basic Statistics

### DIFF
--- a/framework/Models/PostProcessors/LimitSurfaceIntegral.py
+++ b/framework/Models/PostProcessors/LimitSurfaceIntegral.py
@@ -256,9 +256,9 @@ class LimitSurfaceIntegral(PostProcessorInterface):
           f = np.vectorize(self.variableDist[varName].ppf, otypes=[np.float])
           randomMatrix[:, index] = f(randomMatrix[:, index])
         tempDict[varName] = randomMatrix[:, index]
-      pb = self.stat.run({'targets':{self.target:xarray.DataArray(self.functionS.evaluate(tempDict)[self.target])}})[self.computationPrefix +"_"+self.target]
+      pb = self.stat._runLegacy({'targets':{self.target:xarray.DataArray(self.functionS.evaluate(tempDict)[self.target])}})[self.computationPrefix +"_"+self.target]
       if self.errorModel:
-        boundError = abs(pb-self.stat.run({'targets':{self.target:xarray.DataArray(self.errorModel.evaluate(tempDict)[self.target])}})[self.computationPrefix +"_"+self.target])
+        boundError = abs(pb-self.stat._runLegacy({'targets':{self.target:xarray.DataArray(self.errorModel.evaluate(tempDict)[self.target])}})[self.computationPrefix +"_"+self.target])
     else:
       self.raiseAnError(NotImplemented, "quadrature not yet implemented")
     return pb, boundError

--- a/framework/Models/PostProcessors/SafestPoint.py
+++ b/framework/Models/PostProcessors/SafestPoint.py
@@ -335,7 +335,7 @@ class SafestPoint(PostProcessorInterface):
       rlz['ProbabilityWeight'][ncLine] = np.prod(probList)
     metadata = {'ProbabilityWeight':xarray.DataArray(rlz['ProbabilityWeight'])}
     targets = {tar:xarray.DataArray( rlz[tar])  for tar in self.controllableOrd}
-    rlz['ExpectedSafestPointCoordinates'] = self.stat.run({'metadata':metadata, 'targets':targets})
+    rlz['ExpectedSafestPointCoordinates'] = self.stat._runLegacy({'metadata':metadata, 'targets':targets})
     self.raiseADebug(rlz['ExpectedSafestPointCoordinates'])
     return rlz
 

--- a/framework/Samplers/AdaptiveMonteCarlo.py
+++ b/framework/Samplers/AdaptiveMonteCarlo.py
@@ -186,7 +186,7 @@ class AdaptiveMonteCarlo(AdaptiveSampler, MonteCarlo):
       @ Out, None
     """
     if self.counter > 1:
-      output = self.basicStatPP.run(self._targetEvaluation)
+      output = self.basicStatPP._runLegacy(self._targetEvaluation)
       output['solutionUpdate'] = np.asarray([self.counter - 1])
       self._solutionExport.addRealization(output)
       self.checkConvergence(output)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #1653

##### What are the significant changes in functionality due to this change request?
This updates the BasicStatistics PP to use the new PP-ready interface which standardizes the API and hence BasicStatistics can be used by other PPs such as validation PPs.




----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

