### PR TITLE
Cloud Plot by "year"

### DIFF
--- a/ravenframework/OutStreams/PlotInterfaces/SyntheticCloud.py
+++ b/ravenframework/OutStreams/PlotInterfaces/SyntheticCloud.py
@@ -132,7 +132,7 @@ class SyntheticCloud(PlotInterface):
         axes = [axes]
       axes[-1].set_xlabel(self.microName)
 
-      mSamples = samples.drop_sel({self.macroName: mac})
+      mSamples = samples.sel({self.macroName: mac}, drop=True)
       mTraining = None
       if self.macroName in training:
         if int(mac) in training[self.macroName]:
@@ -145,6 +145,8 @@ class SyntheticCloud(PlotInterface):
         # plot cloud of sample data
         for s in mSamples[sTag].values:
           samp = mSamples[{sTag: s}]
+          print(f'DEBUGG m: {m}, v: {v} {var}, s: {s}, samp.micro.shape: {samp[self.microName].values.shape}, ' +
+              f'samp.var.shape: {samp[var].values.shape}')
           ax.plot(samp[self.microName].values, samp[var].values, 'b-.', alpha=alpha)
         ax.set_title(f'{var}, {self.macroName} {int(mac)}')
         ax.set_ylabel(var)

--- a/ravenframework/OutStreams/PlotInterfaces/SyntheticCloud.py
+++ b/ravenframework/OutStreams/PlotInterfaces/SyntheticCloud.py
@@ -145,8 +145,6 @@ class SyntheticCloud(PlotInterface):
         # plot cloud of sample data
         for s in mSamples[sTag].values:
           samp = mSamples[{sTag: s}]
-          print(f'DEBUGG m: {m}, v: {v} {var}, s: {s}, samp.micro.shape: {samp[self.microName].values.shape}, ' +
-              f'samp.var.shape: {samp[var].values.shape}')
           ax.plot(samp[self.microName].values, samp[var].values, 'b-.', alpha=alpha)
         ax.set_title(f'{var}, {self.macroName} {int(mac)}')
         ax.set_ylabel(var)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1812

##### What are the significant changes in functionality due to this change request?
Plots the correct macro data.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

