### PR TITLE
Change runinfo default

### DIFF
--- a/doc/user_manual/runInfo.tex
+++ b/doc/user_manual/runInfo.tex
@@ -45,14 +45,14 @@ the settings of the calculation flow that is being performed through RAVEN:
   execute a command.  The command is passed in as the environmental
   variable COMMAND.
 %
-  \default{raven\_qsub\_command.sh}
+  \default{raven\_ec\_qsub\_command.sh}
 
   %%%%%% NODE PARAMETER
 
 \item \xmlNode{NodeParameter}, \xmlDesc{string, optional field},
   specifies the flag used to specify a node file for the MPIExec command.  This will be followed by a file with the nodes that a single batch will run on.
   %
-  \default{-f}
+  \default{--hostfile}
 
   %%%%%% MPI EXEC
 \item \xmlNode{MPIExec}, \xmlDesc{string, optional field}, specifies the command used to run mpi.  This will be followed by the \xmlNode{NodeParameter} and then the node file and then the code command.

--- a/framework/Simulation.py
+++ b/framework/Simulation.py
@@ -224,8 +224,8 @@ class Simulation(MessageUser):
     self.runInfoDict['SimulationFiles'   ] = []            #the xml input file
     self.runInfoDict['ScriptDir'         ] = os.path.join(os.path.dirname(frameworkDir),"scripts") # the location of the pbs script interfaces
     self.runInfoDict['FrameworkDir'      ] = frameworkDir  # the directory where the framework is located
-    self.runInfoDict['RemoteRunCommand'  ] = os.path.join(frameworkDir,'raven_qsub_command.sh')
-    self.runInfoDict['NodeParameter'     ] = '-f'          # the parameter used to specify the files where the nodes are listed
+    self.runInfoDict['RemoteRunCommand'  ] = os.path.join(frameworkDir,'raven_ec_qsub_command.sh')
+    self.runInfoDict['NodeParameter'     ] = '--hostfile'          # the parameter used to specify the files where the nodes are listed
     self.runInfoDict['MPIExec'           ] = 'mpiexec'     # the command used to run mpi commands
     self.runInfoDict['threadParameter'] = '--n-threads=%NUM_CPUS%'# the command used to run multi-threading commands.
                                                                   # The "%NUM_CPUS%" is a wildcard to replace. In this way for commands


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1761 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

