### PR TITLE
Fix typo in input.

### DIFF
--- a/doc/workshop/optimizer/GeneticAlgorithms/Inputs/3_GA_MaxwoRepConstrained.xml
+++ b/doc/workshop/optimizer/GeneticAlgorithms/Inputs/3_GA_MaxwoRepConstrained.xml
@@ -9,7 +9,7 @@
   </TestInfo>
 
   <RunInfo>
-    <WorkingDir>MaxwoReplacementCOnstrained</WorkingDir>
+    <WorkingDir>MaxwoReplacementConstrained</WorkingDir>
     <Sequence>optimize,print</Sequence><!--Fill this in-->
     <batchSize>1</batchSize>
   </RunInfo>

--- a/doc/workshop/optimizer/GeneticAlgorithms/Inputs/4_GA_MaximumHorizontalRange.xml
+++ b/doc/workshop/optimizer/GeneticAlgorithms/Inputs/4_GA_MaximumHorizontalRange.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Simulation verbosity="debug" profile="jobs">
+<Simulation verbosity="quiet">
   <TestInfo>
     <name>doc/workshop/optimizer/GeneticAlgorithms/inputs.GA_MaxContinuousHRangeConstrained</name>
     <author>Mohammad Abdo (@Jimmy-INL)</author>
@@ -21,7 +21,6 @@
       <Optimizer class="Optimizers" type="GeneticAlgorithm">GAopt</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
-      <Output class="OutStreams" type="Print">opt_export</Output>
     </MultiRun>
     <IOStep name="print">
       <Input class="DataObjects" type="PointSet">opt_export</Input>

--- a/doc/workshop/optimizer/GeneticAlgorithms/Inputs/tests
+++ b/doc/workshop/optimizer/GeneticAlgorithms/Inputs/tests
@@ -18,5 +18,6 @@
     type = 'RavenFramework'
     input = '4_GA_MaximumHorizontalRange.xml'
     output = 'MaxHRange/opt_export_0.csv'
+    #skip_if_OS = 'windows'
   [../]
 []

--- a/doc/workshop/optimizer/GeneticAlgorithms/Inputs/tests
+++ b/doc/workshop/optimizer/GeneticAlgorithms/Inputs/tests
@@ -18,6 +18,5 @@
     type = 'RavenFramework'
     input = '4_GA_MaximumHorizontalRange.xml'
     output = 'MaxHRange/opt_export_0.csv'
-    #skip_if_OS = 'windows'
   [../]
 []

--- a/doc/workshop/reducedOrderModeling/inputs/examples/tests
+++ b/doc/workshop/reducedOrderModeling/inputs/examples/tests
@@ -28,6 +28,7 @@
     type = 'RavenFramework'
     input = '4b_load_and_sample_pretrained_rom.xml'
     output = 'r4_b/plotROM_scatter.png r4_b/romOut.csv'
+    prereq = pickle
   [../]
   [./romWF]
     type = 'RavenFramework'


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
#1806 

##### What are the significant changes in functionality due to this change request?
Fixes typo that was causing test failure.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

