### PR TITLE
Allow Input Templates to inherit from Message User

### DIFF
--- a/framework/CodeInterfaces/Prescient/PrescientCodeInterface.py
+++ b/framework/CodeInterfaces/Prescient/PrescientCodeInterface.py
@@ -20,12 +20,13 @@ This is a CodeInterface for the Presient code.
 
 import os
 import re
+import warnings
 try:
   import pkg_resources
   prescient = pkg_resources.get_distribution("prescient")
   prescientLocation = prescient.location
 except Exception as inst:
-  print("Finding Prescient failed with",inst)
+  warnings.warn(f"Finding Prescient failed with {inst}")
   prescientLocation = None
 
 from CodeInterfaceBaseClass import CodeInterfaceBase

--- a/framework/Decorators/__init__.py
+++ b/framework/Decorators/__init__.py
@@ -16,6 +16,7 @@
  @author: alfoa
 """
 import builtins
+import warnings
 
 # line_profiler decorator, @Decorators.timingProfile
 ## if using kernprof, use "profile" builtin; otherwise, passthrough.
@@ -23,12 +24,12 @@ try:
   builtins.profile
   timingProfile = builtins.profile
 except (AttributeError, ImportError):
-  print('Unable to load "timingProfile" decorator; replacing with passthrough ...')
+  warnings.warn('Unable to load "timingProfile" decorator; replacing with passthrough ...', ImportWarning)
   timingProfile = lambda f: f
 
 # memory_profiler decorator, @Decorators.memoryProfile
 try:
   from memory_profiler import profile as memoryProfile
 except (AttributeError, ImportError):
-  print('Unable to load "memoryProfile" decorator; replacing with passthrough ...')
+  warnings.warn('Unable to load "memoryProfile" decorator; replacing with passthrough ...', ImportWarning)
   memoryProfile = lambda f: f

--- a/framework/Distributions.py
+++ b/framework/Distributions.py
@@ -1804,13 +1804,6 @@ class UniformDiscrete(Distribution):
                             is returned to $N$). In case the ``with replacement'' strategy is used, the distribution samples
                             always from the complete set of specified $N$ values.
                             """
-    lb = InputData.parameterInputFactory('lowerBound', contentType=InputTypes.FloatType, printPriority=109,
-    descr=r""" Lower bound of the set of allowed sample values. """)
-    specs.addSub(lb)
-
-    ub = InputData.parameterInputFactory('upperBound', contentType=InputTypes.FloatType, printPriority=109,
-    descr=r""" Upper bound of the set of allowed sample values. """)
-    specs.addSub(ub)
 
     np = InputData.parameterInputFactory('nPoints', contentType=InputTypes.IntegerType, printPriority=109,
     descr=r""" Number of points between lower and upper bound. """)
@@ -2864,9 +2857,6 @@ class LogUniform(Distribution):
     inputSpecification = super(LogUniform, cls).getInputSpecification()
 
     BaseInputType = InputTypes.makeEnumType("base", "baseType", ["natural","decimal"])
-
-    inputSpecification.addSub(InputData.parameterInputFactory("lowerBound", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("upperBound", contentType=InputTypes.FloatType))
     inputSpecification.addSub(InputData.parameterInputFactory("base"      , BaseInputType))
 
     return inputSpecification

--- a/framework/InputTemplates/TemplateBaseClass.py
+++ b/framework/InputTemplates/TemplateBaseClass.py
@@ -29,9 +29,10 @@ import copy
 frameworkDir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.append(frameworkDir)
 from utils import xmlUtils
+from BaseClasses import MessageUser
 
 
-class Template(object):
+class Template(MessageUser):
   """
     Generic class for templating input files.
     Intended to be used to read a template, be given instructions on how to fill it,
@@ -61,12 +62,13 @@ class Template(object):
   ###############
   # API METHODS #
   ###############
-  def __init__(self):
+  def __init__(self, **kwargs):
     """
       Constructor.
       @ In, None
       @ Out, None
     """
+    super().__init__()
     self._template = None     # XML element with the root Simulation node of a RAVEN input
     # assure that the template path gives the location of the inheriting template, not the base class
     self._templatePath = os.path.dirname(os.path.normpath(sys.modules[self.__class__.__module__].__file__))


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#1755

##### What are the significant changes in functionality due to this change request?
Add explicit warnings to Decorators.py
Add explicit warning for Prescient import error

Remove `lowerBound` and `upperBound` as subs from DiscreteUniform and LogNormal

Let InputTemplates inherit from MessageUser

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

