### PR TITLE
Wanghy/feature selection

### DIFF
--- a/ravenframework/SupervisedLearning/DynamicModeDecompositionControl.py
+++ b/ravenframework/SupervisedLearning/DynamicModeDecompositionControl.py
@@ -330,7 +330,7 @@ class DMDC(DMD):
         initStates[cnt,:] = initStates[cnt,:] - self.stateVals[0, index, :]
       evalX[cnt, 0, :] = initStates[cnt,:]
       evalY[cnt, 0, :] = np.dot(self.__Ctilde[index, :, :], evalX[cnt, 0, :])
-      print(" ** Index = ", index, ", Centered uVector=", uVector[:,0,0])
+      # print(" ** Index = ", index, ", Centered uVector=", uVector[:,0,0])
       ### perform the self-propagation of X, X[k+1] = A*X[k] + B*U[k] ###
       for i in range(tsEval-1):
         xPred = np.reshape(self.__Atilde[index,:,:].dot(evalX[cnt,i,:]) + self.__Btilde[index,:,:].dot(uVector[:,cnt,i]),(-1,1)).T
@@ -563,7 +563,7 @@ class DMDC(DMD):
     # SVD
     uTrucSVD, sTrucSVD, vTrucSVD = mathUtils.computeTruncatedSingularValueDecomposition(omega, rankSVD, False, False)
     # Find the truncation rank triggered by "s>=SminValue"
-    rankTruc = sum(map(lambda x : x>=np.max(sTrucSVD)*1e-3, sTrucSVD.tolist()))
+    rankTruc = sum(map(lambda x : x>=np.max(sTrucSVD)*1e-9, sTrucSVD.tolist()))
     if rankTruc < uTrucSVD.shape[1]:
       uTruc = uTrucSVD[:, :rankTruc]
       vTruc = vTrucSVD[:, :rankTruc]

--- a/ravenframework/SupervisedLearning/DynamicModeDecompositionControl.py
+++ b/ravenframework/SupervisedLearning/DynamicModeDecompositionControl.py
@@ -190,7 +190,11 @@ class DMDC(DMD):
     ### Extract the Output Names (Output, Y)
     self.outputID = [x for x in self.target if x not in (set(self.stateID) | set([self.pivotParameterID]))]
     # check if there are parameters
-    self.parametersIDs = list(set(self.features) - set(self.actuatorsID) - set(self.initStateID))
+    # self.parametersIDs = list(set(self.features) - set(self.actuatorsID) - set(self.initStateID))
+    self.parametersIDs = list(set(self.features) - set(self.actuatorsID))
+    for i in range(len(self.parametersIDs)-1,-1,-1):
+      if str(self.parametersIDs[i]).endswith('_init'):
+        self.parametersIDs.remove(self.parametersIDs[i])
 
   def _train(self,featureVals,targetVals):
     """
@@ -326,6 +330,7 @@ class DMDC(DMD):
         initStates[cnt,:] = initStates[cnt,:] - self.stateVals[0, index, :]
       evalX[cnt, 0, :] = initStates[cnt,:]
       evalY[cnt, 0, :] = np.dot(self.__Ctilde[index, :, :], evalX[cnt, 0, :])
+      print(" ** Index = ", index, ", Centered uVector=", uVector[:,0,0])
       ### perform the self-propagation of X, X[k+1] = A*X[k] + B*U[k] ###
       for i in range(tsEval-1):
         xPred = np.reshape(self.__Atilde[index,:,:].dot(evalX[cnt,i,:]) + self.__Btilde[index,:,:].dot(uVector[:,cnt,i]),(-1,1)).T

--- a/ravenframework/SupervisedLearning/DynamicModeDecompositionControl.py
+++ b/ravenframework/SupervisedLearning/DynamicModeDecompositionControl.py
@@ -563,7 +563,7 @@ class DMDC(DMD):
     # SVD
     uTrucSVD, sTrucSVD, vTrucSVD = mathUtils.computeTruncatedSingularValueDecomposition(omega, rankSVD, False, False)
     # Find the truncation rank triggered by "s>=SminValue"
-    rankTruc = sum(map(lambda x : x>=np.max(sTrucSVD)*1e-6, sTrucSVD.tolist()))
+    rankTruc = sum(map(lambda x : x>=np.max(sTrucSVD)*1e-3, sTrucSVD.tolist()))
     if rankTruc < uTrucSVD.shape[1]:
       uTruc = uTrucSVD[:, :rankTruc]
       vTruc = vTrucSVD[:, :rankTruc]

--- a/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
+++ b/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
@@ -385,7 +385,7 @@ class RFE(BaseInterface):
 
                 tidx = targetsIds.index(target)
                 avg = np.average(y[:,tidx] if len(y.shape) < 3 else y[samp,:,tidx])
-                std = np.std(y[:,tidx] if len(y.shape) < 3 else y[samp,:,tidx])
+                std = np.std(y[:,tidx] if len(y.shape) < 3 else y[samp,:,tidx],ddof=1)
                 if avg == 0: avg = 1
                 if std == 0: std = 1.
                 ev = (evaluated[target] - avg)/std

--- a/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
+++ b/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
@@ -373,15 +373,15 @@ class RFE(BaseInterface):
             previousScore = actualScore
             scores = {}
             dividend = 0.
-            stateW = float(len(targets)-1-len(combo))/float(len(combo))
+            # stateW = 1/float(len(combo))
             for target in evaluated:
               #if target in ['Electric_Power','Turbine_Pressure']:
               #if target in targetsIds and target not in self.parametersToInclude:
               if target in targetsIds:
-                if target not in self.parametersToInclude:
-                  w = 1.0
+                if target not in self.parametersToInclude: # if not state variable, then this target is output variable
+                  w = 1/float(len(targets)-1-len(combo)) #1/ny (targets contains the index to Time, state and output)
                 else:
-                  w = stateW # the weight of Haoyu's GA cost function
+                  w = 1/float(len(combo)) # 1/nx, the weight of Haoyu's GA cost function
 
                 tidx = targetsIds.index(target)
                 avg = np.average(y[:,tidx] if len(y.shape) < 3 else y[samp,:,tidx])


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
1. limited the maximum condition number to 1e9
2. modified the np.std with "ddof=1" to match the mathematical definition of standard deviation.
3. Andrea, did you rolled back this branch to before my previous PR #1860 ? Some of my edits were un-done.


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

