### PR TITLE
fix truncated lognorm distribution

### DIFF
--- a/ravenframework/Distributions.py
+++ b/ravenframework/Distributions.py
@@ -2562,14 +2562,14 @@ class LogNormal(BoostDistribution):
     """
     if self.lowerBoundUsed == False and self.upperBoundUsed == False:
       self._distribution = distribution1D.BasicLogNormalDistribution(self.mean,self.sigma,self.low)
-      self.lowerBound = -sys.float_info.max
+      self.lowerBound = 0.0
       self.upperBound =  sys.float_info.max
     else:
       if self.lowerBoundUsed == False:
         self.lowerBound = self.low
       if self.upperBoundUsed == False:
         self.upperBound = sys.float_info.max
-      self._distribution = distribution1D.BasicLogNormalDistribution(self.mean,self.sigma,self.low,self.lowerBound,self.upperBound)
+      self._distribution = distribution1D.BasicLogNormalDistribution(self.mean,self.sigma,self.lowerBound,self.upperBound, self.low)
 
 DistributionsCollection.addSub(LogNormal.getInputSpecification())
 

--- a/tests/framework/unit_tests/Distributions/TestDistributions.py
+++ b/tests/framework/unit_tests/Distributions/TestDistributions.py
@@ -865,14 +865,47 @@ checkAnswer("plogNormal ppf(0.5)",plogNormal.ppf(0.5),20.0855369232)
 lowlogNormalElement = ET.Element("LogNormal",{"name":"test"})
 lowlogNormalElement.append(createElement("mean",text="3.0"))
 lowlogNormalElement.append(createElement("sigma",text="2.0"))
-lowlogNormalElement.append(createElement("lowerBound",text="0.0"))
+lowlogNormalElement.append(createElement("lowerBound",text="0.1"))
 lowlogNormal = getDistribution(lowlogNormalElement)
+
+checkAnswer("lower bound logNormal cdf(2.0)",lowlogNormal.cdf(2.0),0.12084297139220623)
+checkAnswer("lower bound logNormal cdf(1.0)",lowlogNormal.cdf(1.0),0.06305076776893374)
+checkAnswer("lower bound logNormal cdf(3.0)",lowlogNormal.cdf(3.0),0.16754240030151715)
+
+checkAnswer("lower bound logNormal ppf(0.1243677033)",lowlogNormal.ppf(0.124367703363),2.0689561223850608)
+checkAnswer("lower bound logNormal ppf(0.1)",lowlogNormal.ppf(0.1),1.612019592300385)
+checkAnswer("lower bound logNormal ppf(0.5)",lowlogNormal.ppf(0.5),20.288407440410438)
 
 uplogNormalElement = ET.Element("LogNormal",{"name":"test"})
 uplogNormalElement.append(createElement("mean",text="3.0"))
 uplogNormalElement.append(createElement("sigma",text="2.0"))
 uplogNormalElement.append(createElement("upperBound",text="10.0"))
 uplogNormal = getDistribution(uplogNormalElement)
+
+checkAnswer("upper bound logNormal cdf(2.0)",uplogNormal.cdf(2.0),0.34199415173322556)
+checkAnswer("upper bound logNormal cdf(1.0)",uplogNormal.cdf(1.0),0.18371065405065226)
+checkAnswer("upper bound logNormal cdf(3.0)",uplogNormal.cdf(3.0),0.46989633375986495)
+
+checkAnswer("upper bound logNormal ppf(0.1243677033)",uplogNormal.ppf(0.124367703363),0.6797582141162679)
+checkAnswer("upper bound logNormal ppf(0.1)",uplogNormal.ppf(0.1),0.5548644649676321)
+checkAnswer("upper bound logNormal ppf(0.5)",uplogNormal.ppf(0.5),3.2646509377679664)
+
+#Test Truncated log normal with both lower bound and uper bound
+logNormalElement = ET.Element("LogNormal",{"name":"test"})
+logNormalElement.append(createElement("mean",text="0"))
+logNormalElement.append(createElement("sigma",text="0.5"))
+logNormalElement.append(createElement("lowerBound",text="0.1"))
+logNormalElement.append(createElement("upperBound",text="10.0"))
+logNormal = getDistribution(logNormalElement)
+
+
+checkAnswer("lower and upper bound logNormal cdf(2.0)",logNormal.cdf(2.0),0.9171732002887018)
+checkAnswer("lower and upper bound logNormal cdf(1.0)",logNormal.cdf(1.0),0.49999999999999994)
+checkAnswer("lower and upper bound logNormal cdf(3.0)",logNormal.cdf(3.0),0.9859997973706007)
+
+checkAnswer("lower and upper bound logNormal ppf(0.1243677033)",logNormal.ppf(0.124367703363),0.561743785147457)
+checkAnswer("lower and upper bound logNormal ppf(0.1)",logNormal.ppf(0.1),0.5268859928837893)
+checkAnswer("lower and upper bound logNormal ppf(0.5)",logNormal.ppf(0.5),1.0)
 
 #shift log normal
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #1814 

##### What are the significant changes in functionality due to this change request?
Truncated lognormal distribution is not generate the correct samples, cdf, pdf, ppf values. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

