### PR TITLE
EconomicRatio PostProcessor Enhancements

### DIFF
--- a/doc/user_manual/PostProcessors/EconomicRatio.tex
+++ b/doc/user_manual/PostProcessors/EconomicRatio.tex
@@ -2,6 +2,7 @@
 \label{EconomicRatio}
 The \xmlNode{EconomicRatio} post-processor provides the economic metrics from the percent change
 period return of the asset or strategy that is given as an input. These metrics measure the risk-adjusted returns.
+\nb Any metric from \xmlNode{BasicStatistics} may be requested from \xmlNode{EconomicRatio}.
 %
 \ppType{EconomicRatio}{EconomicRatio}
 
@@ -44,7 +45,7 @@ period return of the asset or strategy that is given as an input. These metrics 
       For matrix quantities, RAVEN will define a variable with name defined as: ``prefix'' + ``\_'' + ``target parameter name'' + ``\_'' + ``feature parameter name''.
       For example, if we define ``sen'' as the prefix for \textbf{sensitivity}, target ``y'' and feature ``x'', then
       variable ``sen\_y\_x'' will be defined by RAVEN.
-      \nb These variable will be used by RAVEN for the internal calculations. It is also accessible by the user through
+      \nb These variables will be used by RAVEN for the internal calculations. It is also accessible by the user through
       \textbf{DataObjects} and \textbf{OutStreams}.
   \end{itemize}
 

--- a/doc/user_manual/PostProcessors/EconomicRatio.tex
+++ b/doc/user_manual/PostProcessors/EconomicRatio.tex
@@ -34,8 +34,13 @@ period return of the asset or strategy that is given as an input. These metrics 
     \itemsep0em
     \item \xmlAttr{prefix}, \xmlDesc{required string attribute}, user-defined prefix for the given \textbf{metric}.
       For scalar quantifies, RAVEN will define a variable with name defined as:  ``prefix'' + ``\_'' + ``parameter name''.
-      For example, if we define ``mean'' as the prefix for \textbf{expectedValue}, and parameter ``x'', then variable
-      ``mean\_x'' will be defined by RAVEN.
+      For example, if we define ``sharpe'' as the prefix for \textbf{sharpeRatio}, and parameter ``x'', then variable
+      ``sharpe\_x'' will be defined by RAVEN. For \textbf{metrics} that include a ``threshold'' parameter,
+      RAVEN will define a variable with name defined as: ``prefix'' + ``\_'' + ``threshold'' + ``\_'' + ``parameter name''.
+      For example, if we define ``VaR'' as the prefix for \textbf{valueAtRisk}, threshold ``0.05'', and parameter name ``x'',
+      then variable ``VaR\_0.05\_x'' will be defined by RAVEN. If we define ``glr'' as the prefix for \textbf{gainLossRatio},
+      ``median'' as the threshold, and ``x'' as the parameter name, then the variable ``glr\_median\_x''
+      will be defined by RAVEN.
       For matrix quantities, RAVEN will define a variable with name defined as: ``prefix'' + ``\_'' + ``target parameter name'' + ``\_'' + ``feature parameter name''.
       For example, if we define ``sen'' as the prefix for \textbf{sensitivity}, target ``y'' and feature ``x'', then
       variable ``sen\_y\_x'' will be defined by RAVEN.

--- a/doc/user_manual/postprocessor.tex
+++ b/doc/user_manual/postprocessor.tex
@@ -144,7 +144,10 @@ data objects, depending on the type of statistics the user wants to compute:
     \item \xmlAttr{prefix}, \xmlDesc{required string attribute}, user-defined prefix for the given \textbf{metric}.
       For scalar quantifies, RAVEN will define a variable with name defined as:  ``prefix'' + ``\_'' + ``parameter name''.
       For example, if we define ``mean'' as the prefix for \textbf{expectedValue}, and parameter ``x'', then variable
-      ``mean\_x'' will be defined by RAVEN.
+      ``mean\_x'' will be defined by RAVEN. For \textbf{percentile}, RAVEN will define a variable with name defined as:
+      ``prefix'' + ``\_'' + ``percent'' + ``\_'' + ``parameter name''. For example, if we define ``perc'' as the prefix
+      for \textbf{percentile}, percent as ``10'', and parameter ``x'', then variable ``perc\_10\_x'' will
+      be defined by RAVEN.
       For matrix quantities, RAVEN will define a variable with name defined as: ``prefix'' + ``\_'' + ``target parameter name'' + ``\_'' + ``feature parameter name''.
       For example, if we define ``sen'' as the prefix for \textbf{sensitivity}, target ``y'' and feature ``x'', then
       variable ``sen\_y\_x'' will be defined by RAVEN.
@@ -169,6 +172,7 @@ data objects, depending on the type of statistics the user wants to compute:
     \item \textbf{sigma}
     \item \textbf{skewness}
     \item \textbf{kurtosis}
+    \item \textbf{percentile}
   \end{itemize}
   RAVEN will define a variable with name defined as: ``prefix for given \textbf{metric}'' + ``\_ste\_'' + ``parameter name'' to
   store standard error of given \textbf{metric} with respect to given parameter. This information will be stored in the DataObjects,

--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -361,7 +361,7 @@ class BasicStatistics(PostProcessorInterface):
 
     assert (len(self.toDo)>0), self.raiseAnError(IOError, 'BasicStatistics needs parameters to work on! Please check input for PP: ' + self.name)
 
-  def __computePower(self, p, dataset):
+  def _computePower(self, p, dataset):
     """
       Compute the p-th power of weights
       @ In, p, int, the power
@@ -385,7 +385,7 @@ class BasicStatistics(PostProcessorInterface):
       @ In, weights, xarray.Dataset, probability weights of all input variables
       @ Out, vp, xarray.Dataset, the sum of p-th power of weights
     """
-    vp = self.__computePower(p,weights)
+    vp = self._computePower(p,weights)
     vp = vp.sum()
     return vp
 
@@ -451,7 +451,7 @@ class BasicStatistics(PostProcessorInterface):
     """
     if dim is None:
       dim = self.sampleTag
-    vr = self.__computePower(2.0, variance)
+    vr = self._computePower(2.0, variance)
     if pbWeight is not None:
       unbiasCorr = self.__computeUnbiasedCorrection(4,pbWeight) if not self.biased else 1.0
       vp = 1.0/self.__computeVp(1,pbWeight)
@@ -484,7 +484,7 @@ class BasicStatistics(PostProcessorInterface):
     """
     if dim is None:
       dim = self.sampleTag
-    vr = self.__computePower(1.5, variance)
+    vr = self._computePower(1.5, variance)
     if pbWeight is not None:
       unbiasCorr = self.__computeUnbiasedCorrection(3,pbWeight) if not self.biased else 1.0
       vp = 1.0/self.__computeVp(1,pbWeight)
@@ -732,7 +732,7 @@ class BasicStatistics(PostProcessorInterface):
     metric = 'sigma'
     if len(needed[metric]['targets'])>0:
       self.raiseADebug('Starting "'+metric+'"...')
-      sigmaDS = self.__computePower(0.5,calculations['variance'][list(needed[metric]['targets'])])
+      sigmaDS = self._computePower(0.5,calculations['variance'][list(needed[metric]['targets'])])
       self.calculations[metric] = sigmaDS
       calculations[metric] = sigmaDS
     #
@@ -808,7 +808,7 @@ class BasicStatistics(PostProcessorInterface):
     metric = 'lowerPartialSigma'
     if len(needed[metric]['targets'])>0:
       self.raiseADebug('Starting "'+metric+'"...')
-      lpsDS = self.__computePower(0.5,calculations['lowerPartialVariance'][list(needed[metric]['targets'])])
+      lpsDS = self._computePower(0.5,calculations['lowerPartialVariance'][list(needed[metric]['targets'])])
       calculations[metric] = lpsDS
     #
     # higherPartialVariance
@@ -828,7 +828,7 @@ class BasicStatistics(PostProcessorInterface):
     metric = 'higherPartialSigma'
     if len(needed[metric]['targets'])>0:
       self.raiseADebug('Starting "'+metric+'"...')
-      hpsDS = self.__computePower(0.5,calculations['higherPartialVariance'][list(needed[metric]['targets'])])
+      hpsDS = self._computePower(0.5,calculations['higherPartialVariance'][list(needed[metric]['targets'])])
       calculations[metric] = hpsDS
 
     ############################################################
@@ -838,7 +838,7 @@ class BasicStatistics(PostProcessorInterface):
     if len(needed[metric]['targets'])>0:
       self.raiseADebug('Starting calculate standard error on"'+metric+'"...')
       if self.pbPresent:
-        factor = self.__computePower(0.5,calculations['equivalentSamples'])
+        factor = self._computePower(0.5,calculations['equivalentSamples'])
       else:
         factor = np.sqrt(self.sampleSize)
       calculations[metric+'_ste'] = calculations['sigma'][list(needed[metric]['targets'])]/factor
@@ -850,7 +850,7 @@ class BasicStatistics(PostProcessorInterface):
       if self.pbPresent:
         en = calculations['equivalentSamples'][varList]
         factor = 2.0 /(en - 1.0)
-        factor = self.__computePower(0.5,factor)
+        factor = self._computePower(0.5,factor)
       else:
         factor = np.sqrt(2.0/(float(self.sampleSize) - 1.0))
       calculations[metric+'_ste'] = calculations['sigma'][varList]**2 * factor
@@ -862,7 +862,7 @@ class BasicStatistics(PostProcessorInterface):
       if self.pbPresent:
         en = calculations['equivalentSamples'][varList]
         factor = 2.0 * (en - 1.0)
-        factor = self.__computePower(0.5,factor)
+        factor = self._computePower(0.5,factor)
       else:
         factor = np.sqrt(2.0 * (float(self.sampleSize) - 1.0))
       calculations[metric+'_ste'] = calculations['sigma'][varList] / factor
@@ -880,7 +880,7 @@ class BasicStatistics(PostProcessorInterface):
       if self.pbPresent:
         en = calculations['equivalentSamples'][varList]
         factor = 6.*en*(en-1.)/((en-2.)*(en+1.)*(en+3.))
-        factor = self.__computePower(0.5,factor)
+        factor = self._computePower(0.5,factor)
         calculations[metric+'_ste'] = xr.full_like(calculations[metric],1.0) * factor
       else:
         en = float(self.sampleSize)
@@ -893,8 +893,8 @@ class BasicStatistics(PostProcessorInterface):
       varList = list(needed[metric]['targets'])
       if self.pbPresent:
         en = calculations['equivalentSamples'][varList]
-        factor1 = self.__computePower(0.5,6.*en*(en-1.)/((en-2.)*(en+1.)*(en+3.)))
-        factor2 = self.__computePower(0.5,(en**2-1.)/((en-3.0)*(en+5.0)))
+        factor1 = self._computePower(0.5,6.*en*(en-1.)/((en-2.)*(en+1.)*(en+3.)))
+        factor2 = self._computePower(0.5,(en**2-1.)/((en-3.0)*(en+5.0)))
         factor = 2.0 * factor1 * factor2
         calculations[metric+'_ste'] = xr.full_like(calculations[metric],1.0) * factor
       else:

--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -290,10 +290,11 @@ class BasicStatistics(PostProcessorInterface):
     metaKeys = inputMetaKeys + outputMetaKeys
     self.addMetaKeys(metaKeys,metaParams)
 
-  def _handleInput(self, paramInput):
+  def _handleInput(self, paramInput, childVals=[]):
     """
       Function to handle the parsed paramInput for this class.
       @ In, paramInput, ParameterInput, the already parsed input.
+      @ In, childVals, list, quantities requested from child statistical object
       @ Out, None
     """
     self.toDo = {}
@@ -355,7 +356,8 @@ class BasicStatistics(PostProcessorInterface):
       elif tag == "multipleFeatures":
         self.multipleFeatures = child.value
       else:
-        self.raiseAWarning('Unrecognized node in BasicStatistics "',tag,'" has been ignored!')
+        if tag not in childVals:
+          self.raiseAWarning('Unrecognized node in BasicStatistics "',tag,'" has been ignored!')
 
     assert (len(self.toDo)>0), self.raiseAnError(IOError, 'BasicStatistics needs parameters to work on! Please check input for PP: ' + self.name)
 

--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -53,7 +53,7 @@ class BasicStatistics(PostProcessorInterface):
                 'higherPartialVariance',   # Statistic metric not available yet
                 'higherPartialSigma',      # Statistic metric not available yet
                 'lowerPartialSigma',       # Statistic metric not available yet
-                'lowerPartialVariance'    # Statistic metric not available yet
+                'lowerPartialVariance'     # Statistic metric not available yet
                 ]
   vectorVals = ['sensitivity',
                 'covariance',
@@ -266,26 +266,27 @@ class BasicStatistics(PostProcessorInterface):
     inputMetaKeys = []
     outputMetaKeys = []
     for metric, infos in self.toDo.items():
-      steMetric = metric + '_ste'
-      if steMetric in self.steVals:
-        for info in infos:
-          prefix = info['prefix']
-          for target in info['targets']:
-            if metric == 'percentile':
-              for strPercent in info['strPercent']:
-                metaVar = prefix + '_' + strPercent + '_ste_' + target if not self.outputDataset else metric + '_' + strPercent + '_ste'
+      if metric in self.scalarVals + self.vectorVals:
+        steMetric = metric + '_ste'
+        if steMetric in self.steVals:
+          for info in infos:
+            prefix = info['prefix']
+            for target in info['targets']:
+              if metric == 'percentile':
+                for strPercent in info['strPercent']:
+                  metaVar = prefix + '_' + strPercent + '_ste_' + target if not self.outputDataset else metric + '_' + strPercent + '_ste'
+                  metaDim = inputObj.getDimensions(target)
+                  if len(metaDim[target]) == 0:
+                    inputMetaKeys.append(metaVar)
+                  else:
+                    outputMetaKeys.append(metaVar)
+              else:
+                metaVar = prefix + '_ste_' + target if not self.outputDataset else metric + '_ste'
                 metaDim = inputObj.getDimensions(target)
                 if len(metaDim[target]) == 0:
                   inputMetaKeys.append(metaVar)
                 else:
                   outputMetaKeys.append(metaVar)
-            else:
-              metaVar = prefix + '_ste_' + target if not self.outputDataset else metric + '_ste'
-              metaDim = inputObj.getDimensions(target)
-              if len(metaDim[target]) == 0:
-                inputMetaKeys.append(metaVar)
-              else:
-                outputMetaKeys.append(metaVar)
     metaParams = {}
     if not self.outputDataset:
       if len(outputMetaKeys) > 0:
@@ -304,7 +305,7 @@ class BasicStatistics(PostProcessorInterface):
     """
       Function to handle the parsed paramInput for this class.
       @ In, paramInput, ParameterInput, the already parsed input.
-      @ In, childVals, list, quantities requested from child statistical object
+      @ In, childVals, list, optional, quantities requested from child statistical object
       @ Out, None
     """
     self.toDo = {}

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -287,7 +287,6 @@ class EconomicRatio(BasicStatistics):
     indexL = utils.first(np.asarray(weightsCDF >= percent).nonzero())[0]
     return sortedWeightsAndPoints, indexL
 
-  # TODO: update if necessary
   def __runLocal(self, inputData):
     """
       This method executes the postprocessor action. In this case, it computes all the requested statistical FOMs
@@ -303,6 +302,9 @@ class EconomicRatio(BasicStatistics):
     needed.update(dict((metric,{'targets':set(),'threshold':{}}) for metric in ['sortinoRatio','gainLossRatio']))
     needed.update(dict((metric,{'targets':set(),'threshold':[]}) for metric in ['valueAtRisk', 'expectedShortfall']))
     for metric, params in self.toDo.items():
+      if metric in self.vectorVals:
+        # vectorVals handled in BasicStatistics, not here
+        continue
       for entry in params:
         needed[metric]['targets'].update(entry['targets'])
         if 'threshold' in entry.keys() :
@@ -329,9 +331,6 @@ class EconomicRatio(BasicStatistics):
     # sortinoRatio needs           | expectedValue,median   |
     # gainLossRatio needs          | expectedValue,median   |
 
-
-
-
     # update needed dictionary when standard errors are requested
     needed['expectedValue']['targets'].update(needed['sigma']['targets'])
     needed['expectedValue']['targets'].update(needed['variance']['targets'])
@@ -343,7 +342,6 @@ class EconomicRatio(BasicStatistics):
     needed['variance']['targets'].update(needed['sigma']['targets'])
     needed['median']['targets'].update(needed['sortinoRatio']['targets'])
     needed['median']['targets'].update(needed['gainLossRatio']['targets'])
-
 
     for metric, params in needed.items():
       needed[metric]['targets'] = list(params['targets'])

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -574,21 +574,3 @@ class EconomicRatio(BasicStatistics):
     inputData = self.inputToInternal(inputIn)
     outputSet = self.__runLocal(inputData)
     return outputSet
-
-  def collectOutput(self, finishedJob, output):
-    """
-      Function to place all of the computed data into the output object
-      @ In, finishedJob, JobHandler External or Internal instance, A JobHandler object that is in charge of running this post-processor
-      @ In, output, dataObjects, The object where we want to place our computed results
-      @ Out, None
-    """
-    evaluation = finishedJob.getEvaluation()
-    outputRealization = evaluation[1]
-    if output.type in ['PointSet','HistorySet']:
-      self.raiseADebug('Dumping output in data object named ' + output.name)
-      output.addRealization(outputRealization)
-    elif output.type in ['DataSet']:
-      self.raiseADebug('Dumping output in DataSet named ' + output.name)
-      output.load(outputRealization,style='dataset')
-    else:
-      self.raiseAnError(IOError, 'Output type ' + str(output.type) + ' unknown.')

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -114,12 +114,21 @@ class EconomicRatio(BasicStatistics):
         for info in infos:
           prefix = info["prefix"]
           for target in info["targets"]:
-            metaVar = prefix + "_ste_" + target if not self.outputDataset else metric + "_ste"
-            metaDim = inputObj.getDimensions(target)
-            if len(metaDim[target]) == 0:
-              inputMetaKeys.append(metaVar)
+            if metric == 'percentile':
+              for strPercent in info['strPercent']:
+                metaVar = prefix + '_' + strPercent + '_ste_' + target if not self.outputDataset else metric + '_' + strPercent + '_ste'
+                metaDim = inputObj.getDimensions(target)
+                if len(metaDim[target]) == 0:
+                  inputMetaKeys.append(metaVar)
+                else:
+                  outputMetaKeys.append(metaVar)
             else:
-              outputMetaKeys.append(metaVar)
+              metaVar = prefix + '_ste_' + target if not self.outputDataset else metric + '_ste'
+              metaDim = inputObj.getDimensions(target)
+              if len(metaDim[target]) == 0:
+                inputMetaKeys.append(metaVar)
+              else:
+                outputMetaKeys.append(metaVar)
     metaParams = {}
     if not self.outputDataset:
       if len(outputMetaKeys) > 0:

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -32,9 +32,13 @@ class EconomicRatio(BasicStatistics):
   """
     EconomicRatio filter class. It computes economic metrics
   """
+
+  # values from BasicStatistics
   scalarVals =   BasicStatistics.scalarVals
   vectorVals =   BasicStatistics.vectorVals
+  steVals    =   BasicStatistics.steVals
 
+  # economic/financial metrics
   tealVals   = ['sharpeRatio',             #financial metric
                 'sortinoRatio',            #financial metric
                 'gainLossRatio',           #financial metric

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -252,25 +252,6 @@ class EconomicRatio(BasicStatistics):
 
     return valsToAdd
 
-  # TODO: update if necessary
-  def __computePower(self, p, dataset):
-    """
-      Compute the p-th power of weights
-      @ In, p, int, the power
-      @ In, dataset, xarray.Dataset, probability weights of all input variables
-      @ Out, pw, xarray.Dataset, the p-th power of weights
-    """
-    pw = {}
-    coords = dataset.coords
-    for target, targValue in dataset.variables.items():
-      ##remove index variable
-      if target in coords:
-        continue
-      pw[target] = np.power(targValue,p)
-    pw = xr.Dataset(data_vars=pw,coords=coords)
-    return pw
-
-  # TODO: update if necessary
   def _computeSortedWeightsAndPoints(self,arrayIn,pbWeight,percent):
     """
       Method to compute the sorted weights and points
@@ -449,7 +430,7 @@ class EconomicRatio(BasicStatistics):
           zeroSet = orgZeroSet[list(zeroTarget)]
           dataSet = inputDataset[list(zeroTarget)]
           lowerPartialVarianceDS = self._computeLowerPartialVariance(dataSet,zeroSet,pbWeight=relWeight,dim=self.sampleTag)
-          lpsDS = self.__computePower(0.5,lowerPartialVarianceDS)
+          lpsDS = self._computePower(0.5,lowerPartialVarianceDS)
           incapableZeroTarget = [x for x in zeroTarget if not lpsDS[x].values != 0]
           for target in incapableZeroTarget:
             needed[metric]['threshold'][target].remove('zero')
@@ -464,7 +445,7 @@ class EconomicRatio(BasicStatistics):
           medSet = orgMedSet[list(medTarget)]
           dataSet = inputDataset[list(medTarget)]
           lowerPartialVarianceDS = self._computeLowerPartialVariance(dataSet,medSet,pbWeight=relWeight,dim=self.sampleTag)
-          lpsDS = self.__computePower(0.5,lowerPartialVarianceDS)
+          lpsDS = self._computePower(0.5,lowerPartialVarianceDS)
           incapableMedTarget = [x for x in medTarget if not lpsDS[x].values != 0]
           medTarget = [x for x in medTarget if not lpsDS[x].values == 0]
           if incapableMedTarget:
@@ -494,7 +475,6 @@ class EconomicRatio(BasicStatistics):
           zeroSet = orgZeroSet[list(zeroTarget)]
           dataSet = inputDataset[list(zeroTarget)]
 
-
           higherSet = (dataSet-zeroSet).clip(min=0)
           lowerSet = (zeroSet-dataSet).clip(min=0)
           relWeight = pbWeights[list(needed[metric]['targets'])] if self.pbPresent else None
@@ -516,13 +496,11 @@ class EconomicRatio(BasicStatistics):
           medSet = orgMedSet[list(medTarget)]
           dataSet = inputDataset[list(medTarget)]
 
-
           higherSet = (dataSet-medSet).clip(min=0)
           lowerSet = (medSet-dataSet).clip(min=0)
           relWeight = pbWeights[list(needed[metric]['targets'])] if self.pbPresent else None
           higherMeanSet = (higherSet * relWeight).sum(dim = self.sampleTag)
           lowerMeanSet = (lowerSet * relWeight).sum(dim = self.sampleTag)
-
 
           incapableMedTarget = [x for x in medTarget if not lowerMeanSet[x].values != 0]
           medTarget = [x for x in medTarget if not lowerMeanSet[x].values == 0]
@@ -533,7 +511,6 @@ class EconomicRatio(BasicStatistics):
           daMed = daMed.assign_coords(threshold ='median')
           daMed = daMed.expand_dims('threshold')
       calculations[metric] = xr.merge([daMed, daZero])
-
 
     for metric, ds in calculations.items():
       if metric in self.scalarVals + self.tealVals +['equivalentSamples'] and metric !='samples':
@@ -562,6 +539,7 @@ class EconomicRatio(BasicStatistics):
               continue
     if self.pivotParameter in outputSet.sizes.keys():
       outputDict[self.pivotParameter] = np.atleast_1d(self.pivotValue)
+
     return outputDict
 
   def run(self, inputIn):

--- a/framework/Models/PostProcessors/EconomicRatio.py
+++ b/framework/Models/PostProcessors/EconomicRatio.py
@@ -55,28 +55,24 @@ class EconomicRatio(BasicStatistics):
       @ Out, inputSpecification, InputData.ParameterInput, class to use for
         specifying input of cls.
     """
+
+    # get input specification from BasicStatistics (scalarVals and vectorVals)
     inputSpecification = super(EconomicRatio, cls).getInputSpecification()
 
-    for scalar in cls.scalarVals:
-      scalarSpecification = InputData.parameterInputFactory(scalar, contentType=InputTypes.StringListType)
-      scalarSpecification.addParam("prefix", InputTypes.StringType)
-      inputSpecification.addSub(scalarSpecification)
-
+    # add tealVals
     for teal in cls.tealVals:
-      tealSpecification = InputData.parameterInputFactory(teal, contentType=InputTypes.StringListType)
-      if teal in['sortinoRatio','gainLossRatio']:
+      tealSpecification = InputData.parameterInputFactory(teal,
+                                                          contentType=InputTypes.StringListType)
+      if teal in ["sortinoRatio", "gainLossRatio"]:
         tealSpecification.addParam("threshold", InputTypes.StringType)
-      elif teal in['expectedShortfall','valueAtRisk']:
+      elif teal in ["expectedShortfall", "valueAtRisk"]:
         tealSpecification.addParam("threshold", InputTypes.FloatType)
       tealSpecification.addParam("prefix", InputTypes.StringType)
       inputSpecification.addSub(tealSpecification)
 
-    pivotParameterInput = InputData.parameterInputFactory('pivotParameter', contentType=InputTypes.StringType)
-    inputSpecification.addSub(pivotParameterInput)
-
-
     return inputSpecification
 
+  # TODO: update if necessary
   def inputToInternal(self, currentInp):
     """
       Method to convert an input object into the internal format that is
@@ -131,6 +127,7 @@ class EconomicRatio(BasicStatistics):
       self.raiseAWarning('EconomicRatio postprocessor did not detect ProbabilityWeights! Assuming unit weights instead...')
     return inputDataset, pbWeights
 
+  # TODO: update if necessary
   def initialize(self, runInfo, inputs, initDict):
     """
       Method to initialize the EconomicRatio pp. In here the working dir is
@@ -160,6 +157,7 @@ class EconomicRatio(BasicStatistics):
     metaKeys = inputMetaKeys + outputMetaKeys
     self.addMetaKeys(metaKeys,metaParams)
 
+  # TODO: update if necessary
   def _localReadMoreXML(self, xmlNode):
     """
       Function to read the portion of the xml input that belongs to this specialized class
@@ -171,6 +169,7 @@ class EconomicRatio(BasicStatistics):
     paramInput.parseNode(xmlNode)
     self._handleInput(paramInput)
 
+  # TODO: update if necessary
   def _handleInput(self, paramInput):
     """
       Function to handle the parsed paramInput for this class.
@@ -253,6 +252,7 @@ class EconomicRatio(BasicStatistics):
 
     assert (len(self.toDo)>0), self.raiseAnError(IOError, 'EconomicRatio needs parameters to work on! Please check input for PP: ' + self.name)
 
+  # TODO: update if necessary
   def __computePower(self, p, dataset):
     """
       Compute the p-th power of weights
@@ -270,6 +270,7 @@ class EconomicRatio(BasicStatistics):
     pw = xr.Dataset(data_vars=pw,coords=coords)
     return pw
 
+  # TODO: update if necessary
   def _computeSortedWeightsAndPoints(self,arrayIn,pbWeight,percent):
     """
       Method to compute the sorted weights and points
@@ -286,6 +287,7 @@ class EconomicRatio(BasicStatistics):
     indexL = utils.first(np.asarray(weightsCDF >= percent).nonzero())[0]
     return sortedWeightsAndPoints, indexL
 
+  # TODO: update if necessary
   def __runLocal(self, inputData):
     """
       This method executes the postprocessor action. In this case, it computes all the requested statistical FOMs
@@ -568,6 +570,7 @@ class EconomicRatio(BasicStatistics):
       outputDict[self.pivotParameter] = np.atleast_1d(self.pivotValue)
     return outputDict
 
+  # TODO: update if necessary
   def run(self, inputIn):
     """
       This method executes the postprocessor action. In this case, it computes all the requested statistical FOMs


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#1752 

##### What are the significant changes in functionality due to this change request?

- Metrics from BasicStatistics are requestable using EconomicRatio alone
- Standard error for percentile (in BasicStatistics) implemented including addition of percent to percentile standard error variable name for clarity - e.g., `percentile_10_ste_x`
- Standard error for value at risk (in EconomicRatio) implemented
- Added threshold to variable names valueAtRisk (including standard error), expectedShortfall, gainLossRatio, and sortinoRatio for clarity (EconomicRatio) - e.g., `VaR_0.05_NPV`, `VaR_0.05_ste_NPV`, `es_0.10_NPV`, `gainLoss_zero_NPV`, `sort_median_NPV`

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

