### PR TITLE
Lock in DistributedMemoryRunner

### DIFF
--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -977,6 +977,8 @@ class JobHandler(BaseType):
       @ In, ids, list(str), job prefixes to terminate
       @ Out, None
     """
+    #XXX terminateJobs modifies the running queue, which
+    # cleanJobQueue, and fillJobQueue assume can't happen
     queues = [self.__queue, self.__clientQueue, self.__running, self.__clientRunning]
     with self.__queueLock:
       for _, queue in enumerate(queues):

--- a/ravenframework/Runners/DistributedMemoryRunner.py
+++ b/ravenframework/Runners/DistributedMemoryRunner.py
@@ -55,6 +55,7 @@ class DistributedMemoryRunner(InternalRunner):
     if not im.isLibAvail("ray"):
       self.__ppserver, args = args[0], args[1:]
     super().__init__(args, functionToRun, **kwargs)
+    self.thread = None
 
   def isDone(self):
     """

--- a/ravenframework/Runners/DistributedMemoryRunner.py
+++ b/ravenframework/Runners/DistributedMemoryRunner.py
@@ -56,6 +56,7 @@ class DistributedMemoryRunner(InternalRunner):
     if not im.isLibAvail("ray"):
       self.__ppserver, args = args[0], args[1:]
     super().__init__(args, functionToRun, **kwargs)
+    # __func (when using ray) is the object ref
     self.__func = None
     # __funcLock is needed because if isDone and kill are called at the
     # same time, isDone might end up trying to use __func after it is deleted

--- a/ravenframework/Runners/InternalRunner.py
+++ b/ravenframework/Runners/InternalRunner.py
@@ -44,7 +44,6 @@ class InternalRunner(Runner):
     self.functionToRun = functionToRun
 
     ## Other parameters manipulated internally
-    self.thread = None
     self.runReturn = None
     self.hasBeenAdded = False
     self.returnCode = 0

--- a/ravenframework/Runners/SharedMemoryRunner.py
+++ b/ravenframework/Runners/SharedMemoryRunner.py
@@ -56,6 +56,7 @@ class SharedMemoryRunner(InternalRunner):
     #self.subque = queue.Queue()
 
     self.skipOnCopy.append('subque')
+    self.thread = None
 
   def isDone(self):
     """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #1881 

##### What are the significant changes in functionality due to this change request?
Adds a lock in DistributedMemoryRunner to prevent two threads stepping on each other.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

