### PR TITLE
Catch RayTaskError and add debug info

### DIFF
--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -811,6 +811,24 @@ class JobHandler(BaseType):
     activeRuns = sum(run is not None for run in self.__running)
     return activeRuns
 
+  def numRunningTotal(self):
+    """
+      Returns the number of runs currently running in both lists.
+      @ In, None
+      @ Out, activeRuns, int, number of active runs
+    """
+    activeRuns = sum(run is not None for run in self.__running + self.__clientRunning)
+    return activeRuns
+
+  def _numQueuedTotal(self):
+    """
+      Returns the number of runs currently waiting in both queues.
+      @ In, None
+      @ Out, queueSize, int, number of runs in queue
+    """
+    queueSize = len(self.__queue) + len(self.__clientQueue)
+    return queueSize
+
   def numSubmitted(self):
     """
       Method to get the number of submitted jobs

--- a/ravenframework/Runners/DistributedMemoryRunner.py
+++ b/ravenframework/Runners/DistributedMemoryRunner.py
@@ -75,6 +75,11 @@ class DistributedMemoryRunner(InternalRunner):
           return True
         except ray.exceptions.GetTimeoutError:
           return False
+        except ray.exceptions.RayTaskError:
+          #The code gets this undocumented error, and
+          # I assume it means the task has unfixably died,
+          # and so is done
+          return True
         #Alternative that was tried:
         #return self.thread in ray.wait([self.thread], timeout=waitTimeOut)[0]
         #which ran slower in ray 1.9

--- a/ravenframework/Steps/MultiRun.py
+++ b/ravenframework/Steps/MultiRun.py
@@ -253,7 +253,7 @@ class MultiRun(SingleRun):
       currentTime = time.time()
       if currentTime > nextReportTime:
         nextReportTime = currentTime + reportDeltaTime
-        self.raiseADebug("Continuing to run. isFinished: %r running: %d unclaimed runs: %d" % (jobHandler.isFinished(), jobHandler.numRunning(), len(jobHandler.getFinishedNoPop())))
+        self.raiseADebug("Continuing to run. isFinished: %r running: %d %d unclaimed runs: %d queued: %d" % (jobHandler.isFinished(), jobHandler.numRunningTotal(), jobHandler.numRunning(), len(jobHandler.getFinishedNoPop()), jobHandler._numQueuedTotal()))
       # Note: calling amIreadyToProvideAnInput can change results,
       #  but might be helpful for debugging sometimes
       # "sampler ready with input: %r" sampler.amIreadyToProvideAnInput()

--- a/ravenframework/Steps/MultiRun.py
+++ b/ravenframework/Steps/MultiRun.py
@@ -253,7 +253,14 @@ class MultiRun(SingleRun):
       currentTime = time.time()
       if currentTime > nextReportTime:
         nextReportTime = currentTime + reportDeltaTime
-        self.raiseADebug("Continuing to run. isFinished: %r running: %d %d unclaimed runs: %d queued: %d" % (jobHandler.isFinished(), jobHandler.numRunningTotal(), jobHandler.numRunning(), len(jobHandler.getFinishedNoPop()), jobHandler._numQueuedTotal()))
+        numRunning = jobHandler.numRunning()
+        numTotalRunning = jobHandler.numRunningTotal()
+        self.raiseADebug("Continuing to run. isFinished: %r running: %d rest running: %d unclaimed runs: %d queued: %d" % \
+                         (jobHandler.isFinished(), numRunning,
+                          numTotalRunning - numRunning,
+                          len(jobHandler.getFinishedNoPop()),
+                          jobHandler._numQueuedTotal())
+                         )
       # Note: calling amIreadyToProvideAnInput can change results,
       #  but might be helpful for debugging sometimes
       # "sampler ready with input: %r" sampler.amIreadyToProvideAnInput()


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #1851


##### What are the significant changes in functionality due to this change request?
Handles a RayTaskError, and adds some extra debugging information.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

