### PR TITLE
Extra setup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include crow/include/distributions/*.h
+include crow/include/utilities/*.h
+recursive-include crow/contrib/include/Eigen *
+recursive-include crow/contrib/include/boost *
+include include/contrib/AMSC/*.h
+include include/contrib/ngl/*.h*

--- a/ravenframework/PluginManager.py
+++ b/ravenframework/PluginManager.py
@@ -91,7 +91,14 @@ def finishLoadPlugin(name):
     @ Out, available, bool, if True then plugin is available to use
   """
   if name not in _delayedPlugins:
-    return False
+    #Try to find module in system (such as from pip install)
+    #Note that loadEntities (below) checks if there is a subclass of
+    # PluginBase.PluginBase before using it, so this is safe.
+    spec = importlib.util.find_spec(name)
+    if spec is None:
+      return False
+    plugin = importlib.util.module_from_spec(spec)
+    _delayedPlugins[name] = (spec, plugin, False)
   spec, plugin, loaded = _delayedPlugins[name]
   if not loaded:
     spec.loader.exec_module(plugin)

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,10 @@ except:
 if eigen_flags.startswith("-I"):
   include_dirs.append(eigen_flags[2:].rstrip())
 setup(name='raven_framework',
-      version='2.1',
+      version='2.2pre1',
       description='RAVEN and RAVEN c++ dependenciences including A library for computing the Approximate Morse-Smale Complex (AMSC) and Crow probability tools',
       package_dir={'AMSC': 'src/contrib/AMSC', 'crow_modules': 'src/crow_modules', 'ravenframework': 'ravenframework'},
+      classifiers=['Programming Language :: Python :: 3'],
       entry_points={
           'console_scripts': [
               'raven_framework = ravenframework.Driver:wheelMain'

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ from distutils.core import setup, Extension
 from distutils.command.build import build
 import os
 import sys
+import setuptools
 
 # Replicating the methods used in the RAVEN Makefile to find CROW_DIR,
 # If the Makefile changes to be more robust, so should this


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
#1833

##### What are the significant changes in functionality due to this change request?
Adds a manifest file
If a plugin is not listed, try loading directly.
Small fixes to setup.py

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

