### PR TITLE
What on earth

### DIFF
--- a/tests/framework/unit_tests/CustomDrivers/TestPythonRaven.py
+++ b/tests/framework/unit_tests/CustomDrivers/TestPythonRaven.py
@@ -22,6 +22,9 @@ import os
 import sys
 import unittest
 
+#if importing matplotlib is removed, this test fails on sawtooth
+import matplotlib.pyplot as plt
+
 frameworkDir = os.path.abspath(os.path.join(*([os.path.dirname(__file__)]+[os.pardir]*4)))
 sys.path.append(frameworkDir)
 

--- a/tests/framework/unit_tests/Optimizers/testFiniteDifference.py
+++ b/tests/framework/unit_tests/Optimizers/testFiniteDifference.py
@@ -18,6 +18,8 @@ import os
 import sys
 
 import numpy as np
+#if importing matplotlib is removed, this test fails on sawtooth
+import matplotlib.pyplot as plt
 
 ravenPath = os.path.abspath(os.path.join(__file__, *['..'] * 5))
 print('... located RAVEN at:', ravenPath)


### PR DESCRIPTION
fixes things on sawtooth.

--------
Pull Request Description
--------
##### What issue does this change request address? 



##### What are the significant changes in functionality due to this change request?
This is a dark arts patch that should probably not be merged if a better way to fix the regression tests on sawtooth is found.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

