### PR TITLE
Value at risk correction

### DIFF
--- a/doc/user_manual/PostProcessors/EconomicRatio.tex
+++ b/doc/user_manual/PostProcessors/EconomicRatio.tex
@@ -1,32 +1,32 @@
 \subsubsection{EconomicRatio}
 \label{EconomicRatio}
-The \xmlNode{EconomicRatio} post-processor provides the economic metrics from the percent change 
-period return of the asset or strategy that is given as an input. These metrics measure the risk-adjusted returns. 
+The \xmlNode{EconomicRatio} post-processor provides the economic metrics from the percent change
+period return of the asset or strategy that is given as an input. These metrics measure the risk-adjusted returns.
 %
 \ppType{EconomicRatio}{EconomicRatio}
 
 \begin{itemize}
   \item \xmlNode{"metric"}, \xmlDesc{comma separated string or node list, required field},
-  specifications for the metric to be calculated. The name of each node is the requested metric. 
-  The text of the node is a comma-separated list of the parameters for which the metric should be calculated. 
+  specifications for the metric to be calculated. The name of each node is the requested metric.
+  The text of the node is a comma-separated list of the parameters for which the metric should be calculated.
 
   Currently the scalar quantities available for request are:
   \begin{itemize}
 
-  \item \textbf{sharpeRatio}: the Sharpe Ratio, measures the performance of an investment. It is defined as the  historical returns of the investment, divided by the standard deviation of the investment(Volatility). 
+  \item \textbf{sharpeRatio}: the Sharpe Ratio, measures the performance of an investment. It is defined as the  historical returns of the investment, divided by the standard deviation of the investment(Volatility).
   \item \textbf{sortinoRatio}: the Sortino ratio, measures the risk-adjusted return of an investment asset. Discounts the excess return of a portfolio above a target threshold by the volatility of downside returns. If this quantity is inputted as \textit{sortinoRatio} the threshold for separate upside and downside value will assign as $0$. Otherwise the user can specify this quantity with a parameter \xmlAttr{threshold='X'}, where the \xmlAttr{X} represents the requested threshold \xmlAttr{median} or \xmlAttr{zero}.
-  
+
   \item \textbf{gainLossRatio}: the gain-loss ratio, discounts the first-order higher partial moment of a portfolio's returns, by the first-order lower partial moment of a portfolio's returns. If this quantity is inputted as \textit{gainLossRatio} the threshold for separate upside and downside value will assign as $0$. Otherwise the user can specify this quantity with a parameter \xmlAttr{threshold='X'}, where the \xmlAttr{X} represents the requested threshold \xmlAttr{median} or \xmlAttr{zero}.
-  
-  
+
+
   \item \textbf{expectedShortfall}: the expected shortfall (Es) or conditional value at risk (CVaR), the expected return on the portfolio in the worst q of cases. If this quantity is inputted as \textit{ExpectedShortfall} the q value will assign as $5\%$. Otherwise the user can specify this quantity with a parameter \xmlAttr{threshold='X'}, where the \xmlAttr{X} represents the requested q value (a floating point value between 0.0 and 1.0)
   \begin{equation}
     ES_\alpha = -\frac{1}{\alpha} \int_0^\alpha \operatorname{VaR}_\gamma(X) \, d\gamma
   \end{equation}
-  \item \textbf{valueAtRisk}: the value at risk for investments. Estimates the maximum possible loss after exclude worse outcomes whose combined probability is at most $\alpha$. If this quantity is inputted as \textit{ValueAtRisk} the $\alpha$ value will assign as $5\%$. Otherwise the user can specify this quantity with a parameter \xmlAttr{threshold='X'}, where the \xmlAttr{X} represents the requested $\alpha$ value (a floating point value between 0.0 and 1.0)
-  
+  \item \textbf{valueAtRisk}: the value at risk for investments. Estimates the maximum possible loss after excluding worse outcomes whose combined probability is at most $\alpha$. If this quantity is inputted as \textit{valueAtRisk} the $\alpha$ value will default to $5\%$. Otherwise the user can specify this quantity with a parameter \xmlAttr{threshold='X'}, where the \xmlAttr{X} represents the requested $\alpha$ value (a floating point value between 0.0 and 1.0). It is calculated (where $ Y = -X $) as,
+
   \begin{equation}
-    \operatorname{VaR}_\alpha(X)=-\inf\big\{x\in\mathbb{R}:F_X(x)>\alpha\big\} = F^{-1}_Y(1-\alpha).
+    \operatorname{VaR}_\alpha(X)=-\inf\big\{x\in\mathbb{R}:F_X(x)>\alpha\big\} = -F^{-1}_X(\alpha) = F^{-1}_Y(1-\alpha).
   \end{equation}
   \end{itemize}
   This XML node needs to contain the attribute:
@@ -59,7 +59,7 @@ period return of the asset or strategy that is given as an input. These metrics 
       <valueAtRisk threshold='0.07' prefix="VaR">z01,x0,x01</valueAtRisk>
       <expectedShortfall threshold='0.99' prefix="CVaR">z01,x0,x01</expectedShortfall>
       <gainLossRatio prefix="glR">x01,y01,z0,x,y,z</gainLossRatio>
-    </PostProcessor>  
+    </PostProcessor>
     ...
   </Models>
   ...

--- a/doc/user_manual/postprocessor.tex
+++ b/doc/user_manual/postprocessor.tex
@@ -1726,7 +1726,7 @@ PPDSS                         & HistorySet                                      
 \end{lstlisting}
 
 %%%%% PP EconomicRatio %%%%%%%
-\input{EconomicRatio.tex}
+\input{PostProcessors/EconomicRatio.tex}
 
 %%%%% HistorySetDelay %%%%%%
 \input{PostProcessors/HistorySetDelay.tex}

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -266,34 +266,6 @@ class EconomicRatio(BasicStatistics):
     pw = xr.Dataset(data_vars=pw,coords=coords)
     return pw
 
-  def _computeWeightedPercentile(self,arrayIn,pbWeight,percent=0.5):
-    """
-      Method to compute the weighted percentile in a array of data
-      @ In, arrayIn, list/numpy.array, the array of values from which the percentile needs to be estimated
-      @ In, pbWeight, list/numpy.array, the reliability weights that correspond to the values in 'array'
-      @ In, percent, float, the percentile that needs to be computed (between 0.01 and 1.0)
-      @ Out, result, float, the percentile
-    """
-
-    idxs                   = np.argsort(np.asarray(list(zip(pbWeight,arrayIn)))[:,1])
-    # Inserting [0.0,arrayIn[idxs[0]]] is needed when few samples are generated and
-    # a percentile that is < that the first pb weight is requested. Otherwise the median
-    # is returned.
-    sortedWeightsAndPoints = np.insert(np.asarray(list(zip(pbWeight[idxs],arrayIn[idxs]))),0,[0.0,arrayIn[idxs[0]]],axis=0)
-    weightsCDF             = np.cumsum(sortedWeightsAndPoints[:,0])
-    # This step returns the index of the array which is < than the percentile, because
-    # the insertion create another entry, this index should shift to the bigger side
-    indexL = utils.first(np.asarray(weightsCDF >= percent).nonzero())[0]
-    # This step returns the indices (list of index) of the array which is > than the percentile
-    indexH = utils.first(np.asarray(weightsCDF > percent).nonzero())
-    try:
-      # if the indices exists that means the desired percentile lies between two data points
-      # with index as indexL and indexH[0]. Calculate the midpoint of these two points
-      result = 0.5*(sortedWeightsAndPoints[indexL,1]+sortedWeightsAndPoints[indexH[0],1])
-    except IndexError:
-      result = sortedWeightsAndPoints[indexL,1]
-    return result
-
   def _computeSortedWeightsAndPoints(self,arrayIn,pbWeight,percent):
     """
       Method to compute the sorted weights and points

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -380,7 +380,7 @@ class EconomicRatio(BasicStatistics):
             VaR = [self._computeWeightedPercentile(group.values,targWeight,percent=thd) for label,group in targDa.groupby(self.pivotParameter)]
           else:
             VaR = self._computeWeightedPercentile(targDa.values,targWeight,percent=thd)
-          VaRList.append(abs(VaR))
+          VaRList.append(-VaR)
         if self.pivotParameter in targDa.sizes.keys():
           da = xr.DataArray(VaRList,dims=('threshold',self.pivotParameter),coords={'threshold':threshold,self.pivotParameter:self.pivotValue})
         else:

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -432,7 +432,7 @@ class EconomicRatio(BasicStatistics):
       zeroTarget = []
       daZero = xr.Dataset()
       medTarget = []
-      daMed = xr.Dataset
+      daMed = xr.Dataset()
       for entry in self.toDo[metric]:
         if entry['threshold'] == 'zero':
           zeroTarget = entry['targets']


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Fixes #1749 

##### What are the significant changes in functionality due to this change request?

- Value at Risk is calculated correctly as negative of a quantile instead of absolute value of quantile
- Additional bug fixed in calculating sortinoRatio that allows calculation to not throw error
- Updated user manual entry for valueAtRisk

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

