### PR TITLE
Added setAddtionalParams method to externalROMLoader

### DIFF
--- a/scripts/externalROMloader.py
+++ b/scripts/externalROMloader.py
@@ -120,6 +120,21 @@ class ravenROMexternal(object):
     self._frameworkLoc = d['whereFrameworkIs']
     self._load(self._binaryLoc, self._frameworkLoc)
 
+  def setAdditionalParams(self, nodes):
+    '''
+    Set ROM parameters for external evaluation
+    @ In, nodes, list, list of xml nodes for setting parameters of pickleROM
+    @ Out, None
+    '''
+    from ravenframework.SupervisedLearning.pickledROM import pickledROM
+    spec = pickledROM.getInputSpecification()()
+    # Changing parameters for the ROM
+    for node in nodes:
+      spec.parseNode(node)
+    # Matching the index name of the defaul params object
+    params = {'paramInput':spec}
+    self.rom.setAdditionalParams(params)
+
   def evaluate(self,request):
     """
       Evaluate the ROM

--- a/scripts/externalROMloader.py
+++ b/scripts/externalROMloader.py
@@ -121,11 +121,11 @@ class ravenROMexternal(object):
     self._load(self._binaryLoc, self._frameworkLoc)
 
   def setAdditionalParams(self, nodes):
-    '''
-    Set ROM parameters for external evaluation
-    @ In, nodes, list, list of xml nodes for setting parameters of pickleROM
-    @ Out, None
-    '''
+    """
+      Set ROM parameters for external evaluation
+      @ In, nodes, list, list of xml nodes for setting parameters of pickleROM
+      @ Out, None
+    """
     from ravenframework.SupervisedLearning.pickledROM import pickledROM
     spec = pickledROM.getInputSpecification()()
     # Changing parameters for the ROM

--- a/tests/framework/ROM/pickleTests/eRl_setAddtlParams.py
+++ b/tests/framework/ROM/pickleTests/eRl_setAddtlParams.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """
   This test demonstrates the ability for users to change the clusterEvalMode of a ROM with the new
-  setAdditionalParams method in the externalROMloader file. This method should allow the user to set any ROM 
+  setAdditionalParams method in the externalROMloader file. This method should allow the user to set any ROM
   parameters that are present in the pickledROM class; however, that is not yet demonstrated in existing tests.
-  The benefit of this method is to allow users to externally evaluate pickled ROM(s) with some ability to 
+  The benefit of this method is to allow users to externally evaluate pickled ROM(s) with some ability to
   customize the evaluation settings.
 """
 import sys
@@ -35,7 +35,7 @@ def check(runner, before, after, signal):
     """
       Decides of application of setAdditionalParams was successful
       @ In, runner, externalROMloader object
-      @ In, before/after, list, list of xml objects 
+      @ In, before/after, list, list of xml objects
       @ In, signal, string, name of signal that exists in ROM
       @ Out, results, dict, counts of passes and fails
     """
@@ -49,7 +49,7 @@ def check(runner, before, after, signal):
     beforeResult = res['_indexMap'][0][signal]
     # Checking for clustered index in non clustered eval
     if '_ROM_Cluster' not in beforeResult:
-        results['pass'] += 1 
+        results['pass'] += 1
     else:
         results['fail'] += 1
     runner.setAdditionalParams(after)
@@ -77,7 +77,7 @@ def initialize(picklePath, frameworkPath):
 def nodeGenerator(clusterEvalMode):
     """
       Defines nodes object specifically for setting clusterEvalMode
-      @ In, clusterEvalMode, string, 'full' or 'clustered' 
+      @ In, clusterEvalMode, string, 'full' or 'clustered'
       @ Out, nodes, list, list of xml nodes for setting pickleROM parameters
     """
     #NOTE this kind of node definition should apply to any ROM parameter changes for this method

--- a/tests/framework/ROM/pickleTests/eRl_setAddtlParams.py
+++ b/tests/framework/ROM/pickleTests/eRl_setAddtlParams.py
@@ -1,0 +1,107 @@
+# Copyright 2022 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''
+This test demonstrates the ability for users to change the clusterEvalMode of a ROM with the new
+setAdditionalParams method in the externalROMloader file. This method should allow the user to set any ROM 
+parameters that are present in the pickledROM class; however, that is not yet demonstrated in existing tests.
+The benefit of this method is to allow users to externally evaluate pickled ROM(s) with some ability to 
+customize the evaluation settings.
+'''
+import sys
+import os
+import numpy as np
+
+# Add romLoader to path
+here = os.path.abspath(os.path.dirname(__file__))
+# Paths for the ravenframework and test pk file
+frameworkPath = os.path.abspath(os.path.join(here, *['..']*4, 'ravenframework'))
+picklePath = os.path.join(here,'externalROMloader', 'arma.pk')
+# Appending externalROMloader to path
+sys.path.append(os.path.abspath(os.path.join(frameworkPath, '..', 'scripts')))
+import externalROMloader
+
+def check(runner, before, after, signal):
+    '''
+    Decides of application of setAdditionalParams was successful
+    @ In, runner, externalROMloader object
+    @ In, before/after, list, list of xml objects 
+    @ In, signal, string, name of signal that exists in ROM
+    @ Out, string, 'Pass' or 'Fail'
+    '''
+    # Initializing the results index
+    results = {'pass':0, 'fail':0}
+    # Placeholder input necessary for evaluate method
+    inp = {'scaling':[1]}
+    # Running method of testing interest and evaluating
+    runner.setAdditionalParams(before)
+    res = runner.evaluate(inp)[0]
+    beforeResult = res['_indexMap'][0][signal]
+    # Checking for clustered index in non clustered eval
+    if '_ROM_Cluster' not in beforeResult:
+        results['pass'] += 1 
+    else:
+        results['fail'] += 1
+    runner.setAdditionalParams(after)
+    res = runner.evaluate(inp)[0]
+    afterResult = res['_indexMap'][0][signal]
+    # Checking for clustered index in clustered eval
+    if '_ROM_Cluster' in afterResult:
+        results['pass'] += 1
+    else:
+        results['fail'] += 1
+    # Returning results
+    return results
+
+
+def initialize(picklePath, frameworkPath):
+    '''
+    Initializes the ravenROMexternal object and imports xmlUtils
+    @ In, picklePath, path variable to pickle file in same folder as test
+    @ In, frameworkPath, relative path to framework from working directory
+    @ Out, runner, ROMloader object for externally evaluating ROM(s)
+    '''
+    runner = externalROMloader.ravenROMexternal(picklePath,frameworkPath)
+    return runner
+
+def nodeGenerator(clusterEvalMode):
+    """
+    Defines nodes object specifically for setting clusterEvalMode
+    @ In, clusterEvalMode, string, 'full' or 'clustered' 
+    @ Out, nodes, list, list of xml nodes for setting pickleROM parameters
+    """
+    #NOTE this kind of node definition should apply to any ROM parameter changes for this method
+    # as long as the parameter being set with the xml node exists in the pickleROM object
+    # Importing xml node tool
+    from ravenframework.utils import xmlUtils
+    nodes = []
+    node = xmlUtils.newNode('loadedROM', attrib={'name': 'ROM', 'subType': 'pickledROM'})
+    node.append(xmlUtils.newNode('clusterEvalMode', text=clusterEvalMode))
+    nodes.append(node)
+    return nodes
+
+def main():
+    # Initializing runner, make sure to call this before nodeGenerator
+    runner = initialize(picklePath, frameworkPath)
+    # Name of signal in the ROM to run test with
+    signal = 'TOTALLOAD'
+    # Getting 'full' and 'clustered' evaluations
+    before = nodeGenerator('full')
+    after = nodeGenerator('clustered')
+    # Running test function
+    results = check(runner, before, after, signal)
+    print(results)
+    sys.exit(results['fail'])
+
+if __name__ == '__main__':
+    main()

--- a/tests/framework/ROM/pickleTests/eRl_setAddtlParams.py
+++ b/tests/framework/ROM/pickleTests/eRl_setAddtlParams.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''
-This test demonstrates the ability for users to change the clusterEvalMode of a ROM with the new
-setAdditionalParams method in the externalROMloader file. This method should allow the user to set any ROM 
-parameters that are present in the pickledROM class; however, that is not yet demonstrated in existing tests.
-The benefit of this method is to allow users to externally evaluate pickled ROM(s) with some ability to 
-customize the evaluation settings.
-'''
+"""
+  This test demonstrates the ability for users to change the clusterEvalMode of a ROM with the new
+  setAdditionalParams method in the externalROMloader file. This method should allow the user to set any ROM 
+  parameters that are present in the pickledROM class; however, that is not yet demonstrated in existing tests.
+  The benefit of this method is to allow users to externally evaluate pickled ROM(s) with some ability to 
+  customize the evaluation settings.
+"""
 import sys
 import os
 import numpy as np
@@ -32,13 +32,13 @@ sys.path.append(os.path.abspath(os.path.join(frameworkPath, '..', 'scripts')))
 import externalROMloader
 
 def check(runner, before, after, signal):
-    '''
-    Decides of application of setAdditionalParams was successful
-    @ In, runner, externalROMloader object
-    @ In, before/after, list, list of xml objects 
-    @ In, signal, string, name of signal that exists in ROM
-    @ Out, string, 'Pass' or 'Fail'
-    '''
+    """
+      Decides of application of setAdditionalParams was successful
+      @ In, runner, externalROMloader object
+      @ In, before/after, list, list of xml objects 
+      @ In, signal, string, name of signal that exists in ROM
+      @ Out, results, dict, counts of passes and fails
+    """
     # Initializing the results index
     results = {'pass':0, 'fail':0}
     # Placeholder input necessary for evaluate method
@@ -65,20 +65,20 @@ def check(runner, before, after, signal):
 
 
 def initialize(picklePath, frameworkPath):
-    '''
-    Initializes the ravenROMexternal object and imports xmlUtils
-    @ In, picklePath, path variable to pickle file in same folder as test
-    @ In, frameworkPath, relative path to framework from working directory
-    @ Out, runner, ROMloader object for externally evaluating ROM(s)
-    '''
+    """
+      Initializes the ravenROMexternal object and imports xmlUtils
+      @ In, picklePath, path variable to pickle file in same folder as test
+      @ In, frameworkPath, relative path to framework from working directory
+      @ Out, runner, ROMloader object for externally evaluating ROM(s)
+    """
     runner = externalROMloader.ravenROMexternal(picklePath,frameworkPath)
     return runner
 
 def nodeGenerator(clusterEvalMode):
     """
-    Defines nodes object specifically for setting clusterEvalMode
-    @ In, clusterEvalMode, string, 'full' or 'clustered' 
-    @ Out, nodes, list, list of xml nodes for setting pickleROM parameters
+      Defines nodes object specifically for setting clusterEvalMode
+      @ In, clusterEvalMode, string, 'full' or 'clustered' 
+      @ Out, nodes, list, list of xml nodes for setting pickleROM parameters
     """
     #NOTE this kind of node definition should apply to any ROM parameter changes for this method
     # as long as the parameter being set with the xml node exists in the pickleROM object
@@ -91,6 +91,9 @@ def nodeGenerator(clusterEvalMode):
     return nodes
 
 def main():
+    """
+      Runs the all the methods of the test script
+    """
     # Initializing runner, make sure to call this before nodeGenerator
     runner = initialize(picklePath, frameworkPath)
     # Name of signal in the ROM to run test with

--- a/tests/framework/ROM/pickleTests/tests
+++ b/tests/framework/ROM/pickleTests/tests
@@ -34,4 +34,8 @@
     input = 'script_rom_loader.py'
     prereq = stochPolyPickleTest
   [../]
+  [./eRl_setAdditionalParams]
+    type = 'RavenPython'
+    input = 'eRl_setAddtlParams.py'
+  [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
 #1856 

##### What are the significant changes in functionality due to this change request?
Added method to externalROMloader that has xml nodes as inputs for changing the pickledROM attributes of the ROM. Alongside this is a test showing the ability to change the clusteredEvalMode of the ROM with this new method.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

