### PR TITLE
Updating libraries.

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -36,17 +36,17 @@ Note all install methods after "main" take
 <dependencies>
   <main>
     <h5py/>
-    <numpy>1.18</numpy>
-    <scipy>1.5</scipy>
-    <scikit-learn>0.24</scikit-learn>
-    <pandas>1.1</pandas>
-    <xarray>0.16</xarray>
-    <netcdf4>1.5</netcdf4>
-    <matplotlib>3.2</matplotlib>
-    <statsmodels>0.12</statsmodels>
-    <cloudpickle>1.6</cloudpickle>
-    <tensorflow os='windows,linux'>2.3</tensorflow>
-    <tensorflow os='mac'>2.7</tensorflow>
+    <numpy>1.21</numpy>
+    <scipy>1.7</scipy>
+    <scikit-learn>1.0</scikit-learn>
+    <pandas>1.3</pandas>
+    <xarray>0.20</xarray>
+    <netcdf4>1.6</netcdf4>
+    <matplotlib>3.5</matplotlib>
+    <statsmodels>0.13</statsmodels>
+    <cloudpickle>2.2</cloudpickle>
+    <tensorflow os='windows,linux'>2.9</tensorflow>
+    <tensorflow os='mac'>2.9</tensorflow>
     <python skip_check='True'>3</python>
     <hdf5 skip_check='True'/>
     <swig skip_check='True'/>
@@ -60,10 +60,10 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <numexpr os='linux'/>
     <cmake skip_check='True' optional='True'/>
-    <ray source="pip" pip_extra="[default]">1.12</ray>
+    <ray source="pip" pip_extra="[default]">1.13</ray>
     <!-- redis is needed by ray, but on windows, this seems to need to be explicitly stated -->
     <redis source="pip" os='windows'/>
-    <imageio>2.9</imageio>
+    <imageio>2.22</imageio>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->
     <pywavelets optional='True'>1.1</pywavelets>

--- a/ravenframework/CodeInterfaceClasses/PHISICS/MaterialParser.py
+++ b/ravenframework/CodeInterfaceClasses/PHISICS/MaterialParser.py
@@ -86,8 +86,8 @@ class MaterialParser():
     matList = []
     isotopeList = []
     XMLdict['density'] = {}
-    for matXML in self.root.getiterator('mat'):
-      for isotopeXML in self.root.getiterator('isotope'):
+    for matXML in self.root.iter('mat'):
+      for isotopeXML in self.root.iter('isotope'):
         matList.append(matXML.attrib.get('id'))
         isotopeList.append(self.noDash(isotopeXML.attrib.get('id')))
     matList = self.unifyElements(matList)
@@ -96,7 +96,7 @@ class MaterialParser():
       XMLdict['density'][mat] = {}
       for isotope in isotopeList:
         XMLdict['density'][mat][isotope] = {}
-    for matXML in self.root.getiterator('mat'):
+    for matXML in self.root.iter('mat'):
       for isotopeXML in matXML.findall('isotope'):
         XMLdict['density'][matXML.attrib.get('id')][self.noDash(isotopeXML.attrib.get('id'))] = isotopeXML.attrib.get('density')
     return XMLdict
@@ -148,7 +148,7 @@ class MaterialParser():
     newXMLDict = self.replaceValues(genericXMLdict)
     templatedNewXMLdict = self.fileReconstruction(newXMLDict)
     open(self.inputFiles, 'w')
-    for matXML in self.root.getiterator('mat'):
+    for matXML in self.root.iter('mat'):
       for isotopeXML in matXML.findall('isotope'):
         isotopeXML.attrib['density'] = templatedNewXMLdict.get('DENSITY').get(matXML.attrib.get('id').upper()).get(self.noDash(isotopeXML.attrib.get('id')).upper())
         self.tree.write(self.inputFiles)

--- a/ravenframework/CodeInterfaceClasses/PHISICS/PhisicsInterface.py
+++ b/ravenframework/CodeInterfaceClasses/PHISICS/PhisicsInterface.py
@@ -58,7 +58,7 @@ class Phisics(CodeInterfaceBase):
         'flux', 'repository'
     ]
     for xmlNodeNumber in range(0, len(xmlNodes)):
-      for xmlNode in pathRoot.getiterator(xmlNodes[xmlNodeNumber]):
+      for xmlNode in pathRoot.iter(xmlNodes[xmlNodeNumber]):
         self.outputFileNameDict[xmlNodes[xmlNodeNumber]] = xmlNode.text
 
   def syncLibPathFileWithRavenInp(self, pathFile, currentInputFiles,
@@ -85,7 +85,7 @@ class Phisics(CodeInterfaceBase):
     ]
 
     for typeNumber in range(len(typeList)):
-      for libPathText in pathRoot.getiterator(libPathList[typeNumber]):
+      for libPathText in pathRoot.iter(libPathList[typeNumber]):
         libPathText.text = os.path.join(
             currentInputFiles[keyWordDict[typeList[typeNumber].lower()]]
             .subDirectory, currentInputFiles[keyWordDict[typeList[typeNumber]

--- a/ravenframework/CodeInterfaceClasses/PHISICS/PhisicsRelapInterface.py
+++ b/ravenframework/CodeInterfaceClasses/PHISICS/PhisicsRelapInterface.py
@@ -98,7 +98,7 @@ class PhisicsRelap5(CodeInterfaceBase):
     libraryTree = ET.parse(inputXML)
     libraryRoot = libraryTree.getroot()
     for key in searchDict:
-      for child in libraryRoot.getiterator(searchDict[key]):
+      for child in libraryRoot.iter(searchDict[key]):
         timeDict[dictKeys[key]] = child.text
     return timeDict
 

--- a/ravenframework/OutStreams/PlotInterfaces/GeneralPlot.py
+++ b/ravenframework/OutStreams/PlotInterfaces/GeneralPlot.py
@@ -2189,6 +2189,9 @@ class GeneralPlot(PlotInterface):
           self.raiseAnError(RuntimeError, '<' + str(ae) + '> -> in execution custom plot "' + self.outStreamTypes[pltIndex] + '" in Plot ' + self.name + '.\nSTREAM MANAGER: ERROR -> command has been called in the following way: ' + 'ax.' + self.outStreamTypes[pltIndex])
 
     if 'legend' in self.options['plotSettings']:
+      if 'loc' in self.options['plotSettings']['legend'] and self.options['plotSettings']['legend']['loc'] == 'best':
+        #XXX This doesn't work in matplotlib 3.5
+        self.options['plotSettings']['legend'].pop('loc')
       self.fig.legend(**self.options['plotSettings']['legend'])
 
     # SHOW THE PICTURE

--- a/ravenframework/utils/Debugging.py
+++ b/ravenframework/utils/Debugging.py
@@ -18,7 +18,8 @@ talbpaul, 2020-11
 """
 import sys
 from numbers import Number
-from collections import Set, Mapping, deque
+from collections import deque
+from collections.abc import Set, Mapping
 import numpy as np
 
 # these types have no depth, so should not be searched for subitems


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 


##### What are the significant changes in functionality due to this change request?
Updates several libraries.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

