### PR TITLE
Use ray on windows as well.

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -35,7 +35,7 @@ Note all install methods after "main" take
 -->
 <dependencies>
   <main>
-    <h5py>2.10</h5py>
+    <h5py/>
     <numpy>1.18</numpy>
     <scipy>1.5</scipy>
     <scikit-learn>0.24</scikit-learn>
@@ -59,7 +59,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <cmake skip_check='True' optional='True'/>
-    <ray source="pip" pip_extra="[default]">1.9</ray>
+    <ray source="pip" pip_extra="[default]">1.12</ray>
     <imageio>2.9</imageio>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -59,7 +59,7 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <cmake skip_check='True' optional='True'/>
-    <ray os="mac,linux" source="pip" pip_extra="[default]">1.9</ray>
+    <ray source="pip" pip_extra="[default]">1.9</ray>
     <imageio>2.9</imageio>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -60,6 +60,7 @@ Note all install methods after "main" take
     <numexpr os='linux'/>
     <cmake skip_check='True' optional='True'/>
     <ray source="pip" pip_extra="[default]">1.12</ray>
+    <redis source="pip" os='windows'/>
     <imageio>2.9</imageio>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -60,6 +60,7 @@ Note all install methods after "main" take
     <numexpr os='linux'/>
     <cmake skip_check='True' optional='True'/>
     <ray source="pip" pip_extra="[default]">1.12</ray>
+    <!-- redis is needed by ray, but on windows, this seems to need to be explicitly stated -->
     <redis source="pip" os='windows'/>
     <imageio>2.9</imageio>
     <line_profiler optional='True'/>

--- a/doc/user_manual/runInfo.tex
+++ b/doc/user_manual/runInfo.tex
@@ -273,20 +273,10 @@ automatically sets this option )
 %
 \default{None - Automatic detection}
 
-%%%%%% redisPassword
-\item \xmlNode{redisPassword}, \xmlDesc{string, optional
-field}, specifies, if \xmlNode{internalParallel} is set to true, the password used by the RAVEN internal parallelization
-in order to link multiple sockets to the main RAVEN runner. If set, in conjunction with  \xmlNode{headNode},  the RAVEN internal parallelization will try to link
-to an already established parallel enviroment (without re-instanciating another).
-\nb This option is generally used when multiple instances of RAVEN are run in the same HPC clusters (e.g. RAVEN running RAVEN, which
-automatically sets this option )
-%
-\default{None - Automatic detection}
-
 %%%%%% remoteNodes
 \item \xmlNode{remoteNodes}, \xmlDesc{comma separated string, optional
 field}, specifies, if \xmlNode{internalParallel} is set to true, the list of nodes (IPs) that should be used by the RAVEN to deploy its internal parallelization.
-If set, in conjunction with  \xmlNode{headNode} and \xmlNode{redisPassword},  the RAVEN internal parallelization will try to link
+If set, in conjunction with  \xmlNode{headNode},  the RAVEN internal parallelization will try to link
 to an already established parallel enviroment (without re-instanciating another).
 \nb This option is generally used when multiple instances of RAVEN are run in the same HPC clusters (e.g. RAVEN running RAVEN, which
 automatically sets this option )

--- a/ravenframework/CodeInterfaceClasses/RAVEN/RAVENInterface.py
+++ b/ravenframework/CodeInterfaceClasses/RAVEN/RAVENInterface.py
@@ -277,7 +277,6 @@ class RAVEN(CodeInterfaceBase):
 
     if 'headNode' in Kwargs:
       modifDict['RunInfo|headNode'] = Kwargs['headNode']
-      modifDict['RunInfo|redisPassword'] = Kwargs['redisPassword']
     if 'remoteNodes' in Kwargs:
       if Kwargs['remoteNodes'] is not None and len(Kwargs['remoteNodes']):
         modifDict['RunInfo|remoteNodes'] = ','.join(Kwargs['remoteNodes'])

--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -225,7 +225,7 @@ class JobHandler(BaseType):
         self.rayServer = ray.init(num_cpus=int(self.runInfoDict['totalNumCoresUsed']),include_dashboard=db) if _rayAvail else \
                            pp.Server(ncpus=int(self.runInfoDict['totalNumCoresUsed']))
       if _rayAvail:
-        self.raiseADebug("Head node IP address: ", self.rayServer['node_ip_address'])
+        self.raiseADebug("Head node IP address: ", self.rayServer.address_info['node_ip_address'])
         self.raiseADebug("Redis address       : ", self.rayServer['redis_address'])
         self.raiseADebug("Object store address: ", self.rayServer['object_store_address'])
         self.raiseADebug("Raylet socket name  : ", self.rayServer['raylet_socket_name'])

--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -226,10 +226,10 @@ class JobHandler(BaseType):
                            pp.Server(ncpus=int(self.runInfoDict['totalNumCoresUsed']))
       if _rayAvail:
         self.raiseADebug("Head node IP address: ", self.rayServer.address_info['node_ip_address'])
-        self.raiseADebug("Redis address       : ", self.rayServer['redis_address'])
-        self.raiseADebug("Object store address: ", self.rayServer['object_store_address'])
-        self.raiseADebug("Raylet socket name  : ", self.rayServer['raylet_socket_name'])
-        self.raiseADebug("Session directory   : ", self.rayServer['session_dir'])
+        self.raiseADebug("Redis address       : ", self.rayServer.address_info['redis_address'])
+        self.raiseADebug("Object store address: ", self.rayServer.address_info['object_store_address'])
+        self.raiseADebug("Raylet socket name  : ", self.rayServer.address_info['raylet_socket_name'])
+        self.raiseADebug("Session directory   : ", self.rayServer.address_info['session_dir'])
         if servers:
           self.raiseADebug("# of remote servers : ", str(len(servers)))
           self.raiseADebug("Remote servers      : ", " , ".join(servers))

--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -24,7 +24,6 @@ import sys
 import threading
 from random import randint
 import socket
-import time
 import re
 
 from .utils import importerUtils as im
@@ -315,34 +314,12 @@ class JobHandler(BaseType):
       if rayStart.returncode != 0:
         self.raiseAnError(RuntimeError, f"RAY failed to start on the --head node! Return code is {rayStart.returncode}")
       else:
-        #address, redisPassword = self.__getRayInfoFromStart("ray_head.ip")
-        address = self.__getRayInfoFromStartNew("ray_head.ip")
+        address = self.__getRayInfoFromStart("ray_head.ip")
     return address, redisPassword
 
   def __getRayInfoFromStart(self, rayLog):
     """
-      Read Ray info from shell return script
-      @ In, rayLog, str, the ray output log
-      @ Out, address, str, the retrieved address (ip:port)
-      @ Out, redisPassword, str, the redis password
-    """
-    address, redisPassword = None, None
-    with open(rayLog, 'r') as rayLogObj:
-      for line in rayLogObj.readlines():
-        if " ray start" in line.strip():
-          ix = line.strip().find("ray start")
-          address, redisPassword = line.strip()[ix:].replace("ray start","").strip().split()
-          redisPassword = redisPassword.split("=")[-1].replace("'","")
-          address_arg, address = address.replace("'","").split("=")
-          if address_arg.strip() != "--address":
-            self.raiseAWarning("Unexpected ray start:" + line)
-          break
-
-    return address, redisPassword
-
-  def __getRayInfoFromStartNew(self, rayLog):
-    """
-      Read Ray info from shell return script for newer ray versions
+      Read Ray info from shell return script for ray
       @ In, rayLog, str, the ray output log
       @ Out, address, str, the retrieved address (ip:port)
     """

--- a/ravenframework/RemoteNodeScripts/start_ray.sh
+++ b/ravenframework/RemoteNodeScripts/start_ray.sh
@@ -23,15 +23,14 @@
 OUTFILE=$1
 # BASH_PROFILE 
 HEAD_ADDRESS=$2
-REDIS_PASS=$3
-NUM_CPUS=$4
-RAVEN_FRAMEWORK_DIR=$5
+NUM_CPUS=$3
+RAVEN_FRAMEWORK_DIR=$4
 
 echo starting >> $OUTFILE
 
-if [ $# -eq 6 ]
+if [ $# -eq 5 ]
   then
-  REMOTE_BASH=$6
+  REMOTE_BASH=$5
   source $REMOTE_BASH >> $OUTFILE 2>&1
 fi
 
@@ -40,4 +39,4 @@ hostname >> $OUTFILE
 
 echo loaded >> $OUTFILE
 command -v ray >> $OUTFILE 2>&1
-ray start --address=$HEAD_ADDRESS --redis-password=$REDIS_PASS --num-cpus $NUM_CPUS >> $OUTFILE 2>&1
+ray start --verbose --address=$HEAD_ADDRESS --num-cpus $NUM_CPUS >> $OUTFILE 2>&1

--- a/ravenframework/RemoteNodeScripts/start_remote_servers.sh
+++ b/ravenframework/RemoteNodeScripts/start_remote_servers.sh
@@ -54,9 +54,6 @@ function display_usage()
 	echo '    --address'
 	echo '      Head node address'
 	echo ''
-	echo '    --redis-password'
-	echo '      Specify the password for redis (head node password)'
-	echo ''
 	echo '    --num-cpus'
 	echo '      Number of cpus available/to use in this node'
 	echo ''
@@ -81,7 +78,6 @@ function display_usage()
 # set control variable
 REMOTE_ADDRESS=""
 HEAD_ADDRESS=""
-REDIS_PASS=""
 PYTHONPATH=""
 WORKINGDIR=""
 RAVEN_FRAMEWORK_DIR=""
@@ -105,10 +101,6 @@ do
     --address)
       shift
       HEAD_ADDRESS=$1
-      ;;
-    --redis-password)
-      shift
-      REDIS_PASS=$1
       ;;
     --num-cpus)
       shift
@@ -151,12 +143,6 @@ then
   exit
 fi
 
-if [[ "$REDIS_PASS" == "" ]];
-then
-  echo ... ERROR: --redis-password argument must be inputted !
-  exit
-fi
-
 if [[ "$PYTHONPATH" == "" ]];
 then
   echo ... ERROR: --python-path argument must be inputted !
@@ -177,7 +163,7 @@ OUTPUT=$CWD/server_debug_$REMOTE_ADDRESS
 
 if [[ "$REMOTE_BASH" == "" ]];
 then
-  ssh $REMOTE_ADDRESS $ECE_SCRIPT_DIR/server_start.py ${WORKINGDIR} ${OUTPUT} ${PYTHONPATH} "${ECE_SCRIPT_DIR}/start_ray.sh $OUTPUT $HEAD_ADDRESS $REDIS_PASS $NUM_CPUS $RAVEN_FRAMEWORK_DIR"
+  ssh $REMOTE_ADDRESS $ECE_SCRIPT_DIR/server_start.py ${WORKINGDIR} ${OUTPUT} ${PYTHONPATH} "${ECE_SCRIPT_DIR}/start_ray.sh $OUTPUT $HEAD_ADDRESS $NUM_CPUS $RAVEN_FRAMEWORK_DIR" 2>&1 | tee $START_OUTPUT
 else
-  ssh $REMOTE_ADDRESS $ECE_SCRIPT_DIR/server_start.py ${WORKINGDIR} ${OUTPUT} ${PYTHONPATH} "${ECE_SCRIPT_DIR}/start_ray.sh $OUTPUT $HEAD_ADDRESS $REDIS_PASS $NUM_CPUS $RAVEN_FRAMEWORK_DIR $REMOTE_BASH"
+  ssh $REMOTE_ADDRESS $ECE_SCRIPT_DIR/server_start.py ${WORKINGDIR} ${OUTPUT} ${PYTHONPATH} "${ECE_SCRIPT_DIR}/start_ray.sh $OUTPUT $HEAD_ADDRESS $NUM_CPUS $RAVEN_FRAMEWORK_DIR $REMOTE_BASH" 2>&1 | tee $START_OUTPUT
 fi

--- a/ravenframework/Simulation.py
+++ b/ravenframework/Simulation.py
@@ -670,8 +670,6 @@ class Simulation(MessageUser):
         self.runInfoDict['deleteOutExtension'] = element.text.strip().split(',')
       elif element.tag == 'headNode':
         self.runInfoDict['headNode'] = element.text.strip()
-      elif element.tag == 'redisPassword':
-        self.runInfoDict['redisPassword'] = element.text.strip()
       elif element.tag == 'remoteNodes':
         self.runInfoDict['remoteNodes'] = [el.strip() for el in element.text.strip().split(',')]
       elif element.tag == 'PYTHONPATH':

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from distutils.core import setup, Extension
 from distutils.command.build import build
 import os
 import sys
+import setuptools
 
 # Replicating the methods used in the RAVEN Makefile to find CROW_DIR,
 # If the Makefile changes to be more robust, so should this


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
#1922 

##### What are the significant changes in functionality due to this change request?
Uses ray on windows.  Ray 1.9 has bugs on windows, so upgrade to 1.12

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

