### PR TITLE
[WIP] trying to keep elite parents

### DIFF
--- a/framework/Optimizers/GradientDescent.py
+++ b/framework/Optimizers/GradientDescent.py
@@ -62,7 +62,7 @@ class GradientDescent(RavenSampled):
      - Implement summary of step iteration to SolutionExport
   """
   # convergence option names and their user manual descriptions
-  convergenceOptions = {'gradient': r"""provides the desired value for the local estimated of the gradient
+  convergenceOptions = {'gradient': r"""provides the desired value for the local estimation of the gradient
                                     for convergence. \default{1e-6, if no criteria specified}""",
                         # TODO change in input space?
                         'objective': r"""provides the maximum relative change in the objective function for convergence.""",

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/testGAMinwoRep.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/testGAMinwoRep.xml
@@ -55,7 +55,7 @@
   <Optimizers>
     <GeneticAlgorithm name="GAopt">
       <samplerInit>
-        <limit>10</limit>
+        <limit>25</limit>
         <initialSeed>42</initialSeed>
         <writeSteps>every</writeSteps>
         <type>min</type>

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/testGAMinwoRepConvAHDp.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/testGAMinwoRepConvAHDp.xml
@@ -56,7 +56,7 @@
   <Optimizers>
     <GeneticAlgorithm name="GAopt">
       <samplerInit>
-        <limit>10</limit>
+        <limit>25</limit>
         <initialSeed>42</initialSeed>
         <writeSteps>every</writeSteps>
         <type>min</type>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

