### PR TITLE
Removing directly calling setup.py

### DIFF
--- a/build_raven
+++ b/build_raven
@@ -102,9 +102,10 @@ if test `uname` = Darwin; then
     export MACOSX_DEPLOYMENT_TARGET;
 fi
 
-(cd $CROW_DIR && ${PYTHON_COMMAND} ./setup.py build_ext build install --install-platlib=./install)
+PIP_COMMAND=pip3
+(cd $CROW_DIR && ${PIP_COMMAND} --verbose install . --upgrade --target ./install)
 
-(cd $RAVEN_BUILD_DIR && ${PYTHON_COMMAND} ./setup.py build_ext build install --install-platlib=./framework/contrib/AMSC)
+(cd $RAVEN_BUILD_DIR && ${PIP_COMMAND} --verbose install . --upgrade --target ./framework/contrib/AMSC)
 
 if [ ! -z "$RAVEN_SIGNATURE" ];
 then

--- a/crow/setup.py
+++ b/crow/setup.py
@@ -12,8 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from distutils.core import setup, Extension
+from distutils.command.build import build
 import subprocess
 import sys
+
+
+# We need a custom build order in order to ensure that files
+# distribution1Dpy3.py interpolationNDpy3.py and randomENGpy3.py are available
+# before we try to copy it to the target location
+class CustomBuild(build):
+    sub_commands = [('build_ext', build.has_ext_modules),
+                    ('build_py', build.has_pure_modules),
+                    ('build_clib', build.has_c_libraries),
+                    ('build_scripts', build.has_scripts)]
+
 try:
   if sys.version_info.major > 2:
     eigen_flags = subprocess.check_output(["./scripts/find_eigen.py"]).decode("ascii")
@@ -56,4 +68,5 @@ setup(name='crow',
         Extension('_randomENG'+ext,['crow_modules/randomENG'+ext+'.i','src/distributions/randomClass.cxx'],include_dirs=include_dirs,swig_opts=swig_opts,extra_compile_args=extra_compile_args),
         Extension('_interpolationND'+ext,['crow_modules/interpolationND'+ext+'.i','src/utilities/ND_Interpolation_Functions.cxx','src/utilities/NDspline.cxx','src/utilities/microSphere.cxx','src/utilities/inverseDistanceWeigthing.cxx','src/utilities/MDreader.cxx','src/distributions/randomClass.cxx'],include_dirs=include_dirs,swig_opts=swig_opts,extra_compile_args=extra_compile_args)],
       py_modules=['crow_modules.distribution1D'+ext,'crow_modules.randomENG'+ext,'crow_modules.interpolationND'+ext],
+      cmdclass={'build': CustomBuild},
       )


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #1737 

##### What are the significant changes in functionality due to this change request?
Improves setup.py so it builds properly when called from pip, and switches to using pip to install crow and amsc.

On the backend, it now builds a wheel file and installs it in a raven subdirectory, instead of directly copying files.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

