### PR TITLE
Makes random number generator class picklable

### DIFF
--- a/ravenframework/SupervisedLearning/ARMA.py
+++ b/ravenframework/SupervisedLearning/ARMA.py
@@ -21,7 +21,6 @@
 #External Modules------------------------------------------------------------------------------------
 import copy
 import collections
-from xml.dom.minidom import Attr
 from ..utils import importerUtils
 from ..utils.utils import findCrowModule
 statsmodels = importerUtils.importModuleLazy("statsmodels", globals())
@@ -467,8 +466,8 @@ class ARMA(SupervisedLearning):
     except AttributeError:  # catches where ARMA was pickled without saving the RNG
       self.setEngine(randomUtils.newRNG(), seed=None, count=rngCounts)
     else:
-      if type(self.randomEng) == findCrowModule('randomENG').RandomClass:
-        self.randomEng = randomUtils.RNG(self.randomEng, self.seed)  # wraps crow class if needed
+      if isinstance(self.randomEng, findCrowModule('randomENG').RandomClass):
+        self.randomEng = randomUtils.RNG(self.randomEng, self.seed)  # wraps raw crow RNG
 
     if self.reseedCopies:
       randd = np.random.randint(1, 2e9)

--- a/ravenframework/utils/randomUtils.py
+++ b/ravenframework/utils/randomUtils.py
@@ -88,11 +88,8 @@ class BoxMullerGenerator:
     return mean,stdev
 
 
-class CrowRNG(findCrowModule('randomENG').RandomClass):
-  """ Wraps crow RandomClass to make it serializable
-  NOTE: CrowRNG inherits from findCrowModule('randomENG').RandomClass but never initializes it in __init__. This is just
-        so it can fool type checks made with the ininstance() function elsewhere which are checking for RandomClass.
-  """
+class CrowRNG:
+  """ Wraps crow RandomClass to make it serializable """
   def __init__(self, engine=None, seed=None):
     """
       Constructor
@@ -207,7 +204,7 @@ def randomSeed(value, seedBoth=False, engine=None):
   if engine is None:
     if stochasticEnv == 'crow':
       distStochEnv.seedRandom(value)
-      engine=CrowRNG(crowStochEnv)
+      engine = crowStochEnv
     elif stochasticEnv == 'numpy':
       replaceGlobalEnv=True
       global npStochEnv
@@ -217,7 +214,7 @@ def randomSeed(value, seedBoth=False, engine=None):
 
   if isinstance(engine, np.random.RandomState):
     engine = np.random.RandomState(value)
-  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
+  elif isinstance(engine, CrowRNG):
     engine.seed(value)
     if seedBoth:
       np.random.seed(value+1) # +1 just to prevent identical seed sets
@@ -240,7 +237,7 @@ def random(dim=1, samples=1, keepMatrix=False, engine=None):
   samples = int(samples)
   if isinstance(engine, np.random.RandomState):
     vals = engine.rand(samples,dim)
-  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
+  elif isinstance(engine, CrowRNG):
     vals = np.zeros([samples, dim])
     for i in range(len(vals)):
       for j in range(len(vals[0])):
@@ -265,7 +262,7 @@ def randomNormal(size=(1,), keepMatrix=False, engine=None):
     size = (size, )
   if isinstance(engine, np.random.RandomState):
     vals = engine.randn(*size)
-  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
+  elif isinstance(engine, CrowRNG):
     vals = np.zeros(np.prod(size))
     for i in range(len(vals)):
       vals[i] = boxMullerGen.generate(engine=engine)
@@ -305,7 +302,7 @@ def randomIntegers(low, high, caller=None, engine=None):
   engine = getEngine(engine)
   if isinstance(engine, np.random.RandomState):
     return engine.randint(low, high=high+1)
-  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
+  elif isinstance(engine, CrowRNG):
     intRange = high - low + 1.0
     rawNum = low + random(engine=engine)*intRange
     rawInt = math.floor(rawNum)
@@ -359,7 +356,7 @@ def randomPermutation(l,caller,engine=None):
   engine = getEngine(engine)
   if isinstance(engine, np.random.RandomState):
     return engine.permutation(l)
-  elif isinstance(engine, findCrowModule('randomENG').RandomClass):
+  elif isinstance(engine, CrowRNG):
     newList = []
     oldList = l[:]
     while len(oldList) > 0:
@@ -458,7 +455,7 @@ def getEngine(eng):
       eng = npStochEnv
     elif stochasticEnv == 'crow':
       eng = crowStochEnv
-  if not isinstance(eng, np.random.RandomState) and not isinstance(eng, findCrowModule('randomENG').RandomClass):
+  if not isinstance(eng, np.random.RandomState) and not isinstance(eng, CrowRNG):
     raise TypeError('Engine type not recognized! {}'.format(type(eng)))
   return eng
 

--- a/ravenframework/utils/randomUtils.py
+++ b/ravenframework/utils/randomUtils.py
@@ -23,7 +23,6 @@ import sys
 import math
 import threading
 from collections import deque, defaultdict
-from install import crow_modules
 import numpy as np
 import copy
 
@@ -329,7 +328,6 @@ def newRNG(env=None):
   if env is None:
     env = stochasticEnv
   if env == 'crow':
-    # engine = findCrowModule('randomENG').RandomClass()
     engine = RNG()
   elif env == 'numpy':
     engine = np.random.RandomState()

--- a/tests/framework/ROM/TimeSeries/SyntheticHistory/arma.xml
+++ b/tests/framework/ROM/TimeSeries/SyntheticHistory/arma.xml
@@ -8,11 +8,14 @@
     <description>
       Tests the SyntheticHistory ROM using only the ARMA TimeSeriesAnalyzer algorithm.
     </description>
+    <revisions>
+      <revision author="j-bryan" date="2022-06-23">Added serialization step to test if ARMA is picklable</revision>
+    </revisions>
   </TestInfo>
 
   <RunInfo>
     <WorkingDir>ARMA</WorkingDir>
-    <Sequence>read, train, print, sample</Sequence>
+    <Sequence>read, train, print, serialize, sample</Sequence>
     <batchSize>1</batchSize>
   </RunInfo>
 
@@ -30,6 +33,10 @@
       <Output class="DataObjects" type="DataSet">romMeta</Output>
       <Output class="OutStreams" type="Print">romMeta</Output>
     </IOStep>
+    <IOStep name="serialize">
+      <Input class="Models" type="ROM">synth</Input>
+      <Output class="Files" type="">pk</Output>
+    </IOStep>
     <MultiRun name="sample">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ROM">synth</Model>
@@ -41,6 +48,7 @@
 
   <Files>
     <Input name="infile">../TrainingData/ARMA_A.csv</Input>
+    <Input name="pk">arma.pk</Input>
   </Files>
 
   <Samplers>

--- a/tests/framework/ROM/pickleTests/tests
+++ b/tests/framework/ROM/pickleTests/tests
@@ -38,8 +38,4 @@
     type = 'RavenPython'
     input = 'eRl_setAddtlParams.py'
   [../]
-  [./syntheticHistoryARMAPickleTest]
-    type = 'RavenFramework'
-    input = 'synthetic_history_arma_pickle.xml'
-  [../]
 []

--- a/tests/framework/ROM/pickleTests/tests
+++ b/tests/framework/ROM/pickleTests/tests
@@ -37,5 +37,8 @@
   [./eRl_setAdditionalParams]
     type = 'RavenPython'
     input = 'eRl_setAddtlParams.py'
+  [./syntheticHistoryARMAPickleTest]
+    type = 'RavenFramework'
+    input = 'synthetic_history_arma_pickle.xml'
   [../]
 []

--- a/tests/framework/ROM/pickleTests/tests
+++ b/tests/framework/ROM/pickleTests/tests
@@ -37,6 +37,7 @@
   [./eRl_setAdditionalParams]
     type = 'RavenPython'
     input = 'eRl_setAddtlParams.py'
+  [../]
   [./syntheticHistoryARMAPickleTest]
     type = 'RavenFramework'
     input = 'synthetic_history_arma_pickle.xml'

--- a/tests/framework/unit_tests/utils/testRandomUtils.py
+++ b/tests/framework/unit_tests/utils/testRandomUtils.py
@@ -108,26 +108,6 @@ def checkType(comment,value,expected,updateResults=True):
       results["pass"] += 1
     return True
 
-def checkPicklable(comment, updateResults=True):
-  """
-    This method checks if the RNG wrapper class is picklable
-    @ In, comment, str, a comment printed out if it fails
-    @ In, updateResults, bool, optional, if True updates global results
-    @ Out, None
-  """
-  import pickle
-  try:
-    pickle.loads(pickle.dumps(randomUtils.RNG()))
-  except (TypeError, pickle.PicklingError):
-    print(comment)
-    if updateResults:
-      results["fail"] += 1
-    return False
-  else:
-    if updateResults:
-      results["pass"] += 1
-    return True
-
 ### BEGIN TESTS
 # NOTE that due to seeding, this test relies HEAVILY on not changing the orders of calls to randomUtils!
 # Reseed at the beginning of sections and add new tests to the end of sections.
@@ -416,10 +396,6 @@ engine = randomUtils.newRNG()
 engine.seed(42)
 sampled = [engine.random() for _ in range(5)]
 checkArray('Independent RNG, seeded',sampled,correct)
-
-
-# Picklable RNG
-checkPicklable('RNG class object could not be pickled')
 
 print(results)
 

--- a/tests/framework/unit_tests/utils/testRandomUtils.py
+++ b/tests/framework/unit_tests/utils/testRandomUtils.py
@@ -17,8 +17,6 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, unicode_literals, absolute_import
-from pickle import PickleError
-from turtle import update
 import warnings
 warnings.simplefilter('default',DeprecationWarning)
 
@@ -120,7 +118,7 @@ def checkPicklable(comment, updateResults=True):
   import pickle
   try:
     pickle.loads(pickle.dumps(randomUtils.RNG()))
-  except pickle.PicklingError:
+  except (TypeError, pickle.PicklingError):
     print(comment)
     if updateResults:
       results["fail"] += 1

--- a/tests/framework/unit_tests/utils/testRandomUtils.py
+++ b/tests/framework/unit_tests/utils/testRandomUtils.py
@@ -17,6 +17,8 @@
 
 #For future compatibility with Python 3
 from __future__ import division, print_function, unicode_literals, absolute_import
+from pickle import PickleError
+from turtle import update
 import warnings
 warnings.simplefilter('default',DeprecationWarning)
 
@@ -100,6 +102,26 @@ def checkType(comment,value,expected,updateResults=True):
   """
   if type(value) != type(expected):
     print("checking type",comment,value,'|',type(value),"!=",expected,'|',type(expected))
+    if updateResults:
+      results["fail"] += 1
+    return False
+  else:
+    if updateResults:
+      results["pass"] += 1
+    return True
+
+def checkPicklable(comment, updateResults=True):
+  """
+    This method checks if the RNG wrapper class is picklable
+    @ In, comment, str, a comment printed out if it fails
+    @ In, updateResults, bool, optional, if True updates global results
+    @ Out, None
+  """
+  import pickle
+  try:
+    pickle.loads(pickle.dumps(randomUtils.RNG()))
+  except pickle.PicklingError:
+    print(comment)
     if updateResults:
       results["fail"] += 1
     return False
@@ -397,6 +419,9 @@ engine.seed(42)
 sampled = [engine.random() for _ in range(5)]
 checkArray('Independent RNG, seeded',sampled,correct)
 
+
+# Picklable RNG
+checkPicklable('RNG class object could not be pickled')
 
 print(results)
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#1863 

##### What are the significant changes in functionality due to this change request?
Crow RNG engines are now picklable. This was accomplished by adding a wrapper class for the crow RandomClass RNG class.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

