### PR TITLE
Speed up percentile standard error calculation

### DIFF
--- a/framework/Models/PostProcessors/BasicStatistics.py
+++ b/framework/Models/PostProcessors/BasicStatistics.py
@@ -999,20 +999,21 @@ class BasicStatistics(PostProcessorInterface):
         targDa = dataSet[target]
         if self.pivotParameter in targDa.sizes.keys():
           percentileSte = []
-          for pct in percent:
+          for label, group in targDa.groupby(self.pivotParameter):
             subPercentileSte = []
-            factor = np.sqrt(pct*(1.0 - pct)/en)
-            for label, group in targDa.groupby(self.pivotParameter):
-              if group.values.min() == group.values.max():
-                # all values are the same
+            if group.values.min() == group.values.max():
+              # all values are the same
+              for pct in percent:
                 subPercentileSte.append(0.0)
-              else:
-                # get KDE
-                kde = stats.gaussian_kde(group.values, weights=targWeight)
+            else:
+              # get KDE
+              kde = stats.gaussian_kde(group.values, weights=targWeight)
+              for pct in percent:
+                factor = np.sqrt(pct*(1.0 - pct)/en)
                 val = calculatedPercentiles[target].sel(**{'percent': pct, self.pivotParameter: label}).values
                 subPercentileSte.append(factor/kde(val)[0])
             percentileSte.append(subPercentileSte)
-          da = xr.DataArray(percentileSte, dims=('percent', self.pivotParameter), coords={'percent': percent, self.pivotParameter: self.pivotValue})
+          da = xr.DataArray(percentileSte, dims=(self.pivotParameter, 'percent'), coords={self.pivotParameter: self.pivotValue, 'percent': percent})
           percentileSteSet[target] = da
         else:
           calcPercentiles = calculatedPercentiles[target]


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1772 

##### What are the significant changes in functionality due to this change request?
Changes order of loops to minimize number of times KDEs are built to speed up calculation of percentile standard error.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

