### PR TITLE
Parallel improvements

### DIFF
--- a/ravenframework/CodeInterfaces/RAVEN/RAVENInterface.py
+++ b/ravenframework/CodeInterfaces/RAVEN/RAVENInterface.py
@@ -268,8 +268,9 @@ class RAVEN(CodeInterfaceBase):
           raise IOError(self.printTag+' ERROR: The nodefile "'+str(nodeFileToUse)+'" and PBS_NODEFILE enviroment var do not exist!')
         else:
           nodeFileToUse = os.environ["PBS_NODEFILE"]
-      modifDict['RunInfo|mode'           ] = 'mpi'
-      modifDict['RunInfo|mode|nodefile'  ] = nodeFileToUse
+      if len(parser.tree.findall('./RunInfo/mode')) == 1:
+        #If there is a mode node, give it a nodefile.
+        modifDict['RunInfo|mode|nodefile'  ] = nodeFileToUse
     if internalParallel or newBatchSize > 1:
       # either we have an internal parallel or NumMPI > 1
       modifDict['RunInfo|batchSize'] = newBatchSize

--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -335,7 +335,7 @@ class JobHandler(BaseType):
     address, redisPassword = None, None
     with open(rayLog, 'r') as rayLogObj:
       for line in rayLogObj.readlines():
-        if "ray start" in line.strip():
+        if " ray start" in line.strip():
           ix = line.strip().find("ray start")
           address, redisPassword = line.strip()[ix:].replace("ray start","").strip().split()
           redisPassword = redisPassword.split("=")[-1].replace("'","")

--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -424,6 +424,11 @@ class JobHandler(BaseType):
           utils.pickleSafeSubprocessPopen(['ssh',nodeId,"COMMAND='"+command+"'","RAVEN_FRAMEWORK_DIR='"+self.runInfoDict["FrameworkDir"]+"'",self.runInfoDict['RemoteRunCommand']],shell=True,env=localEnv)
         ## update list of servers
         servers.append(nodeId)
+      if _rayAvail:
+        #wait for the servers to finish starting (prevents zombies)
+        for nodeId in uniqueNodes:
+          self.remoteServers[nodeId].wait()
+          self.raiseADebug("server "+str(nodeId)+" result: "+str(self.remoteServers[nodeId]))
 
     return servers
 

--- a/ravenframework/Models/Code.py
+++ b/ravenframework/Models/Code.py
@@ -575,6 +575,8 @@ class Code(Model):
     elif not self.code.getRunOnShell():
       command = self._expandCommand(command)
     self.raiseADebug(f'shell execution command: "{command}"')
+    self.raiseADebug('shell cwd: "'+localenv['PWD']+'"')
+    self.raiseADebug('self pid:' + str(os.getpid())+' ppid: '+str(os.getppid()))
     ## reset python path
     localenv.pop('PYTHONPATH',None)
     ## This code should be evaluated by the job handler, so it is fine to wait
@@ -595,6 +597,8 @@ class Code(Model):
       process.wait()
 
     returnCode = process.returncode
+    self.raiseADebug(" Process "+str(process.pid)+" finished "+time.ctime()+
+                     " with returncode "+str(process.returncode))
     # procOutput = process.communicate()[0]
 
     ## If the returnCode is already non-zero, we should maintain our current

--- a/ravenframework/RemoteNodeScripts/server_start.py
+++ b/ravenframework/RemoteNodeScripts/server_start.py
@@ -43,8 +43,9 @@ if re.search("lib.python", pythonPath):
   for part in splitted:
     if not re.search("lib.python", part):
       newpath.append(part)
+    else:
+      print("removepath :", part, file=out)
   pythonPath = os.pathsep.join(newpath)
-  print("adjusted pythonpath:",pythonPath)
 os.environ["PYTHONPATH"] = pythonPath
 
 #Close standard in, out, and error

--- a/ravenframework/Simulation.py
+++ b/ravenframework/Simulation.py
@@ -505,7 +505,11 @@ class Simulation(MessageUser):
       #Copy in all the new keys
       self.runInfoDict[key] = newRunInfo[key]
     self.jobHandler.applyRunInfo(self.runInfoDict)
-    self.jobHandler.initialize()
+    self.__remoteRunCommand = self.__modeHandler.remoteRunCommand(dict(self.runInfoDict))
+    if self.__remoteRunCommand is None:
+      #If __remoteRunCommand is None, then we are *not* going to run remotely,
+      # so need to start jobhandler stuff
+      self.jobHandler.initialize()
     # only print the dictionaries when the verbosity is set to debug
     #if self.verbosity == 'debug': self.printDicts()
     for stepName, stepInstance in self.stepsDict.items():
@@ -810,13 +814,13 @@ class Simulation(MessageUser):
     #can we remove the check on the existence of the file, it might make more sense just to check in case they are input and before the step they are used
     self.raiseADebug('entering the run')
     #controlling the PBS environment
-    remoteRunCommand = self.__modeHandler.remoteRunCommand(dict(self.runInfoDict))
-    if remoteRunCommand is not None:
-      subprocess.call(args=remoteRunCommand["args"],
-                      cwd=remoteRunCommand.get("cwd", None),
-                      env=remoteRunCommand.get("env", None))
+    if self.__remoteRunCommand is not None:
+      subprocess.call(args=self.__remoteRunCommand["args"],
+                      cwd=self.__remoteRunCommand.get("cwd", None),
+                      env=self.__remoteRunCommand.get("env", None))
       self.raiseADebug('Submitted in queue! Shutting down Jobhandler!')
-      self.jobHandler.shutdown()
+      #Note that jobhandler has not been initialized,
+      # so no need to call self.jobHandler.shutdown()
       return
     # initialize, then execute, steps
     for stepName in self.__stepSequenceList:

--- a/ravenframework/Simulation.py
+++ b/ravenframework/Simulation.py
@@ -20,6 +20,7 @@ import sys
 import io
 import string
 import datetime
+import time
 import numpy as np
 import threading
 
@@ -823,6 +824,7 @@ class Simulation(MessageUser):
       self.executeStep(stepInputDict, stepInstance)
     # finalize the simulation
     self.finalizeSimulation()
+    self.raiseADebug(time.ctime())
     self.raiseAMessage('Run complete!', forcePrint=True)
     return 0
 
@@ -880,3 +882,6 @@ class Simulation(MessageUser):
     """
     with open('.ravenStatus', 'w') as f:
       f.writelines('Success')
+      #force it to disk
+      f.flush()
+      os.fsync(f.fileno())

--- a/tests/cluster_tests/RavenRunsRaven/Code/inner.xml
+++ b/tests/cluster_tests/RavenRunsRaven/Code/inner.xml
@@ -4,8 +4,8 @@
   <RunInfo>
     <WorkingDir>Inner</WorkingDir>
     <Sequence>sample, aggregate, print</Sequence>
+    <internalParallel>True</internalParallel>
     <batchSize>4</batchSize>
-    <NodeParameter>--hostfile</NodeParameter>
   </RunInfo>
 
   <Steps>

--- a/tests/cluster_tests/RavenRunsRaven/code.xml
+++ b/tests/cluster_tests/RavenRunsRaven/code.xml
@@ -20,8 +20,8 @@
     <JobName>RrR_Code_o</JobName>
     <WorkingDir>Code</WorkingDir>
     <Sequence>sample, print</Sequence>
-    <batchSize>2</batchSize>
-    <NumMPI>4</NumMPI>
+    <batchSize>8</batchSize>
+    <NumMPI>8</NumMPI>
     <mode>
       mpi
       <runQSUB/>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#1809

##### What are the significant changes in functionality due to this change request?
Various changes to improve the parallel and debugging the parallel.
1. Prior to this, using RavenRunsRaven always switches on MPI mode.  This causes them to run with mpiexec, when they might want to be run with ray.
2. This now waits for ray servers to finish starting.  Before, RAVEN ignored them and they became zombies.
3. This adds various debugging information that is useful for diagnosing parallel problems.
4. The RavenRunRaven code is switched to internal parallel on the inner to test inner raven runs raven with internalParallel. It also increases it to 8 x 8 so that it will always run on more than one node.
5. Requests that ray find an available port, instead of always using 6379.
6. Don't start ray if we are just doing a remote run (as in don't start ray, then do a qsub, then shutdown ray, then in the qsub'd raven start ray again)

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

