### PR TITLE
Brings CrowRNG method names into compliance with code standards

### DIFF
--- a/ravenframework/SupervisedLearning/ARMA.py
+++ b/ravenframework/SupervisedLearning/ARMA.py
@@ -461,7 +461,7 @@ class ARMA(SupervisedLearning):
     try:
       self.randomEng
     except AttributeError:  # catches where ARMA was pickled without saving the RNG
-      self.setEngine(engine=randomUtils.newRNG(), seed=self.seed, count=rngCounts)
+      self.setEngine(randomUtils.newRNG(), seed=self.seed, count=rngCounts)
 
     if self.reseedCopies:
       randd = np.random.randint(1, 2e9)

--- a/ravenframework/SupervisedLearning/ARMA.py
+++ b/ravenframework/SupervisedLearning/ARMA.py
@@ -322,7 +322,7 @@ class ARMA(SupervisedLearning):
     self.normEngine.lowerBoundUsed = False
     self.normEngine.initializeDistribution()
 
-    self.setEngine(randomUtils.newRNG(),seed=self.seed,count=0)
+    self.setEngine(randomUtils.newRNG(), seed=self.seed)
 
     # FIXME set the numpy seed
       ## we have to do this because VARMA.simulate does not accept a random number generator,
@@ -461,10 +461,7 @@ class ARMA(SupervisedLearning):
     try:
       self.randomEng
     except AttributeError:  # catches where ARMA was pickled without saving the RNG
-      self.setEngine(randomUtils.newRNG(), seed=None, count=rngCounts)
-    else:
-      if isinstance(self.randomEng, findCrowModule('randomENG').RandomClass):
-        self.randomEng = randomUtils.RNG(self.randomEng, self.seed)  # wraps raw crow RNG
+      self.setEngine(engine=randomUtils.newRNG(), seed=self.seed, count=rngCounts)
 
     if self.reseedCopies:
       randd = np.random.randint(1, 2e9)
@@ -2523,15 +2520,12 @@ class ARMA(SupervisedLearning):
      @ Out, None
     """
     if seed is None:
-      seed=self.seed
-    seed=abs(seed)
-    eng.seed(seed)
-    if count is None:
-      count=self.randomEng.getRNGState()
-    eng.forwardSeed(count)
-    self.randomEng=eng
-
-
+      seed = self.seed
+    seed = abs(seed)
+    randomUtils.randomSeed(seed, engine=eng)
+    if count is not None:
+      randomUtils.forwardSeed(count, engine=eng)
+    self.randomEng = eng
 
 #
 #

--- a/ravenframework/SupervisedLearning/ARMA.py
+++ b/ravenframework/SupervisedLearning/ARMA.py
@@ -2527,8 +2527,8 @@ class ARMA(SupervisedLearning):
     seed=abs(seed)
     eng.seed(seed)
     if count is None:
-      count=self.randomEng.get_rng_state()
-    eng.forward_seed(count)
+      count=self.randomEng.getRNGState()
+    eng.forwardSeed(count)
     self.randomEng=eng
 
 

--- a/ravenframework/utils/randomUtils.py
+++ b/ravenframework/utils/randomUtils.py
@@ -25,7 +25,6 @@ import threading
 from collections import deque, defaultdict
 import numpy as np
 import copy
-import ctypes
 
 from .utils import findCrowModule
 from . import mathUtils
@@ -87,14 +86,12 @@ class BoxMullerGenerator:
     stdev = np.std(samples)
     return mean,stdev
 
-
 class CrowRNG:
   """ Wraps crow RandomClass to make it serializable """
-  def __init__(self, engine=None, seed=None):
+  def __init__(self, engine=None):
     """
       Constructor
       @ In, engine, RandomClass, optional, will wrap the given engine if provided, otherwise a new engine is created
-      @ In, reseed_copies, bool, whether or not recovered copies of the class should use a new seed or not
       @ Out, None
     """
     if engine is None:
@@ -103,12 +100,6 @@ class CrowRNG:
       self._engine = engine
     else:
       raise TypeError(f'Object of unknown type {type(engine)} cannot be wrapped by CrowRNG class!')
-
-    if seed is not None:
-      self._seed = abs(int(seed))
-      self._engine.seed(self._seed)
-    else:
-      self._seed = self._engine.get_rng_seed()
 
   def __getstate__(self):
     """
@@ -176,7 +167,6 @@ class CrowRNG:
     self._seed = abs(int(val))
     return self._seed
 
-
 if stochasticEnv == 'numpy':
   npStochEnv = np.random.RandomState()
 else:
@@ -206,7 +196,7 @@ def randomSeed(value, seedBoth=False, engine=None):
       distStochEnv.seedRandom(value)
       engine = crowStochEnv
     elif stochasticEnv == 'numpy':
-      replaceGlobalEnv=True
+      replaceGlobalEnv = True
       global npStochEnv
       # global npStochEvn is needed in numpy environment here
       # to prevent referenced before assignment in local loop
@@ -218,10 +208,22 @@ def randomSeed(value, seedBoth=False, engine=None):
     engine.seed(value)
     if seedBoth:
       np.random.seed(value+1) # +1 just to prevent identical seed sets
-  if stochasticEnv== 'numpy' and replaceGlobalEnv:
-    npStochEnv= engine
+  if stochasticEnv == 'numpy' and replaceGlobalEnv:
+    npStochEnv = engine
   if replaceGlobalEnv:
     print('randomUtils: Global random number seed has been changed to',value)
+
+def forwardSeed(count, engine):
+  """
+    Function to advance the state of a random number generator engine
+    @ In, count, int, number of steps to advance the RNG
+    @ In, engine, np.random.RandomState or CrowRNG, RNG engine to modify
+    @ Out, None
+  """
+  if isinstance(engine, np.random.RandomState):
+    engine.rand(count)
+  elif isinstance(engine, CrowRNG):
+    engine.forwardSeed(count)
 
 def random(dim=1, samples=1, keepMatrix=False, engine=None):
   """
@@ -327,7 +329,7 @@ def randomChoice(array, size = 1, replace = True, engine = None):
   assert(hasattr(array,"shape") or isinstance(array,list))
 
   if not replace:
-    if hasattr(array,"shape"):
+    if hasattr(array,"shape"):  # TODO: not a problem actually. Should be able to use numpy.random.RandomState.choice(a, replace=False)
       raise RuntimeError("Option with replace False not available for ndarrays")
     if len(array) < size:
       raise RuntimeError("array size < of number of requested samples (size)")

--- a/ravenframework/utils/randomUtils.py
+++ b/ravenframework/utils/randomUtils.py
@@ -150,7 +150,7 @@ class CrowRNG:
     """
     return self._engine.random()  # returns double
 
-  def get_rng_state(self):
+  def getRNGState(self):
     """
       Wrapper for RandomClass.get_rng_state()
       @ In, None
@@ -158,7 +158,7 @@ class CrowRNG:
     """
     return self._engine.get_rng_state()  # returns int
 
-  def forward_seed(self, counts):
+  def forwardSeed(self, counts):
     """
       Wrapper for RandomClass.forward_seed()
       @ In, counts, int, number of random states to progress
@@ -166,7 +166,7 @@ class CrowRNG:
     """
     self._engine.forward_seed(counts)  # takes unsigned int
 
-  def get_rng_seed(self):
+  def getRNGSeed(self):
     """
       Wrapper for RandomClass.get_rng_seed()
       @ In, None

--- a/tests/framework/unit_tests/SupervisedLearning/testARMA.py
+++ b/tests/framework/unit_tests/SupervisedLearning/testARMA.py
@@ -433,42 +433,42 @@ if plotting:
 #            RESEEDCOPIES, ENGINE           #
 #############################################
 
-testVal=arma._trainARMA(data)
-arma.amITrained=True
-signal1=arma._generateARMASignal(testVal)
-signal2=arma._generateARMASignal(testVal)
+testVal = arma._trainARMA(data)
+arma.amITrained = True
+signal1 = arma._generateARMASignal(testVal)
+signal2 = arma._generateARMASignal(testVal)
 
 #Test the reseed = False
 
-armaReF=arma
-armaReF.reseedCopies=False
-pklReF=pk.dumps(armaReF)
-unpkReF=pk.loads(pklReF)
+armaReF = arma
+armaReF.reseedCopies = False
+pklReF = pk.dumps(armaReF)
+unpkReF = pk.loads(pklReF)
 #signal 3 and 4 should be the same
-signal3=armaReF._generateARMASignal(testVal)
-signal4=unpkReF._generateARMASignal(testVal)
+signal3 = armaReF._generateARMASignal(testVal)
+signal4 = unpkReF._generateARMASignal(testVal)
 for n in range(len(data)):
   checkFloat('signal 3, signal 4 ind{}'.format(n), signal3[n], signal4[n], tol=1e-5)
 
 #Test the reseed = True
 
-arma.reseedCopies=True
-pklReT=pk.dumps(arma)
-unpkReT=pk.loads(pklReT)
+arma.reseedCopies = True
+pklReT = pk.dumps(arma)
+unpkReT = pk.loads(pklReT)
 #signal 5 and 6 should not be the same
-signal5=arma._generateARMASignal(testVal)
-signal6=unpkReT._generateARMASignal(testVal)
+signal5 = arma._generateARMASignal(testVal)
+signal6 = unpkReT._generateARMASignal(testVal)
 for n in range(len(data)):
   checkTrue('signal 5, signal 6 ind{}'.format(n),signal5[n]!=signal6[n])
 
 # Test the engine with seed
 
-eng=randomUtils.newRNG()
-arma.setEngine(eng,seed=901017,count=0)
-signal7=arma._generateARMASignal(testVal)
+eng = randomUtils.newRNG()
+arma.setEngine(eng, seed=901017)
+signal7 = arma._generateARMASignal(testVal)
 
-sig7=[0.39975177, -0.14531468,  0.13138866, -0.56565224,  0.06020252,
-      0.60752306, -0.29076173, -1.1758456,   0.41108591, -0.05735384]
+sig7 = [0.39975177, -0.14531468,  0.13138866, -0.56565224,  0.06020252,
+        0.60752306, -0.29076173, -1.1758456,   0.41108591, -0.05735384]
 for n in range(10):
   checkFloat('signal 7, evaluation ind{}'.format(n), signal7[n], sig7[n], tol=1e-7)
 

--- a/tests/framework/unit_tests/utils/testRandomUtils.py
+++ b/tests/framework/unit_tests/utils/testRandomUtils.py
@@ -348,8 +348,8 @@ for i in range(samps.shape[1]):
   checkTrue('Entry {}, simultaneous random 5D hypersphere for local engine provided'.format(i),np.sum(s*s)<=1.0,True)
 ## check if it is possible to instanciate multiple random number generators (isolated)
 ## this is more a test for the crow_modules.randomENGpy[2,3]
-firstRNG = randomENG.RandomClass()
-secondRNG = randomENG.RandomClass()
+firstRNG = randomUtils.newRNG()
+secondRNG = randomUtils.newRNG()
 # seed with different seeds
 firstRNG.seed(200286)
 secondRNG.seed(20021986)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#1863 

##### What are the significant changes in functionality due to this change request?
Changes CrowRNG method names to camel case to bring them into compliance with RAVEN code standards.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

