### PR TITLE
Fixing framework path.

### DIFF
--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -36,8 +36,8 @@ else
     cd $BUILD_DIR
     #SHA256=56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1
     $DOWNLOADER https://files.pythonhosted.org/packages/35/fe/e7df7289d717426093c68d156e0fd9117c8f4872b6588e8a8928a0f68424/coverage-4.5.1.tar.gz
-    tar -xvzf coverage-3.7.1.tar.gz
-    cd coverage-3.7.1
+    tar -xvzf coverage-4.5.1.tar.gz
+    cd coverage-4.5.1
     (unset CC CXX; $PYTHON_CMD setup.py install --prefix=$INSTALL_DIR)
 fi
 
@@ -46,7 +46,7 @@ update_python_path
 cd $SCRIPT_DIR
 
 #coverage help run
-FRAMEWORK_DIR=`(cd framework && pwd)`
+FRAMEWORK_DIR=`(cd ravenframework && pwd)`
 
 source $SCRIPT_DIR/scripts/establish_conda_env.sh --quiet --load
 # get display var


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
#1764 


##### What are the significant changes in functionality due to this change request?
Fixes cd to find framework since it is now ravenframework
Also, fixes building command.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

