### PR TITLE
Fmu work

### DIFF
--- a/ravenframework/contrib/PythonFMU/pythonfmu/pythonfmu-export/CMakeLists.txt
+++ b/ravenframework/contrib/PythonFMU/pythonfmu/pythonfmu-export/CMakeLists.txt
@@ -71,10 +71,15 @@ if (WIN32)
         PRIVATE
         ${Python3_LIBRARIES}
         )
-else ()
+elseif (APPLE)
   target_link_libraries(pythonfmu-export
         PRIVATE
         Python3::Module
+        )
+else ()
+  target_link_libraries(pythonfmu-export
+        PRIVATE
+        Python3::Python
         )
 endif ()
 

--- a/ravenframework/contrib/PythonFMU/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
+++ b/ravenframework/contrib/PythonFMU/pythonfmu/pythonfmu-export/cpp/PySlaveInstance.cpp
@@ -99,6 +99,10 @@ void PySlaveInstance::clearLogBuffer() const
 {
     clearLogStrBuffer();
 
+    if (pMessages_ == NULL) {
+      return;
+    }
+
     PyObject* debugField = Py_BuildValue("s", "debug");
     PyObject* msgField = Py_BuildValue("s", "msg");
     PyObject* categoryField = Py_BuildValue("s", "category");

--- a/tests/framework/Models/External/load_and_run_fmu.py
+++ b/tests/framework/Models/External/load_and_run_fmu.py
@@ -115,7 +115,7 @@ def simulateCustomInputFMU(fmuFilename,pathToRaven,show_plot=True):
 if __name__ == '__main__':
   import os
   fmuFilename = './SerializeWrkd/attenuate_pk2.fmu'
-  pathToRaven = os.sep.join(['..','..','..','..'])+os.sep+"framework"
+  pathToRaven = os.path.abspath(os.sep.join(['..','..','..','..']))
   print("Loading", fmuFilename)
   print("pathToRaven", pathToRaven)
   simulateCustomInputFMU(fmuFilename, pathToRaven, False)

--- a/tests/framework/Models/External/load_and_run_rom_fmu.py
+++ b/tests/framework/Models/External/load_and_run_rom_fmu.py
@@ -116,7 +116,7 @@ def simulateCustomInputFMU(fmuFilename,pathToRaven,show_plot=True):
 if __name__ == '__main__':
   import os
   fmuFilename = './FMURom/rom_out.fmu'
-  pathToRaven = os.sep.join(['..','..','..','..'])+os.sep+"framework"
+  pathToRaven = os.path.abspath(os.sep.join(['..','..','..','..']))
   print("Loading", fmuFilename)
   print("pathToRaven", pathToRaven)
   simulateCustomInputFMU(fmuFilename, pathToRaven, False)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes  #2023

##### What are the significant changes in functionality due to this change request?
Various bug fixes for FMU generation.
Continues work from https://github.com/idaholab/raven/pull/1481

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

