### PR TITLE
Fix WorkingDir of Driver.py

### DIFF
--- a/ravenframework/Driver.py
+++ b/ravenframework/Driver.py
@@ -141,6 +141,10 @@ def main(checkLibraries):
 
     # call the function to load the external xml files into the input tree
     cwd = os.path.dirname(os.path.abspath(inputFile))
+    # If a user chooses to run RAVEN outside of the directory containing the
+    # xml input file, then we should should change the python working directory
+    # to the directory containing the input file to avoid confusion.
+    os.chdir(cwd)
     simulation.XMLpreprocess(root,cwd)
     #generate all the components of the simulation
     #Call the function to read and construct each single module of the simulation

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/failureOfRuns.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/constrained/failureOfRuns.xml
@@ -111,7 +111,7 @@
   </Samplers>
 
   <Models>
-    <ExternalModel ModuleToLoad="failureOfRuns/failureOnDemand.py" name="myLocalSum" subType="">
+    <ExternalModel ModuleToLoad="../../failureOfRuns/failureOnDemand.py" name="myLocalSum" subType="">
       <variables>x1,x2,x3,ans</variables>
     </ExternalModel>
   </Models>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

#1033
close #1687 
##### What are the significant changes in functionality due to this change request?

No significant changes. RAVEN will now adjust its working directory to be wherever the input file is pointed. 

For example, before this would break raven:

```
cd raven
./raven_framework tests/framework/user_guide/ravenTutorial/singleRun.xml
```

Now it doesn't. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

