### PR TITLE
Fix SyntaxWarnings introduced in 3.8

### DIFF
--- a/ravenframework/CodeInterfaceClasses/MooseBasedApp/MooseData.py
+++ b/ravenframework/CodeInterfaceClasses/MooseBasedApp/MooseData.py
@@ -88,7 +88,7 @@ class mooseData:
       location[key] = {}
       timeStep[key] = {}
       for coordinate in writeDict[key].keys():
-        if coordinate is 'x' or coordinate is 'y' or coordinate is 'z':
+        if coordinate == 'x' or coordinate == 'y' or coordinate == 'z':
           location[key][coordinate] = writeDict[key][coordinate]
         else:
           timeStep[key][coordinate] = writeDict[key][coordinate]

--- a/ravenframework/utils/mathUtils.py
+++ b/ravenframework/utils/mathUtils.py
@@ -602,7 +602,7 @@ def computeTruncatedSingularValueDecomposition(X, truncationRank, full=False, co
   U, s, V = np.linalg.svd(X, full_matrices=full)
   V = V.conj().T if conj else V.T
 
-  if truncationRank is 0:
+  if truncationRank == 0:
     omeg = lambda x: 0.56 * x**3 - 0.95 * x**2 + 1.82 * x + 1.43
     rank = np.sum(s > np.median(s) * omeg(np.divide(*sorted(X.shape))))
   elif truncationRank > 0 and truncationRank < 1:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

#1806

##### What are the significant changes in functionality due to this change request?

Due to our recent update to Python 3.8. We now will receive `SyntaxWarning` when doing specific things in the code. This PR seeks to remove the warnings associated with 

```
 SyntaxWarning: "is" with a literal. Did you mean "=="?
```

You can find more information as to why we'd want to change this here: https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

