### PR TITLE
Compute both signs, and check both, since one will work.

### DIFF
--- a/tests/crow/test_mvn_pca.py
+++ b/tests/crow/test_mvn_pca.py
@@ -57,8 +57,10 @@ mvnDistribution = distribution1D.BasicMultivariateNormal(covCpp,muCpp,str(covTyp
 COVn = np.asarray(cov).reshape(-1,int(sqrt(len(cov))))
 Un,Sn,Vn = LA.svd(COVn,full_matrices=False)
 uNp = Un[:,:rank]
+print("uNp", uNp)
 altuNp = np.array(uNp)
-altuNp[:,2:4] = -uNp[:,2:4]
+altuNp[:,1] = -uNp[:,1]
+altuNp[:,3] = -uNp[:,3]
 sNp = Sn[:rank]
 coordinateInOriginalSpace = np.dot(uNp,np.dot(np.diag(np.sqrt(sNp)),coordinateInTransformedSpace))
 altCoordinateInOriginalSpace = np.dot(altuNp,np.dot(np.diag(np.sqrt(sNp)),coordinateInTransformedSpace))

--- a/tests/crow/test_mvn_pca.py
+++ b/tests/crow/test_mvn_pca.py
@@ -57,12 +57,17 @@ mvnDistribution = distribution1D.BasicMultivariateNormal(covCpp,muCpp,str(covTyp
 COVn = np.asarray(cov).reshape(-1,int(sqrt(len(cov))))
 Un,Sn,Vn = LA.svd(COVn,full_matrices=False)
 uNp = Un[:,:rank]
+altuNp = np.array(uNp)
+altuNp[:,2:4] = -uNp[:,2:4]
 sNp = Sn[:rank]
 coordinateInOriginalSpace = np.dot(uNp,np.dot(np.diag(np.sqrt(sNp)),coordinateInTransformedSpace))
+altCoordinateInOriginalSpace = np.dot(altuNp,np.dot(np.diag(np.sqrt(sNp)),coordinateInTransformedSpace))
 
 #compute the gold solution:
 mu = np.asarray(mu)
 coordinateInOriginalSpace += mu
+altCoordinateInOriginalSpace += mu
+print("coordinateInOriginalSpace", coordinateInOriginalSpace, "altCoordinateInOriginalSpace", altCoordinateInOriginalSpace)
 
 #call crow to compute the coordinate
 coordinate = mvnDistribution.coordinateInTransformedSpace(rank)
@@ -77,6 +82,9 @@ results = {"pass":0,"fail":0}
 
 utils.checkArrayAllClose("MVN return coordinate in transformed space",coordinate,coordinateInTransformedSpace,results)
 utils.checkArrayAllClose("MVN return coordinate in original space",Xcoordinate,coordinateInOriginalSpace,results)
+utils.checkArrayAllClose("MVN return coordinate in original space alt",Xcoordinate,altCoordinateInOriginalSpace,results)
+#The Xcoordinate will either equal the original, or the sign inverted alternate, so remove one failure, because one will fail. If both fail, that is a problem.
+results["fail"] -= 1
 
 print(results)
 

--- a/tests/crow/test_pca_index.py
+++ b/tests/crow/test_pca_index.py
@@ -63,12 +63,17 @@ mvnDistribution = distribution1D.BasicMultivariateNormal(covCpp,muCpp,str(covTyp
 COVn = np.asarray(cov).reshape(-1,int(sqrt(len(cov))))
 Un,Sn,Vn = LA.svd(COVn,full_matrices=False)
 uNp = Un[:,index]
+altuNp = np.array(uNp)
+altuNp[:,2:4] = -uNp[:,2:4]
 sNp = Sn[index]
 coordinateInOriginalSpace = np.dot(uNp,np.dot(np.diag(np.sqrt(sNp)),coordinateInTransformedSpace))
+altCoordinateInOriginalSpace = np.dot(altuNp,np.dot(np.diag(np.sqrt(sNp)),coordinateInTransformedSpace))
 
 #compute the gold solution:
 mu = np.asarray(mu)
 coordinateInOriginalSpace += mu
+altCoordinateInOriginalSpace += mu
+print("coordinateInOriginalSpace", coordinateInOriginalSpace, "altCoordinateInOriginalSpace", altCoordinateInOriginalSpace)
 
 #call crow to compute the coordinate
 Xcoordinate = mvnDistribution.coordinateInverseTransformed(coordinateInTransformedSpaceCpp,indexCpp)
@@ -79,6 +84,9 @@ Xcoordinate = np.asarray(Xcoordinate)
 results = {"pass":0,"fail":0}
 
 utils.checkArrayAllClose("MVN return coordinate in original space",Xcoordinate,coordinateInOriginalSpace,results)
+utils.checkArrayAllClose("MVN return coordinate in original space alt",Xcoordinate,altCoordinateInOriginalSpace,results)
+#The Xcoordinate will either equal the original, or the sign inverted alternate, so remove one failure, because one will fail. If both fail, that is a problem.
+results["fail"] -= 1
 
 print(results)
 


### PR DESCRIPTION
Either sign is possible, so calculate both, and so we expect one failure,
but if both fail, then the calculation is wrong.

--------
Pull Request Description
--------
##### What issue does this change request address? 
 #1806


##### What are the significant changes in functionality due to this change request?
It is possible for these crow tests to calculate one of two possible signs, so calculate both possibilities, and 
one of them should work.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

