### PR TITLE
Closes #1793

### DIFF
--- a/framework/contrib/__init__.py
+++ b/framework/contrib/__init__.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Created on September 16, 2015
-@author: maljdp
+Created on March 20, 2022
+@author: aalfonsi
 """
-from .CustomDrivers.PythonRaven import Raven # allows from framework import Raven
 # This file is necessary so that the sub-modules understand the correct hierarchy
-# of things.
-
+# of the contrib modules. 

--- a/framework/contrib/pyDOE/build_regression_matrix.py
+++ b/framework/contrib/pyDOE/build_regression_matrix.py
@@ -21,7 +21,7 @@ def grep(haystack, needle):
     
     Returns
     -------
-    R : 2d-array
+    start : int
     
     """
     start = 0

--- a/framework/contrib/pyDOE/build_regression_matrix.py
+++ b/framework/contrib/pyDOE/build_regression_matrix.py
@@ -16,6 +16,14 @@ Abraham Lee.
 import numpy as np
 
 def grep(haystack, needle):
+    """
+    Grep element from haystack
+    
+    Returns
+    -------
+    R : 2d-array
+    
+    """
     start = 0
     while True:
         start = haystack.find(needle, start)

--- a/framework/contrib/pyDOE/build_regression_matrix.py
+++ b/framework/contrib/pyDOE/build_regression_matrix.py
@@ -17,7 +17,10 @@ import numpy as np
 
 def grep(haystack, needle):
     """
-    Grep element from haystack
+    Grep element from haystack.
+    Find the index of the char 
+    'needle' in the string hystack
+    and return it as 'start'
     
     Returns
     -------


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1793

##### What are the significant changes in functionality due to this change request?
added ```__init__``` file in contrib directory

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

