### PR TITLE
Fix misc

### DIFF
--- a/framework/CodeInterfaces/Prescient/PrescientCodeInterface.py
+++ b/framework/CodeInterfaces/Prescient/PrescientCodeInterface.py
@@ -26,8 +26,8 @@ try:
   prescient = pkg_resources.get_distribution("prescient")
   prescientLocation = prescient.location
 except Exception as inst:
-  warnings.warn(f"Finding Prescient failed with {inst}")
   prescientLocation = None
+  prestientException = inst
 
 from CodeInterfaceBaseClass import CodeInterfaceBase
 
@@ -52,6 +52,8 @@ class Prescient(CodeInterfaceBase):
       @ In, preExec, string, optional, a string the command that needs to be pre-executed before the actual command here defined
       @ Out, returnCommand, tuple, tuple containing the generated command. returnCommand[0] is a list of commands to run the code (string), returnCommand[1] is the name of the output root
     """
+    if prescientLocation is None:
+      warnings.warn(f"Finding Prescient failed with {prestientException}")
     runnerInput = []
     for inp in inputFiles:
       if inp.getType() == 'PrescientRunnerInput':
@@ -69,6 +71,8 @@ class Prescient(CodeInterfaceBase):
             where RAVEN stores the variables that got sampled (e.g. Kwargs['SampledVars'] => {'var1':10,'var2':40})
       @ Out, newInputFiles, list, list of newer input files, list of the new input files (modified and not)
     """
+    if prescientLocation is None:
+      warnings.warn(f"Finding Prescient failed with {prestientException}")
     self._outputDirectory = None
     for singleInput in inputs:
       if singleInput.getType() == 'PrescientRunnerInput':

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -57,7 +57,7 @@ function find_conda_defs ()
     if [[ ${#CONDA_DEFS} == 0 ]];
     then
       # default location of conda definitions, windows is unsurprisingly an exception
-      if [[ "$OSOPTION" = "--windows" ]];
+      if [[ "$OSOPTION" = "--os windows" ]];
       then
         CONDA_DEFS="/c/ProgramData/Miniconda3/etc/profile.d/conda.sh";
       elif test -e "$HOME/miniconda3/etc/profile.d/conda.sh";


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes  #1785

##### What are the significant changes in functionality due to this change request?
Fixes test to find windows conda defs.
Also removes Prescient warning when not needed.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

