### PR TITLE
Simplifying py_modules list by using packages instead.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,3 @@ recursive-include crow/contrib/include/Eigen *
 recursive-include crow/contrib/include/boost *
 include include/contrib/AMSC/*.h
 include include/contrib/ngl/*.h*
-include ravenframework/ROMExternal.py

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,6 @@ setup(name='raven_framework',
                              'src/AMSC/UnionFind.cpp',
                              'src/AMSC/AMSC.cpp'],
                     include_dirs=include_dirs, swig_opts=swig_opts,extra_compile_args=extra_compile_args)],
-      py_modules=['AMSC.amsc','crow_modules.distribution1D','crow_modules.randomENG','crow_modules.interpolationND', 'AMSC.AMSC_Object']+['ravenframework.'+x for x in ['Application', 'ClassProperty', 'CodeInterfaceBaseClass', 'CodeInterfaces', 'CsvLoader', 'CustomCommandExecuter', 'Distributions', 'Driver', 'EntityFactoryBase', 'Files', 'Functions', 'GridEntities', 'IndexSets', 'Interaction', 'JobHandler', 'MessageHandler', 'MetricDistributor', 'OrthoPolynomials', 'PluginManager', 'Quadratures', 'Simulation', 'VariableGroups', 'h5py_interface_creator', 'raven_qsub_command', 'unSupervisedLearning']],
-      packages=['ravenframework.'+x for x in setuptools.find_packages('ravenframework')],
+      py_modules=['AMSC.amsc','crow_modules.distribution1D','crow_modules.randomENG','crow_modules.interpolationND', 'AMSC.AMSC_Object'],
+      packages=['ravenframework.'+x for x in setuptools.find_packages('ravenframework')]+['ravenframework'],
       cmdclass={'build': CustomBuild})


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
#1764 

##### What are the significant changes in functionality due to this change request?
Simplifies the setup.py by only specifying the package instead of all the modules.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

