### PR TITLE
Add _indexMap to CustomSampler

### DIFF
--- a/ravenframework/Samplers/CustomSampler.py
+++ b/ravenframework/Samplers/CustomSampler.py
@@ -76,6 +76,7 @@ class CustomSampler(Sampler):
     self.printTag = 'SAMPLER CUSTOM'
     self.readingFrom = None # either File or DataObject, determines sample generation
     self.indexes = None
+    self.sourceIndexMap = {}
     self.batch = 1    # number of samples in each batch
     self.batchId = 0  # ID for each batch
 
@@ -209,6 +210,7 @@ class CustomSampler(Sampler):
           if sourceName not in dataObj.getVars() + dataObj.getVars('indexes'):
             self.raiseAnError(IOError, f"the variable {sourceName} not found in {dataObj.type} {dataObj.name}")
       self.limit = len(self.pointsToSample)
+      self.sourceIndexMap = dataObj.getDimensions()
     # if "index" provided, limit sampling to those points
     if self.indexes is not None:
       self.limit = len(self.indexes)
@@ -253,6 +255,10 @@ class CustomSampler(Sampler):
             sourceName = self.nameInSource[subVar]
             # get the value(s) for the variable for this realization
             self.values[subVar] = mathUtils.npZeroDToEntry(rlz[sourceName].values)
+            # get supporting indices (e.g. 'time')
+            for dim in rlz.dims:
+              if dim not in self.values:
+                self.values[dim] = rlz[self.nameInSource.get(dim, dim)]
             # set the probability weight due to this variable (default to 1)
             pbWtName = 'ProbabilityWeight-'
             self.inputInfo[pbWtName+subVar] = rlz.get(pbWtName+sourceName,1.0)
@@ -272,6 +278,7 @@ class CustomSampler(Sampler):
         # Construct probabilities based on the user provided information
         self.inputInfo['PointProbability'] = self.infoFromCustom['PointProbability'][index]
         self.inputInfo['ProbabilityWeight'] = self.infoFromCustom['ProbabilityWeight'][index]
+      self.values['_indexMap'] = self.sourceIndexMap
       self.inputInfo['SamplerType'] = 'Custom'
       if self.inputInfo['batchMode']:
         self.inputInfo['SampledVars'] = self.values


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

 #1858

##### What are the significant changes in functionality due to this change request?

Adds _indexMap to CustomSampler and the ability to handle datasets for CustomSampler


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

