### PR TITLE
Cleaning up .gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ framework/states.txt
 
 # plugin installation paths
 plugins/plugin_directory.xml
+
+# vscode
+.vscode
+*.code-workspace

--- a/tests/framework/.gitignore
+++ b/tests/framework/.gitignore
@@ -112,13 +112,16 @@ RedundantInputs/sim_py_grid/
 RedundantInputs/sim_py_MC/
 RedundantInputs/sim_py_SC/
 RedundantInputs/sobol_redundant/
+ROM/pickleTests/ARMA/arma.pk
 ROM/pickleTests/StochasticPolyPickleTest/ROMpk
 ROM/scgpc/
 ROM/Sobol/AdaptSobol/
 ROM/Sobol/SobolTime/
 ROM/Sobol/states.txt
+ROM/tensorflow_keras/data/cnn1d.pk
 ROM/TimeSeries/ARMA/ARMAparallel/
 ROM/TimeSeries/ARMA/ARMAreseed/
+ROM/TimeSeries/ARMA/Interpolated/interpolated.pk
 ROM/TimeSeries/ARMA/Multicycle/arma.pk
 ROM/TimeSeries/ARMA/Segmented/arma.pk
 ROM/TimeSeries/ARMA/ZeroFilterCluster/arma.pk
@@ -129,6 +132,7 @@ ROM/TimeSeries/DMD/TraditionalDMD/
 ROM/TimeSeries/PolyExponential/PolyExpNearest/
 ROM/TimeSeries/PolyExponential/PolyExpPoly/
 ROM/TimeSeries/PolyExponential/PolyExpSpline/
+ROM/TimeSeries/SyntheticHistory/ARMA/
 RunFailures/csample/
 SingleRuns/run/sample/
 TestXSD/test_more.xsd


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Addresses #1647

##### What are the significant changes in functionality due to this change request?
No changes to RAVEN functionality. This PR updates .gitignore files to ignore the files generated from running regression tests. It cleans things up when running `git status`.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

