### PR TITLE
fix run_tests for testing plugins when installed with pip package

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -52,6 +52,11 @@ then
     source $SCRIPT_DIR/scripts/establish_conda_env.sh --load --installation-manager PIP
 else
     echo No installation: $INSTALLATION_MANAGER
+    if [ -z $PYTHON_COMMAND ];
+    then
+        # check the RC file
+        PYTHON_COMMAND=$(read_ravenrc "PYTHON_COMMAND")
+    fi
 fi
 
 # pick tests to run

--- a/run_tests
+++ b/run_tests
@@ -79,10 +79,6 @@ for A in "$@"; do
     esac
 done
 
-#Note that this is from the perspective of python
-FRAMEWORK_DIR=`$PYTHON_COMMAND $SCRIPT_DIR/scripts/plugin_handler.py -z`
-
-
 # run the tests
 # success/fail storage
 #   Names of successful test sets are stored in "PASSED"
@@ -123,7 +119,7 @@ if [[ $DO_RAVEN == 0 ]]; then
   echo
   echo Running $P tests ...
   # get location of ExamplePlugin test dir
-  ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $FRAMEWORK_DIR/../scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
+  ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $SCRIPT_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
   # $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --add-non-default-run-types qsub "${ARGS[@]}"
   $ROOK_COMMAND
   rc=$?
@@ -151,7 +147,7 @@ if [[ $DO_PLUGINS == 0 ]]; then
     echo
     echo Starting tests for plugin "$P" ...
     # add RAVEN testers to plugin testers
-    ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $FRAMEWORK_DIR/../scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
+    ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $SCRIPT_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
     echo Running ROOK command: "$ROOK_COMMAND" ...
     {
       # try


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
#1764

##### What are the significant changes in functionality due to this change request?
This allows run_tests to be used to test plugins when raven is installed with a pip package.
Before, it used FRAMEWORK_DIR to find the scripts directory, but FRAMEWORK_DIR might not exist
Also, if installation manager was not PIP or CONDA, it did not load PYTHON_COMMAND.

(Basically, my way to test the TEAL plugin package is:
```shell
python3.7 -m venv raven_install_test
source raven_install_test/bin/activate
python3.7 -m pip install teal-ravenframework --extra-index-url https://test.pypi.org/simple/

git clone git@github.com:idaholab/raven.git
cd raven
cat << EOF > .ravenrc
INSTALLATION_MANAGER = NONE
PYTHON_COMMAND = python
EOF
git submodule update --init plugins/TEAL/
python scripts/install_plugins.py -s plugins/ExamplePlugin/
python scripts/install_plugins.py -s plugins/TEAL/
rm -Rf ravenframework/ plugins/TEAL/src/
./run_tests -j11 --re=TEAL
```
)

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

