### PR TITLE
Update ray

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -16,6 +16,8 @@ Note all install methods after "main" take
  add library from forge:     <library source='forge'>...
  optional:                   <library optional='True'>...
  skip run/install check:     <library skip_check='True'>...
+ add pip library with extra parameters:
+                             <ray source="pip" pip_extra="[tune]">1.9</ray>
 
  default OS is "all"
  default source is "conda" meaning main conda repo
@@ -54,7 +56,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <cmake skip_check='True' optional='True'/>
-    <ray os="mac,linux" source="pip">1.3</ray>
+    <ray os="mac,linux" source="pip" pip_extra="[default]">1.9</ray>
     <imageio>2.9</imageio>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -473,6 +473,9 @@ def _readLibNode(libNode, config, toRemove, opSys, addOptional, limitSources, re
   libVersion = text
   libSkipCheck = libNode.attrib.get('skip_check', None)
   request = {'skip_check': libSkipCheck, 'version': libVersion, 'requestor': requestor}
+  pipExtra = libNode.attrib.get('pip_extra', None)
+  if pipExtra is not None:
+    request['pip_extra'] = pipExtra
   # does this entry already exist?
   if tag in config:
     existing = config[tag]
@@ -637,8 +640,9 @@ if __name__ == '__main__':
         preamble = ''
 
     preamble = preamble.format(installer=installer, action=action, args=actionArgs)
-    libTexts = ' '.join(['{lib}{ver}'
+    libTexts = ' '.join(['{lib}{extra}{ver}'
                          .format(lib=lib,
+                                 extra=request['pip_extra'] if  installer.startswith('pip') and 'pip_extra' in request else '',
                                  ver=('{e}{r}{et}'.format(e=equals, r=request['version'], et=equalsTail) if request['version'] is not None else ''))
                          for lib, request in libs.items()])
     if len(libTexts) > 0:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#1598

##### What are the significant changes in functionality due to this change request?
Improves pip library installation ability and updates ray.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

