### PR TITLE
Remove Invalid Escape Sequences

### DIFF
--- a/framework/CodeInterfaces/AccelerateCFD/AccelerateCFD.py
+++ b/framework/CodeInterfaces/AccelerateCFD/AccelerateCFD.py
@@ -109,7 +109,7 @@ class AcceleratedCFD(CodeInterfaceBase):
         self.romName = xmlFind('./rom/romName')
         self.romType = xmlFind('./rom/romType')
         # read data from FOM
-        datai = pd.read_csv(self.fomDataFolder,skiprows=3,header=None,sep='\s+').iloc[:,[0,1,2]].replace('[()]','',regex=True).astype(float)
+        datai = pd.read_csv(self.fomDataFolder,skiprows=3,header=None,sep=r'\s+').iloc[:,[0,1,2]].replace('[()]','',regex=True).astype(float)
         datai = datai.rename(columns={0:'t',1:'ux',2:'uy'})
         dataList = [datai]
         self.dataFom = pd.concat(dataList,keys=['fom'])
@@ -322,7 +322,7 @@ class AcceleratedCFD(CodeInterfaceBase):
       # process post-processing file for rom
       ppRomFile = os.path.join(workingDir,"rom",self.romType +"_"+ self.romName,"postProcessing","probe","0","Urom")
       if os.path.exists(ppRomFile):
-        datai = pd.read_csv(ppRomFile,skiprows=3,header=None,sep='\s+').iloc[:,[0,1,2]].replace('[()]','',regex=True).astype(float)
+        datai = pd.read_csv(ppRomFile,skiprows=3,header=None,sep=r'\s+').iloc[:,[0,1,2]].replace('[()]','',regex=True).astype(float)
         datai = datai.rename(columns={0:'t',1:'ux',2:'uy'})
         dataList = [datai]
         romData = pd.concat(dataList,keys=['rom'])

--- a/framework/CodeInterfaces/Dymola/DymolaInterface.py
+++ b/framework/CodeInterfaces/Dymola/DymolaInterface.py
@@ -262,8 +262,8 @@ class Dymola(CodeInterfaceBase):
     patterns = [# Dymola 1- or 2-line parameter specification
                 (r'(^\s*%s\s+)%s(\s+%s\s+%s\s+%s\s+%s\s*#\s*%s\s*$)'
                  % (i, f, f, f, u, u, '%s')),
-                (r'(^\s*)' + i + '(\s*#\s*%s)'),
-                (r'(^\s*)' + f + '(\s*#\s*%s)'),
+                (r'(^\s*)' + i + r'(\s*#\s*%s)'),
+                (r'(^\s*)' + f + r'(\s*#\s*%s)'),
                 # From Dymola:
                 # column 1: Type of initial value
                 #           = -2: special case: for continuing simulation

--- a/framework/CodeInterfaces/MELCOR/MELCORdata.py
+++ b/framework/CodeInterfaces/MELCOR/MELCORdata.py
@@ -68,10 +68,10 @@ class MELCORdata:
       @ Out, functionValuesForEachTime, dict, {"time":{"functionName":"functionValue"}}
     """
     functionValuesForEachTime = {'time': []}
-    timeOneRegex_name = re.compile("^\s*CONTROL\s+FUNCTION\s+(?P<name>[^\(]*)\s+(\(.*\))?\s*IS\s+.+\s+TYPE.*$")
-    timeOneRegex_value = re.compile("^\s*VALUE\s+=\s+(?P<value>[^\s]*)")
-    startRegex = re.compile("\s*CONTROL\s*FUNCTION\s*NUMBER\s*CURRENT\s*VALUE")
-    regex = re.compile("^\s*(?P<name>( ?([0-9a-zA-Z-]+))*)\s+([0-9]+)\s*(?P<value>((([0-9.-]+)E(\+|-)[0-9][0-9])|((T|F))))\s*.*$")
+    timeOneRegex_name = re.compile(r"^\s*CONTROL\s+FUNCTION\s+(?P<name>[^\(]*)\s+(\(.*\))?\s*IS\s+.+\s+TYPE.*$")
+    timeOneRegex_value = re.compile(r"^\s*VALUE\s+=\s+(?P<value>[^\s]*)")
+    startRegex = re.compile(r"\s*CONTROL\s*FUNCTION\s*NUMBER\s*CURRENT\s*VALUE")
+    regex = re.compile(r"^\s*(?P<name>( ?([0-9a-zA-Z-]+))*)\s+([0-9]+)\s*(?P<value>((([0-9.-]+)E(\+|-)[0-9][0-9])|((T|F))))\s*.*$")
     for time,listOfLines in timeBlock.items():
       functionValuesForEachTime['time'].append(float(time))
       start = -1

--- a/framework/CodeInterfaces/MooseBasedApp/BISONMESHSCRIPTparser.py
+++ b/framework/CodeInterfaces/MooseBasedApp/BISONMESHSCRIPTparser.py
@@ -84,7 +84,7 @@ class BISONMESHSCRIPTparser():
           # Append string of non-varying parts of input file to file storage and reset the collection string
           if len(between_str) > 0:
             self.fileOrderStorage.append(between_str); between_str = ''
-          dictname, varname, varvalue = re.split("\['|'] = |'] =|']= ", line)
+          dictname, varname, varvalue = re.split(r"\['|'] = |'] =|']= ", line)
           if dictname in self.AllVarDict.keys():
             self.AllVarDict[dictname][varname] = varvalue.strip()
           else:
@@ -119,7 +119,7 @@ class BISONMESHSCRIPTparser():
             # Append string of non-varying parts of input file to file storage and reset the collection string
             if len(between_str) > 0:
               self.fileOrderStorage.append(between_str); between_str = ''
-            dictname, varname, varvalue = re.split("\['|'] = |'] =|']= ", line)
+            dictname, varname, varvalue = re.split(r"\['|'] = |'] =|']= ", line)
             if dictname in self.AllVarDict.keys():
               self.AllVarDict[dictname][varname] = varvalue.strip()
             else:

--- a/framework/CodeInterfaces/OpenModelica/OpenModelicaInterface.py
+++ b/framework/CodeInterfaces/OpenModelica/OpenModelicaInterface.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
+r"""
 Created on May 22, 2015
 
 @author: bobk

--- a/framework/CodeInterfaces/PHISICS/PhisicsInterface.py
+++ b/framework/CodeInterfaces/PHISICS/PhisicsInterface.py
@@ -267,7 +267,7 @@ class Phisics(CodeInterfaceBase):
       )]].getFilename() + ' -dep ' + inputFiles[mapDict['Depletion_input'.lower(
       )]].getFilename() + ' -o ' + self.instantOutput
       commandToRun = commandToRun.replace("\n", " ")
-      commandToRun = re.sub("\s\s+", " ", commandToRun)
+      commandToRun = re.sub(r"\s\s+", " ", commandToRun)
       outputfile = 'out~' + inputFiles[mapDict['inp'.lower()]].getBase()
     returnCommand = [('parallel', commandToRun)], outputfile
     return returnCommand

--- a/framework/CodeInterfaces/PHISICS/PhisicsRelapInterface.py
+++ b/framework/CodeInterfaces/PHISICS/PhisicsRelapInterface.py
@@ -134,7 +134,7 @@ class PhisicsRelap5(CodeInterfaceBase):
     self.outputExt = '.o'
     commandToRun = executable + ' -i ' +inputFiles[mapDict['relapInp'.lower()]].getFilename() + ' -o  ' + self.outFileName + self.outputExt
     commandToRun = commandToRun.replace("\n"," ")
-    commandToRun  = re.sub("\s\s+", " ",commandToRun)
+    commandToRun  = re.sub(r"\s\s+", " ",commandToRun)
     returnCommand = [('parallel',commandToRun)], outputfile
     return returnCommand
 

--- a/framework/CodeInterfaces/RELAP5/RELAPparser.py
+++ b/framework/CodeInterfaces/RELAP5/RELAPparser.py
@@ -367,7 +367,7 @@ class RELAPparser():
       for lineNum, line in enumerate(self.deckLines[deck]):
         if all(foundAllCards[deck].values()):
           break
-        if not re.match('^\s*\n',line):
+        if not re.match(r'^\s*\n',line):
           readCard = line.split()[0].strip()
           if readCard in deckCards[deck].keys():
             foundWord = False

--- a/framework/CodeInterfaces/RELAP5/Relap5Interface.py
+++ b/framework/CodeInterfaces/RELAP5/Relap5Interface.py
@@ -142,7 +142,7 @@ class Relap5(CodeInterfaceBase):
       addflags = ''
     commandToRun = executable + ' -i ' + inputFiles[index].getFilename() + ' -o ' + outputfile  + '.o ' +  addflags
     commandToRun = commandToRun.replace("\n"," ")
-    commandToRun  = re.sub("\s\s+" , " ", commandToRun )
+    commandToRun  = re.sub(r"\s\s+" , " ", commandToRun )
     returnCommand = [('parallel',commandToRun)], outputfile
     return returnCommand
 

--- a/framework/CodeInterfaces/SCALE/tritonAndOrigenData.py
+++ b/framework/CodeInterfaces/SCALE/tritonAndOrigenData.py
@@ -207,7 +207,7 @@ class origenAndTritonData:
       if uom not in totals:
         totals[uom] = []
       indexConcTable+=4
-      timeUom = re.split('(\d+)', self.lines[indexConcTable].split()[0])[-1].strip()
+      timeUom = re.split(r'(\d+)', self.lines[indexConcTable].split()[0])[-1].strip()
       timeGrid = [float(elm.replace(timeUom.strip(),"")) for elm in  self.lines[indexConcTable].split()]
 
       if outputDict is None:

--- a/framework/InputTemplates/TemplateBaseClass.py
+++ b/framework/InputTemplates/TemplateBaseClass.py
@@ -185,7 +185,7 @@ class Template(object):
   # OTHER UTILITIES              #
   ################################
   def _getRavenLocation(self, which='framework'):
-    """
+    r"""
       Returns the (string) path to RAVEN
       NOTE this is problematic in mingw windows, since using abspath includes e.g. C:\msys64\home\etc.
       @ In, framework, bool, optional, if True then give location of "raven/framework" else "raven/"

--- a/framework/Optimizers/GeneticAlgorithm.py
+++ b/framework/Optimizers/GeneticAlgorithm.py
@@ -725,7 +725,7 @@ class GeneticAlgorithm(RavenSampled):
     return max(self._GDp(a,b,p),self._GDp(b,a,p))
 
   def _GDp(self,a,b,p):
-    """
+    r"""
       Modified Generational Distance Indicator
       @ In, a, np.array, old population A
       @ In, b, np.array, new population B
@@ -739,7 +739,7 @@ class GeneticAlgorithm(RavenSampled):
     return (1/n * s)**(1/p)
 
   def _popDist(self,ai,b,q=2):
-    """
+    r"""
       Minimum Minkowski distance from a_i to B (nearest point in B)
       @ In, ai, 1d array, the ith chromosome in the generation A
       @ In, b, np.array, population B
@@ -761,7 +761,7 @@ class GeneticAlgorithm(RavenSampled):
     return max(self._GD(a,b),self._GD(b,a))
 
   def _GD(self,a,b):
-    """
+    r"""
       Generational Distance Indicator
       @ In, a, np.array, old population A
       @ In, b, np.array, new population B

--- a/framework/Optimizers/SimulatedAnnealing.py
+++ b/framework/Optimizers/SimulatedAnnealing.py
@@ -626,7 +626,7 @@ class SimulatedAnnealing(RavenSampled):
       self.raiseAnError(NotImplementedError,'cooling schedule type not implemented.')
 
   def _nextNeighbour(self, rlz,fraction=1):
-    """
+    r"""
       Perturbs the state to find the next random neighbour based on the cooling schedule
       @ In, rlz, dict, current realization
       @ In, fraction, float, optional, the current iteration divided by the iteration limit i.e., $\frac{iter}{Limit}$

--- a/framework/Optimizers/fitness/fitness.py
+++ b/framework/Optimizers/fitness/fitness.py
@@ -28,7 +28,7 @@ import xarray as xr
 
 # @profile
 def invLinear(rlz,**kwargs):
-  """
+  r"""
     Inverse linear fitness method requires that the fitness value is inversely proportional to the objective function
     This method is designed such that:
     For minimization Problems:
@@ -76,7 +76,7 @@ def invLinear(rlz,**kwargs):
   return fitness
 
 def feasibleFirst(rlz,**kwargs):
-  """
+  r"""
     Efficient Parameter-less Feasible First Penalty Fitness method
     This method is designed such that:
     For minimization Problems:

--- a/framework/SupervisedLearning/ARMA.py
+++ b/framework/SupervisedLearning/ARMA.py
@@ -230,7 +230,7 @@ class ARMA(SupervisedLearning):
     specs.addSub(InputData.parameterInputFactory("nyquistScalar", contentType=InputTypes.IntegerType, default=1))
     ### ARMA zero filter
     zeroFilt = InputData.parameterInputFactory('ZeroFilter', contentType=InputTypes.StringType,
-                                               descr="""turns on \emph{zero filtering}
+                                               descr=r"""turns on \emph{zero filtering}
                                                  for the listed targets. Zero filtering is a very specific algorithm, and should not be used without
                                                  understanding its application.  When zero filtering is enabled, the ARMA will remove all the values from
                                                  the training data equal to zero for the target, then train on the remaining data (including Fourier detrending

--- a/framework/contrib/pyDOE/doe_factorial.py
+++ b/framework/contrib/pyDOE/doe_factorial.py
@@ -190,7 +190,7 @@ def fracfact(gen):
     """
     # Recognize letters and combinations
     #### fixed for python 3.7 by alfoa
-    A = [item for item in re.split('\-|\s|\+', gen) if item] # remove empty strings
+    A = [item for item in re.split(r'\-|\s|\+', gen) if item] # remove empty strings
     
     C = [len(item) for item in A]
     

--- a/scripts/TestHarness/testers/RavenFramework.py
+++ b/scripts/TestHarness/testers/RavenFramework.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 import os
 import subprocess
 import sys
-import distutils.version
 import platform
 from Tester import Tester
 import OrderedCSVDiffer
@@ -209,8 +208,8 @@ class RavenFramework(Tester):
       if not found:
         self.set_skip('skipped (Unable to import library: "'+libraryName+'")')
         return False
-      if distutils.version.LooseVersion(actualVersion) < \
-         distutils.version.LooseVersion(libraryVersion):
+      if library_handler.parseVersion(actualVersion) < \
+         library_handler.parseVersion(libraryVersion):
         self.set_skip('skipped (Outdated library: "'+libraryName+'")')
         return False
       i += 2

--- a/scripts/TestHarness/testers/RavenPython.py
+++ b/scripts/TestHarness/testers/RavenPython.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 import os
 import sys
 import subprocess
-import distutils.version
 from Tester import Tester
 
 scriptsDir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -130,8 +129,8 @@ class RavenPython(Tester):
       if not found:
         self.set_skip('skipped (Unable to import library: "'+libraryName+'")')
         return False
-      if distutils.version.LooseVersion(actualVersion) < \
-         distutils.version.LooseVersion(libraryVersion):
+      if library_handler.parseVersion(actualVersion) < \
+         library_handler.parseVersion(libraryVersion):
         self.set_skip('skipped (Outdated library: "'+libraryName+'")')
         return False
       i += 2

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -17,6 +17,7 @@ Adopted from RavenUtils.py
 """
 import os
 import sys
+import re
 import platform
 import argparse
 import subprocess
@@ -111,6 +112,22 @@ def checkLibraries(buildReport=False):
   if buildReport:
     return messages
   return missing, notQA
+
+def parseVersion(versionString):
+  """
+    Parses a version string into its components
+    @ In, versionStirng, str, the version string to parse
+    @ Out, version, list, list of components as integers and strings
+  """
+  version = []
+  for part in re.split('([0-9]+|[a-z]+|\.)',versionString):
+    if len(part) == 0 or part == ".":
+      continue
+    try:
+      version.append(int(part))
+    except ValueError:
+      version.append(part)
+  return version
 
 def checkSameVersion(expected, received):
   """

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -120,7 +120,7 @@ def parseVersion(versionString):
     @ Out, version, list, list of components as integers and strings
   """
   version = []
-  for part in re.split('([0-9]+|[a-z]+|\.)',versionString):
+  for part in re.split(r'([0-9]+|[a-z]+|\.)',versionString):
     if len(part) == 0 or part == ".":
       continue
     try:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

close #1740

##### What are the significant changes in functionality due to this change request?

This PR fixes a deprecation defect by utilizing `raw-strings` for RAVEN docstrings that contain LaTeX equations and other escape sequences. 

It also removes deprecated disutils.version. So warnings stemming from that should cease as well. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

