### PR TITLE
fix couple of issues 

### DIFF
--- a/doc/user_manual/OutStreamSystem.tex
+++ b/doc/user_manual/OutStreamSystem.tex
@@ -258,11 +258,11 @@ The available options, for the \xmlNode{what} sub-block, are listed below:
 \vspace{-5mm}
 \begin{itemize}
   \itemsep0em
-  \item \textbf{Output}, the output space will be dumped out (see
+  \item \textbf{Output}, the output space will be saved to user defined output file (see
   ``second-example'')
-  \item \textbf{Input}, the input space will be dumped out (see
+  \item \textbf{Input}, the input space will be saved to user defined output file (see
   ``third-example'')
-  \item \textbf{metadata}, the metadata will be dumped out. This information
+  \item \textbf{metadata}, the metadata will be saved to user defined output file. This information
   depends on analysis workflow. If the data stored in the DataObject comes from Sampler,
   the metadata will include ``ProbabilityWeight, PointProbability''. If the data comes from
   clustering PostProcessor, the metadata will include ``labels''.

--- a/doc/user_manual/OutStreamSystem.tex
+++ b/doc/user_manual/OutStreamSystem.tex
@@ -262,7 +262,11 @@ The available options, for the \xmlNode{what} sub-block, are listed below:
   ``second-example'')
   \item \textbf{Input}, the input space will be dumped out (see
   ``third-example'')
-  \item \textbf{Input|var-name-in/Output|var-name-out}, only the particular
+  \item \textbf{metadata}, the metadata will be dumped out. This information
+  depends on analysis workflow. If the data stored in the DataObject comes from Sampler,
+  the metadata will include ``ProbabilityWeight, PointProbability''. If the data comes from
+  clustering PostProcessor, the metadata will include ``labels''.
+  \item \textbf{Input$|$var-name-in/Output$|$var-name-out/metadata$|$meta-var-name}, only the particular
   variables ``var-name-in'' and ``var-name-out'' will be reported in the output
   file (see ``fourth-example'')
 \end{itemize}
@@ -1772,8 +1776,8 @@ The \xmlString{PopulationPlot} \xmlAttr{subType} shows the path taken during a \
 an \xmlNode{Optimizer} as the sampling strategy. This is in particular useful to monitor the evolution of multiple
 trajectories or a population of points.
 The evolution step should be indicated in the dataObject as a variable specified in the \xmlNode{index} node.
-This plotter constructs a series of plots whose x-axis is the variable specified in the \xmlNode{index} node 
-and y-axis is a particular variable's values evaluated during that iteration. 
+This plotter constructs a series of plots whose x-axis is the variable specified in the \xmlNode{index} node
+and y-axis is a particular variable's values evaluated during that iteration.
 
 The \xmlString{SamplePlot} \xmlAttr{subType} requires the following nodes:
 \begin{itemize}
@@ -1813,7 +1817,7 @@ The \xmlString{OptParallelCoordinatePlot} \xmlAttr{subType} shows the path taken
 an \xmlNode{Optimizer} as the sampling strategy. This is in particular usefull to monitor the evolution of multiple
 trajectories or a population of points.
 The evolution step should be indicated in the dataObject as a variable specified in the \xmlNode{index} node.
-This plotter constructs a gif which plots the parallel coordinate plots of particular variable's values evaluated 
+This plotter constructs a gif which plots the parallel coordinate plots of particular variable's values evaluated
 during that iteration for each iteration indicated by the variable specified in the \xmlNode{index} node.
 
 The \xmlString{SamplePlot} \xmlAttr{subType} requires the following nodes:
@@ -1841,4 +1845,3 @@ For example,
   </OutStreams>
 </Simulations>
 \end{lstlisting}
-

--- a/ravenframework/Samplers/MonteCarlo.py
+++ b/ravenframework/Samplers/MonteCarlo.py
@@ -18,10 +18,6 @@
   @author: alfoa
   supercedes Samplers.py from crisr
 """
-# for future compatibility with Python 3------------------------------------------------------------
-from __future__ import division, print_function, unicode_literals, absolute_import
-# End compatibility block for Python 3--------------------------------------------------------------
-
 # External Modules----------------------------------------------------------------------------------
 from operator import mul
 from functools import reduce
@@ -131,6 +127,10 @@ class MonteCarlo(Sampler):
           lower = distData['xMin']
           upper = distData['xMax']
           rvsnum = lower + (upper - lower) * randomUtils.random()
+          # TODO (wangc): I think the calculation for epsilon need to be updated as following
+          """
+            epsilon = (upper-lower)/(self.limit+1) * 0.5
+          """
           epsilon = (upper-lower)/self.limit
           midPlusCDF  = self.distDict[key].cdf(rvsnum + epsilon)
           midMinusCDF = self.distDict[key].cdf(rvsnum - epsilon)

--- a/ravenframework/Samplers/MonteCarlo.py
+++ b/ravenframework/Samplers/MonteCarlo.py
@@ -128,9 +128,7 @@ class MonteCarlo(Sampler):
           upper = distData['xMax']
           rvsnum = lower + (upper - lower) * randomUtils.random()
           # TODO (wangc): I think the calculation for epsilon need to be updated as following
-          """
-            epsilon = (upper-lower)/(self.limit+1) * 0.5
-          """
+          # epsilon = (upper-lower)/(self.limit+1) * 0.5
           epsilon = (upper-lower)/self.limit
           midPlusCDF  = self.distDict[key].cdf(rvsnum + epsilon)
           midMinusCDF = self.distDict[key].cdf(rvsnum - epsilon)

--- a/ravenframework/Samplers/Sampler.py
+++ b/ravenframework/Samplers/Sampler.py
@@ -585,7 +585,12 @@ class Sampler(utils.metaclass_insert(abc.ABCMeta, BaseEntity), Assembler, InputD
       if distrib in self.distributions2variablesMapping:
         params = self.NDSamplingParams[distrib]
         temp = utils.first(self.distributions2variablesMapping[distrib][0].keys())
-        self.distDict[temp].updateRNGParam(params)
+        try:
+          self.distDict[temp].updateRNGParam(params)
+        except AttributeError as err:
+          msg =f'Distribution with name {distrib} is not a valid N-Dimensional probability distribution!'
+          err.msg = msg
+          raise err
       else:
         self.raiseAnError(IOError, f'Distribution "{distrib}" specified in distInit block of sampler "{self.name}" does not exist!')
 

--- a/ravenframework/Samplers/Stratified.py
+++ b/ravenframework/Samplers/Stratified.py
@@ -18,10 +18,6 @@
   @author: alfoa
   supercedes Samplers.py from alfoa
 """
-# for future compatibility with Python 3------------------------------------------------------------
-from __future__ import division, print_function, unicode_literals, absolute_import
-# End compatibility block for Python 3--------------------------------------------------------------
-
 # External Modules----------------------------------------------------------------------------------
 from operator import mul
 from functools import reduce

--- a/ravenframework/utils/xmlUtils.py
+++ b/ravenframework/utils/xmlUtils.py
@@ -338,7 +338,7 @@ def readExternalXML(extFile, extNode, cwd):
       content = inFile.readlines()
     line = content[lineNo-1].strip('\n')
     caret = '{:=>{}}'.format('^', col)
-    err.msg = err.msg = '{}\n{}\n{}\n in input file: {}'.format(err, line, caret, extFile)
+    err.msg = '{}\n{}\n{}\n in input file: {}'.format(err, line, caret, extFile)
     raise err
   if root.tag != extNode.strip():
     raise IOError('XML UTILS ERROR: Node "{}" is not the root node of "{}"!'.format(extNode, extFile))

--- a/ravenframework/utils/xmlUtils.py
+++ b/ravenframework/utils/xmlUtils.py
@@ -330,7 +330,16 @@ def readExternalXML(extFile, extNode, cwd):
   if not os.path.exists(extFile):
     raise IOError('XML UTILS ERROR: External XML file not found: "{}"'.format(os.path.abspath(extFile)))
   # find the element to read
-  root = ET.parse(open(extFile, 'r')).getroot()
+  try:
+    root = ET.parse(extFile).getroot()
+  except ET.ParseError as err:
+    lineNo, col = err.position
+    with open(extFile, 'r') as inFile:
+      content = inFile.readlines()
+    line = content[lineNo-1].strip('\n')
+    caret = '{:=>{}}'.format('^', col)
+    err.msg = err.msg = '{}\n{}\n{}\n in input file: {}'.format(err, line, caret, extFile)
+    raise err
   if root.tag != extNode.strip():
     raise IOError('XML UTILS ERROR: Node "{}" is not the root node of "{}"!'.format(extNode, extFile))
   return root


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #62, close #53, close #235

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

