### PR TITLE
Fix ability for plugins to find the crow module

### DIFF
--- a/ravenframework/CustomDrivers/DriverUtils.py
+++ b/ravenframework/CustomDrivers/DriverUtils.py
@@ -98,11 +98,15 @@ def setupCpp():
     @ Out, None
   """
   frameworkDir = findFramework()
-  from ravenframework.utils import utils
-  utils.find_crow(frameworkDir)
-  utils.add_path(os.path.join(frameworkDir,'contrib'))
-  ##TODO REMOVE PP3 WHEN RAY IS AVAILABLE FOR WINDOWS
-  utils.add_path_recursively(os.path.join(frameworkDir,'contrib','pp'))
+  ravenDir = os.path.dirname(frameworkDir)
+  if any(os.path.normcase(sp) == os.path.join(ravenDir, 'crow') for sp in sys.path):
+    print(f'WARNING: "{os.path.join(ravenDir, "crow")}" already in system path. Skipping CPP setup')
+  else:
+    from ravenframework.utils import utils
+    utils.find_crow(frameworkDir)
+    utils.add_path(os.path.join(frameworkDir,'contrib'))
+    ##TODO REMOVE PP3 WHEN RAY IS AVAILABLE FOR WINDOWS
+    utils.add_path_recursively(os.path.join(frameworkDir,'contrib','pp'))
 
 def checkVersions():
   """

--- a/ravenframework/CustomDrivers/DriverUtils.py
+++ b/ravenframework/CustomDrivers/DriverUtils.py
@@ -98,12 +98,13 @@ def setupCpp():
     @ Out, None
   """
   frameworkDir = findFramework()
-  ravenDir = os.path.dirname(frameworkDir)
-  if any(os.path.normcase(sp) == os.path.join(ravenDir, 'crow') for sp in sys.path):
-    print(f'WARNING: "{os.path.join(ravenDir, "crow")}" already in system path. Skipping CPP setup')
+
+  from ravenframework.utils import utils
+  utils.find_crow(frameworkDir)
+
+  if any(os.path.normcase(sp) == os.path.join(frameworkDir,'contrib') for sp in sys.path):
+    print(f'WARNING: "{os.path.join(frameworkDir,"contrib")}" already in system path. Skipping CPP setup')
   else:
-    from ravenframework.utils import utils
-    utils.find_crow(frameworkDir)
     utils.add_path(os.path.join(frameworkDir,'contrib'))
     ##TODO REMOVE PP3 WHEN RAY IS AVAILABLE FOR WINDOWS
     utils.add_path_recursively(os.path.join(frameworkDir,'contrib','pp'))

--- a/ravenframework/CustomDrivers/DriverUtils.py
+++ b/ravenframework/CustomDrivers/DriverUtils.py
@@ -98,7 +98,7 @@ def setupCpp():
     @ Out, None
   """
   frameworkDir = findFramework()
-  from utils import utils
+  from ravenframework.utils import utils
   utils.find_crow(frameworkDir)
   utils.add_path(os.path.join(frameworkDir,'contrib'))
   ##TODO REMOVE PP3 WHEN RAY IS AVAILABLE FOR WINDOWS

--- a/ravenframework/utils/randomUtils.py
+++ b/ravenframework/utils/randomUtils.py
@@ -27,6 +27,7 @@ import numpy as np
 
 from .utils import findCrowModule
 from . import mathUtils
+from ..CustomDrivers.DriverUtils import setupCpp
 
 # in general, we will use Crow for now, but let's make it easy to switch just in case it is helpful eventually.
 # Numpy stochastic environment can not pass the test as this point
@@ -87,6 +88,7 @@ class BoxMullerGenerator:
 if stochasticEnv == 'numpy':
   npStochEnv = np.random.RandomState()
 else:
+  setupCpp()
   crowStochEnv = findCrowModule('randomENG').RandomClass()
   # this is needed for now since we need to split the stoch environments
   distStochEnv = findCrowModule('distribution1D').DistributionContainer.instance()


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

#1764

##### What are the significant changes in functionality due to this change request?

This just ensures that the crow module path is correctly specified before trying to find the crow module in `utils.randomUtils.py`

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

