### PR TITLE
Mandd/todo list

### DIFF
--- a/doc/workshop/timeDepDataMining/inputs/TD_KMeans.xml
+++ b/doc/workshop/timeDepDataMining/inputs/TD_KMeans.xml
@@ -100,22 +100,17 @@
         <precompute_distances>True</precompute_distances>
       </KDD>
     </PostProcessor>
-    <PostProcessor name="dataPreProc" subType="InterfacedPostProcessor">
-      <method>HS2PS</method>
+    <PostProcessor name="dataPreProc" subType="HS2PS">
       <pivotParameter>time</pivotParameter>
     </PostProcessor>
     <ExternalModel ModuleToLoad="../lorentzAttractor_disc" name="PythonModule" subType="">
       <variables>sigma,rho,beta,x,y,z,time,x0,y0,z0</variables>
     </ExternalModel>
-    <PostProcessor name="filter0" subType="InterfacedPostProcessor">
-      <method>dataObjectLabelFilter</method>
-      <dataType>HistorySet</dataType>
+    <PostProcessor name="filter0" subType="dataObjectLabelFilter">
       <label>KMeans1Labels</label>
       <clusterIDs>0</clusterIDs>
     </PostProcessor>
-    <PostProcessor name="filter1" subType="InterfacedPostProcessor">
-      <method>dataObjectLabelFilter</method>
-      <dataType>HistorySet</dataType>
+    <PostProcessor name="filter1" subType="dataObjectLabelFilter">
       <label>KMeans1Labels</label>
       <clusterIDs>1</clusterIDs>
     </PostProcessor>

--- a/doc/workshop/timeDepDataMining/inputs/TD_KMeans.xml
+++ b/doc/workshop/timeDepDataMining/inputs/TD_KMeans.xml
@@ -5,7 +5,7 @@
     <author>wangc</author>
     <created>2018-09-21</created>
     <classesTested>PostProcessors.DataMining</classesTested>
-    <description>Workshop test: Time dependent data mining with KMeans analysis wit preprocessor</description>
+    <description>Workshop test: Time dependent data mining with KMeans analysis with preprocessor</description>
     <revisions>
       <revision author="wangc" date="2018-09-27">
         As reported in issue #805, RAVEN will not allow input DataObject of PostProcessor to be output DataObject,

--- a/ravenframework/CodeInterfaceBaseClass.py
+++ b/ravenframework/CodeInterfaceBaseClass.py
@@ -174,7 +174,7 @@ class CodeInterfaceBase(utils.metaclass_insert(abc.ABCMeta,object)):
     """
       This method returns a list of extension the code interface accepts for the input file (the main one)
       @ In, None
-      @ Out, tuple, tuple of strings containing accepted input extension (e.g.(".i",".inp"]) )
+      @ Out, tuple, tuple of strings containing accepted input extension (e.g.[".i",".inp"]) )
     """
     return tuple(self.inputExtensions)
 
@@ -217,7 +217,7 @@ class CodeInterfaceBase(utils.metaclass_insert(abc.ABCMeta,object)):
 
   def finalizeCodeOutput(self, command, output, workingDir):
     """
-      this method is called by the RAVEN code at the end of each run (if the method is present).
+      This method is called by the RAVEN code at the end of each run (if the method is present).
       It can be used for those codes, that do not create CSV files to convert the whatever output format into a csv
       @ In, command, string, the command used to run the just ended job
       @ In, output, string, the Output name root
@@ -233,7 +233,7 @@ class CodeInterfaceBase(utils.metaclass_insert(abc.ABCMeta,object)):
   def checkForOutputFailure(self, output, workingDir):
     """
       This method is called by RAVEN at the end of each run if the return code is == 0.
-      This method needs to be implemented by the codes that, if the run fails, return a return code that is 0
+      This method needs to be implemented for the codes that, if the run fails, return a return code that is 0
       This can happen in those codes that record the failure of the job (e.g. not converged, etc.) as normal termination (returncode == 0)
       This method can be used, for example, to parse the output file looking for a special keyword that testifies that a particular job got failed
       (e.g. in RELAP5 would be the keyword "********")

--- a/ravenframework/CodeInterfaceClasses/Generic/GenericCodeInterface.py
+++ b/ravenframework/CodeInterfaceClasses/Generic/GenericCodeInterface.py
@@ -26,7 +26,7 @@ from ravenframework.CodeInterfaceBaseClass import CodeInterfaceBase
 class GenericCode(CodeInterfaceBase):
   """
     This class is used as a generic code interface for Model.Code in Raven.  It expects
-    input paremeters to be specified by input file, input files be specified by either
+    input parameters to be specified by input file, input files be specified by either
     command line or in a main input file, and produce a csv output.  It makes significant
     use of the 'clargs', 'fileargs', 'prepend', 'text', and 'postpend' nodes in the input
     XML file.  See base class for more details.
@@ -76,7 +76,7 @@ class GenericCode(CodeInterfaceBase):
       @ In, inputFiles, list, List of input files (length of the list depends on the number of inputs have been added in the Step is running this code)
       @ In, executable, string, executable name with absolute path (e.g. /home/path_to_executable/code.exe)
       @ In, clargs, dict, optional, dictionary containing the command-line flags the user can specify in the input (e.g. under the node < Code >< clargstype =0 input0arg =0 i0extension =0 .inp0/ >< /Code >)
-      @ In, fargs, dict, optional, a dictionary containing the axuiliary input file variables the user can specify in the input (e.g. under the node < Code >< fileargstype =0 input0arg =0 aux0extension =0 .aux0/ >< /Code >)
+      @ In, fargs, dict, optional, a dictionary containing the auxiliary input file variables the user can specify in the input (e.g. under the node < Code >< fileargstype =0 input0arg =0 aux0extension =0 .aux0/ >< /Code >)
       @ In, preExec, string, optional, a string the command that needs to be pre-executed before the actual command here defined
       @ Out, returnCommand, tuple, tuple containing the generated command. returnCommand[0] is the command to run the code (string), returnCommand[1] is the name of the output root
     """

--- a/ravenframework/CodeInterfaceClasses/Generic/GenericParser.py
+++ b/ravenframework/CodeInterfaceClasses/Generic/GenericParser.py
@@ -47,7 +47,7 @@ class GenericParser():
       Accept the input file and parse it by the prefix-postfix breaks. Someday might be able to change prefix,postfix,defaultDelim from input file, but not yet.
       @ In, inputFiles, list, string list of input filenames that might need parsing.
       @ In, prefix, string, optional, the string prefix to find input variables within the input files
-      @ In, postfix, string, optional, the string postfix signifying hte end of an input variable within an input file
+      @ In, postfix, string, optional, the string postfix signifying the end of an input variable within an input file
       @ In, defaultDelim, string, optional, the string used between prefix and postfix to set default values
       @ In, formatDelim, string, optional, the string used between prefix and postfix to set the format of the value
       @ Out, None
@@ -127,7 +127,7 @@ class GenericParser():
 
   def modifyInternalDictionary(self,**Kwargs):
     """
-      Edits the parsed file stored in self.segments to enter new variable values preperatory to a new run.
+      Edits the parsed file stored in self.segments to enter new variable values preparatory to a new run.
       @ In, **Kwargs, dict, dict including moddit (the dictionary of variable:value to replace) and additionalEdits.
       @ Out, None
     """

--- a/ravenframework/CodeInterfaceClasses/Generic/GenericParser.py
+++ b/ravenframework/CodeInterfaceClasses/Generic/GenericParser.py
@@ -40,7 +40,7 @@ def _reprIfFloat(value):
 
 class GenericParser():
   """
-    import the user-edited input file, build list of strings with replacable parts
+    import the user-edited input file, build list of strings with replaceable parts
   """
   def __init__(self,inputFiles,prefix='$RAVEN-',postfix='$',defaultDelim=':', formatDelim='|'):
     """

--- a/ravenframework/Models/Code.py
+++ b/ravenframework/Models/Code.py
@@ -588,7 +588,7 @@ class Code(Model):
         time.sleep(0.5)
         process.poll()
         if time.time() > timeout and process.returncode is None:
-          self.raiseAWarning('walltime exeeded in run in working dir: '+str(metaData['subDirectory'])+'. Killing the run...')
+          self.raiseAWarning('walltime exceeded in run in working dir: '+str(metaData['subDirectory'])+'. Killing the run...')
           process.kill()
           process.returncode = -1
         if process.returncode is not None or time.time() > timeout:

--- a/ravenframework/Optimizers/Optimizer.py
+++ b/ravenframework/Optimizers/Optimizer.py
@@ -358,7 +358,7 @@ class Optimizer(AdaptiveSampler):
 
   def _addTrackingInfo(self, info, **kwargs):
     """
-      Creates realization identifiers to identifiy particular realizations as they return from the JobHandler.
+      Creates realization identifiers to identify particular realizations as they return from the JobHandler.
       Expandable by inheritors.
       @ In, info, dict, dictionary of potentially-existing added identifiers
       @ In, kwargs, dict, dictionary of keyword arguments

--- a/ravenframework/Optimizers/RavenSampled.py
+++ b/ravenframework/Optimizers/RavenSampled.py
@@ -96,7 +96,7 @@ class RavenSampled(Optimizer):
     ok.update({'trajID': 'integer identifier for different optimization starting locations and paths',
                'iteration': 'integer identifying which iteration (or step, or generation) a trajectory is on',
                'accepted': 'string acceptance status of the potential optimal point (algorithm dependent)',
-               'rejectReason':'discription of reject reason, \'noImprovement\' means rejected the new optimization point for no improvement from last point, \'implicitConstraintsViolation\' means rejected by implicit constraints violation, return None if the point is accepted',
+               'rejectReason':'description of reject reason, \'noImprovement\' means rejected the new optimization point for no improvement from last point, \'implicitConstraintsViolation\' means rejected by implicit constraints violation, return None if the point is accepted',
                '{VAR}': r'any variable from the \xmlNode{TargetEvaluation} input or output; gives the value of that variable at the optimal candidate for this iteration.',
               })
 
@@ -384,7 +384,7 @@ class RavenSampled(Optimizer):
     """
       Increments the "generation" or "iteration" of an optimization algorithm.
       The definition of generation is algorithm-specific; this is a utility for tracking only.
-      @ In, traj, int, identifer for trajectory
+      @ In, traj, int, identifier for trajectory
       @ Out, None
     """
     self.__stepCounter[traj] += 1
@@ -393,7 +393,7 @@ class RavenSampled(Optimizer):
     """
       Provides the "generation" or "iteration" of an optimization algorithm.
       The definition of generation is algorithm-specific; this is a utility for tracking only.
-      @ In, traj, int, identifer for trajectory
+      @ In, traj, int, identifier for trajectory
       @ Out, counter, int, iteration of the trajectory
     """
     return self.__stepCounter[traj]
@@ -406,7 +406,7 @@ class RavenSampled(Optimizer):
       @ In, proposed, dict, NORMALIZED sample opt point
       @ In, previous, dict, NORMALIZED previous opt point
       @ In, pointType, string, type of point to handle constraints for
-      @ Out, normed, dict, suggested NORMALIZED contraint-handled point
+      @ Out, normed, dict, suggested NORMALIZED constraint-handled point
       @ Out, modded, bool, whether point was modified or not
     """
     denormed = self.denormalizeData(proposed)
@@ -543,7 +543,7 @@ class RavenSampled(Optimizer):
     # FIXME check implicit constraints? Function call, - Jia
     acceptable, old, rejectReason = self._checkAcceptability(traj, rlz, optVal, info)
     converged = self._updateConvergence(traj, rlz, old, acceptable)
-    # we only want to update persistance if we've accepted a new point.
+    # we only want to update persistence if we've accepted a new point.
     # We don't want rejected points to count against our convergence.
     if acceptable in ['accepted']:
       self._updatePersistence(traj, converged, optVal)

--- a/ravenframework/SupervisedLearning/SupervisedLearning.py
+++ b/ravenframework/SupervisedLearning/SupervisedLearning.py
@@ -122,7 +122,7 @@ class SupervisedLearning(BaseInterface):
     self.printTag = 'SupervisedLearning'
     self.features = None           # "inputs" to this model
     self.target = None             # "outputs" of this model
-    self.amITrained = False        # "True" if the ROM is alread trained
+    self.amITrained = False        # "True" if the ROM is already trained
     self._dynamicHandling = False  # time-like dependence in the model?
     self.dynamicFeatures = False   # time-like dependence in the feature space? FIXME: this is not the right design
     self._assembledObjects = None  # objects assembled by the ROM Model, passed through.
@@ -425,7 +425,7 @@ class SupervisedLearning(BaseInterface):
   def isDynamic(self):
     """
       This method is a utility function that tells if the relative ROM is able to
-      treat dynamic data (e.g. time-series) on its own or not (Primarly called by LearningGate)
+      treat dynamic data (e.g. time-series) on its own or not (Primarily called by LearningGate)
       @ In, None
       @ Out, isDynamic, bool, True if the ROM is able to treat dynamic data, False otherwise
     """

--- a/tests/framework/user_guide/optimizing/simple.xml
+++ b/tests/framework/user_guide/optimizing/simple.xml
@@ -72,7 +72,8 @@
 
   <Models>
     <ExternalModel ModuleToLoad="../../../../framework/AnalyticModels/optimizing/beale" name="beale" subType="">
-      <variables>x,y,ans</variables>
+      <inputs>x,y</inputs>
+      <outputs>ans</outputs>
     </ExternalModel>
   </Models>
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes issues #799 , #1291 
Fixing few typos in the code
Random edits

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

