### PR TITLE
Allows XML diff to only check a specific node.

### DIFF
--- a/rook/XMLDiff.py
+++ b/rook/XMLDiff.py
@@ -405,7 +405,20 @@ class XMLDiff:
           files_read = False
           self.__messages += 'Exception reading file '+gold_filename+': '+str(exp.args)
         if files_read:
-          if 'unordered' in self.__options.keys() and self.__options['unordered']:
+          if self.__options['alt_root'] is not None:
+            alt_test_root_list = test_root.findall(self.__options['alt_root'])
+            alt_gold_root_list = gold_root.findall(self.__options['alt_root'])
+            if len(alt_test_root_list) != 1 or len(alt_gold_root_list) != 1:
+              self.__same = False
+              messages = ["Alt root used and test len "+str(len(alt_test_root_list))+
+                          " and gold len "+str(len(alt_gold_root_list))]
+              same = False
+            else:
+              test_root = alt_test_root_list[0]
+              gold_root = alt_gold_root_list[0]
+          if not self.__same:
+            pass #already failed
+          elif 'unordered' in self.__options.keys() and self.__options['unordered']:
             same, messages = compare_unordered_element(gold_root, test_root, **self.__options)
           else:
             same, messages = compare_ordered_element(test_root, gold_root, **self.__options)
@@ -441,7 +454,10 @@ class XML(Differ):
     params.add_param('remove_unicode_identifier', False,
                      'if true, then remove u infront of a single quote')
     params.add_param('xmlopts', '', "Options for xml checking")
-    params.add_param('rel_err', '', 'Relative Error for csv files or floats in xml ones')
+    params.add_param('rel_err', '',
+                     'Relative Error for csv files or floats in xml ones')
+    params.add_param('alt_root', '', 'If included, do a findall on the value on the root,'+
+                     ' and then use that as the root instead.  Note, findall must return one value')
     return params
 
   def __init__(self, name, params, test_dir):
@@ -462,6 +478,10 @@ class XML(Differ):
     self.__xmlopts['remove_unicode_identifier'] = self.specs['remove_unicode_identifier']
     if len(self.specs['xmlopts']) > 0:
       self.__xmlopts['xmlopts'] = self.specs['xmlopts'].split(' ')
+    if len(self.specs['alt_root']) > 0:
+      self.__xmlopts['alt_root'] = self.specs['alt_root']
+    else:
+      self.__xmlopts['alt_root'] = None
 
   def check_output(self):
     """

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 check_errors/revirD_tset/
 reg_self_tests/text_test.txt
 reg_self_tests/text_test2.txt
+reg_self_tests/a_xml_file.xml

--- a/tests/reg_self_tests/create_xml_file.py
+++ b/tests/reg_self_tests/create_xml_file.py
@@ -1,0 +1,11 @@
+
+open("a_xml_file.xml", "w").write("""
+<root>
+ <matching>
+   <inside/>
+ </matching>
+ <mismatch>
+   <not_the_same/>
+ </mismatch>
+</root>
+""")

--- a/tests/reg_self_tests/gold/a_xml_file.xml
+++ b/tests/reg_self_tests/gold/a_xml_file.xml
@@ -1,0 +1,8 @@
+<root>
+ <matching>
+   <inside/>
+ </matching>
+ <mismatch>
+   <a_diffrent_thing/>
+ </mismatch>
+</root>

--- a/tests/reg_self_tests/tests
+++ b/tests/reg_self_tests/tests
@@ -37,4 +37,15 @@
      rel_err = 1.0e-4
    [../]
  [../]
+ [./xml_check]
+   type = 'GenericExecutable'
+   executable = 'python'
+   parameters = 'create_xml_file.py'
+   [./xml]
+    type = XML
+    unordered = true
+    output = a_xml_file.xml
+    alt_root = './matching'
+   [../]
+ [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #1950 

##### What are the significant changes in functionality due to this change request?
alt_root can be used to limit xml diff to only one node,
so if other nodes are different, it will not fail the test.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

