### PR TITLE
ExternalModel Alias improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect-report.yml
+++ b/.github/ISSUE_TEMPLATE/defect-report.yml
@@ -2,7 +2,7 @@ name: Defect Report
 description: Report a DEFECT you experienced using the code
 title: "[DEFECT] "
 labels: defect, priority_normal
-assignees: PaulTalbot-INL, joshua-cogliati-inl, wangcj05, mandd
+assignees:
 body:
   - type: checkboxes
     id: requirements

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest a new capability or addition you would like to see
 title: "[TASK] Title here"
 labels: priority_minor, task
-assignees: PaulTalbot-INL, joshua-cogliati-inl, wangcj05, mandd
+assignees:
 
 
 ---

--- a/.github/ISSUE_TEMPLATE/under-discussion.md
+++ b/.github/ISSUE_TEMPLATE/under-discussion.md
@@ -4,7 +4,7 @@ about: This issue template is aimed to propose an item of discussion for new fea
   or similar
 title: "[UNDER-DISCUSSION] New Topic"
 labels: under-discussion
-assignees: PaulTalbot-INL, joshua-cogliati-inl, wangcj05, mandd
+assignees:
 
 
 ---

--- a/framework/Models/ExternalModel.py
+++ b/framework/Models/ExternalModel.py
@@ -265,7 +265,7 @@ class ExternalModel(Dummy):
     # collect the user results
     for key in self.modelVariableType:
       # preferentially obtain values from the instantiated object
-      if key.isidentifier(): # checks valid python variable name
+      if key.isidentifier() and hasattr(externalSelf, key): # checks valid python variable name
         modelVariableValues[key] = copy.copy(getattr(externalSelf, key))
       # otherwise, try to get it from the dictionary. If not, save it as "None" so it reports back to the user.
       else:
@@ -274,10 +274,7 @@ class ExternalModel(Dummy):
         modelVariableValues[key] = copy.copy(InputDict.get(key, None))
     # in case initialization variables have been modified, update them.
     for key in self.initExtSelf.__dict__:
-      if key.isidentifier(): # checks valid python variable name
-        setattr(self.initExtSelf, key, copy.copy(getattr(externalSelf, key)))
-      else:
-        self.raiseAnError(RuntimeError, f'Variable "{key}" has an invalid Python variable name and cannot be set in ExternalModel!')
+      setattr(self.initExtSelf, key, copy.copy(getattr(externalSelf, key)))
     # check for missing/bad data
     if None in self.modelVariableType.values():
       errorFound = False

--- a/framework/Models/ExternalModel.py
+++ b/framework/Models/ExternalModel.py
@@ -222,67 +222,63 @@ class ExternalModel(Dummy):
     """
     if self.pickled and not self.constructed:
       self.raiseAnError(IOError, 'The <pickledModel> "{}" has not been de-serialized (IOStep)!'.format(self.name))
-
+    # instantiate an object to pass to the user on which to store I/O variables
     externalSelf = utils.Object()
-    # self.sim=__import__(self.ModuleToLoad)
+    # build dict of variables mapped to values
     modelVariableValues = {}
     for key in self.modelVariableType.keys():
       modelVariableValues[key] = None
     for key, value in self.initExtSelf.__dict__.items():
       setattr(externalSelf, key, copy.copy(value))
-      #CustomCommandExecuter.execCommand('self.'+ key +' = copy.copy(object)',self=externalSelf,object=value)  # exec('externalSelf.'+ key +' = copy.copy(value)')
       modelVariableValues[key] = copy.copy(value)
     for key in Input.keys():
       if key in modelVariableValues.keys():
         modelVariableValues[key] = copy.copy(Input[key])
+    # collect updates from user's createNewInput if it's present
     if 'createNewInput' not in dir(self.sim):
       InputDict = {}
     else:
       InputDict = Input
-    #if 'createNewInput' not in dir(self.sim):
     additionalKeys = []
     if '_indexMap' in Input.keys():
       additionalKeys.append('_indexMap')
     for key in Input.keys():
       if key in additionalKeys:
         modelVariableValues[key] = copy.copy(Input[key])
+    # make sure the instance we pass to the user has the variables it needs
     for key in list(self.modelVariableType.keys()) + additionalKeys:
-      # add the variable as a member of "self"
-      #try:
+      # preference is to make it a member of the insantiated object
       if key.isidentifier():
         setattr(externalSelf, key, copy.copy(modelVariableValues[key]))
-        #CustomCommandExecuter.execCommand('self.'+ key +' = copy.copy(object["'+key+'"])',self=externalSelf,object=modelVariableValues) #exec('externalSelf.'+ key +' = copy.copy(modelVariableValues[key])')  #self.__uploadSolution()
-      # if variable name is too strange to be a member of "self", then skip it
-      # Note SyntaxError is for bad characters ("v@riable") and AttributeError is for e.g. index-looking ("Var[1]")
-      #except (SyntaxError, AttributeError):
+      # otherwise, just have it available in the dictionary instead. This feels redundant.
       else:
         self.raiseAWarning(f'Variable "{key}" could not be added to ExternalModel first argument due to complex name. ' +
-                            'Find it in the second argument instead.')
+                            'Find it in the second (dictionary) argument instead.')
     # only pass the variables and their values according to the model itself.
     for key in Input:
       if key in self.modelVariableType or key in additionalKeys:
         InputDict[key] = Input[key]
 
+    # run the user's model
     self.sim.run(externalSelf, InputDict)
 
+    # collect the user results
     for key in self.modelVariableType:
-      #try:
+      # preferentially obtain values from the instantiated object
       if key.isidentifier(): # checks valid python variable name
         modelVariableValues[key] = copy.copy(getattr(externalSelf, key))
-        #CustomCommandExecuter.execCommand('object["'+key+'"]  = copy.copy(self.'+key+')', self=externalSelf,object=modelVariableValues) #exec('modelVariableValues[key]  = copy.copy(externalSelf.'+key+')') #self.__pointSolution()
-        # Note, the following string can't be converted using {} formatting, at least as far as I can tell.
+      # otherwise, try to get it from the dictionary. If not, save it as "None" so it reports back to the user.
       else:
         self.raiseAWarning(f'Variable "{key}" could not be read from ExternalModel first argument due to complex name. ' +
-                            'Checking it in the second argument instead.')
-        #self.raiseAWarning(f'Variable "{}" cannot be read from "self" due to complex name.  Retaining original value.'.format(key))
+                            'Checking it in the second (dictionary) argument instead.')
         modelVariableValues[key] = copy.copy(InputDict.get(key, None))
+    # in case initialization variables have been modified, update them.
     for key in self.initExtSelf.__dict__:
       if key.isidentifier(): # checks valid python variable name
         setattr(self.initExtSelf, key, copy.copy(getattr(externalSelf, key)))
       else:
         self.raiseAnError(RuntimeError, f'Variable "{key}" has an invalid Python variable name and cannot be set in ExternalModel!')
-      # Note, the following string can't be converted using {} formatting, at least as far as I can tell.
-      #CustomCommandExecuter.execCommand('self.' +key+' = copy.copy(object.'+key+')', self=self.initExtSelf, object=externalSelf) #exec('self.initExtSelf.' +key+' = copy.copy(externalSelf.'+key+')')
+    # check for missing/bad data
     if None in self.modelVariableType.values():
       errorFound = False
       for key in self.modelVariableType:

--- a/tests/framework/aliasSystemTests/externalModel/lorentzAttractor.py
+++ b/tests/framework/aliasSystemTests/externalModel/lorentzAttractor.py
@@ -25,7 +25,13 @@ def initialize(self,runInfoDict,inputFiles):
   self.beta  = 8.0/3.0
   return
 
-def run(self,Input):
+def run(self, Input):
+  """
+    Run
+    @ In, self, object, variable-storing object
+    @ In, Input, dict, additional variables
+    @ Out, None
+  """
   max_time = 0.03
   t_step = 0.01
 
@@ -50,3 +56,7 @@ def run(self,Input):
     self.firstOut[t+1]    = self.firstOut[t] + self.sigma*(self.secondOut[t]-self.firstOut[t]) * t_step
     self.secondOut[t+1]    = self.secondOut[t] + (self.firstOut[t]*(self.rho-self.z[t])-self.secondOut[t]) * t_step
     self.z[t+1]    = self.z[t] + (self.firstOut[t]*self.secondOut[t]-self.beta*self.z[t]) * t_step
+
+  # aliased outputs
+  Input['x@'] = self.firstOut
+  Input['y[1]'] = self.secondOut

--- a/tests/framework/aliasSystemTests/test_external_model_aliased.xml
+++ b/tests/framework/aliasSystemTests/test_external_model_aliased.xml
@@ -14,6 +14,7 @@
       <revision author="alfoa" date="2016-11-28">Added XSD schema and Closes #756</revision>
       <revision author="alfoa" date="2017-01-21">Adding this test description.</revision>
       <revision author="talbpaul" date="2018-04-04">added awful.variable+name for hard-testing input alias</revision>
+      <revision author="talbpaul" date="2022-01-18">added difficult output alias, index-ish alias</revision>
     </revisions>
   </TestInfo>
   <!-- RUNINFO -->
@@ -51,8 +52,10 @@
       <variables>sigma,rho,beta,x,y,z,time,x0,y0,z0</variables>
       <alias variable="x0" type="input">awful.variable+name</alias>
       <alias variable="y0" type="input">@another|awful name</alias>
-      <alias variable="x"  type="output">firstOut</alias>
-      <alias variable="y"  type="output">secondOut</alias>
+      <alias variable="x"  type="output">x@</alias>
+      <alias variable="y"  type="output">y[1]</alias>
+      <!-- <alias variable="x"  type="output">firstOut</alias>
+      <alias variable="y"  type="output">secondOut</alias> -->
     </ExternalModel>
   </Models>
 

--- a/tests/framework/aliasSystemTests/test_external_model_aliased.xml
+++ b/tests/framework/aliasSystemTests/test_external_model_aliased.xml
@@ -54,8 +54,6 @@
       <alias variable="y0" type="input">@another|awful name</alias>
       <alias variable="x"  type="output">x@</alias>
       <alias variable="y"  type="output">y[1]</alias>
-      <!-- <alias variable="x"  type="output">firstOut</alias>
-      <alias variable="y"  type="output">secondOut</alias> -->
     </ExternalModel>
   </Models>
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1746

##### What are the significant changes in functionality due to this change request?
- Protects against input "odd variable names" aliases better in ExternalModel
- Allows output aliases with "odd variable names" in ExternalModel

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

