### PR TITLE
fix the metadata info from Basic Statistics

### DIFF
--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -306,9 +306,9 @@ class BasicStatistics(PostProcessorInterface):
         for key in inputMetaKeys:
           # percentile standard error has additional index
           if key == 'percentile_ste':
-            params[key] = [self.pivotParameter, self.steMetaIndex, 'percent']
+            params[key] = [self.steMetaIndex, 'percent']
           else:
-            params[key] = [self.pivotParameter, self.steMetaIndex]
+            params[key] = [self.steMetaIndex]
         metaParams.update(params)
     metaKeys = inputMetaKeys + outputMetaKeys
     self.addMetaKeys(metaKeys,metaParams)

--- a/framework/utils/utils.py
+++ b/framework/utils/utils.py
@@ -696,7 +696,6 @@ def findCrowModule(name):
     @ In, name, str, the name of the module
     @ Out, module, instance, the instance of module of "name"
   """
-  print(sys.path)
   availableCrowModules = ['distribution1D','interpolationND','randomENG']
   # assert
   assert(name in availableCrowModules)
@@ -705,6 +704,7 @@ def findCrowModule(name):
     module = import_module("crow_modules.{}".format(name))
   except (ImportError, ModuleNotFoundError) as ie:
     if not str(ie).startswith("No module named"):
+      print('sys.path:', sys.path)
       raise ie
     module = import_module("{}".format(name))
   return module


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1771 

##### What are the significant changes in functionality due to this change request?
Try to fix the failure of LOGOS plugin. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

