### PR TITLE
More parallel work

### DIFF
--- a/ravenframework/Models/Code.py
+++ b/ravenframework/Models/Code.py
@@ -770,6 +770,9 @@ class Code(Model):
       @ Out, None
     """
     evaluation = finishedJob.getEvaluation()
+    if not hasattr(evaluation, 'pop'):
+      print("evaluation", evaluation, "job", finishedJob, finishedJob.getReturnCode())
+
 
     self._replaceVariablesNamesWithAliasSystem(evaluation, 'input',True)
     # in the event a batch is run, the evaluations will be a dict as {'RAVEN_isBatch':True, 'realizations': [...]}

--- a/ravenframework/Runners/DistributedMemoryRunner.py
+++ b/ravenframework/Runners/DistributedMemoryRunner.py
@@ -75,10 +75,14 @@ class DistributedMemoryRunner(InternalRunner):
     with self.__funcLock:
       if self.__func is None:
         return True
+      elif self.hasBeenAdded:
+        return True
       else:
         if im.isLibAvail("ray"):
           try:
-            ray.get(self.__func, timeout=waitTimeOut)
+            runReturn = ray.get(self.__func, timeout=waitTimeOut)
+            self.runReturn = runReturn
+            self.hasBeenAdded = True
             return True
           except ray.exceptions.GetTimeoutError:
             return False
@@ -101,12 +105,13 @@ class DistributedMemoryRunner(InternalRunner):
       @ In, None
       @ Out, None
     """
-    if not self.hasBeenAdded:
-      if self.__func is not None:
-        self.runReturn = ray.get(self.__func) if im.isLibAvail("ray") else self.__func()
-      else:
-        self.runReturn = None
-      self.hasBeenAdded = True
+    with self.__funcLock:
+      if not self.hasBeenAdded:
+        if self.__func is not None:
+          self.runReturn = ray.get(self.__func) if im.isLibAvail("ray") else self.__func()
+        else:
+          self.runReturn = None
+        self.hasBeenAdded = True
 
   def start(self):
     """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
#1901 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

