### PR TITLE
Add a way to only run a test if a needed executable is on the path.

### DIFF
--- a/rook/Tester.py
+++ b/rook/Tester.py
@@ -20,6 +20,7 @@ import warnings
 import subprocess
 import sys
 import os
+import shutil
 import time
 import threading
 import platform
@@ -388,6 +389,8 @@ class Tester:
     params.add_param('min_python_version', 'none',
                      'The Minimum python version required for this test.'+
                      ' Example 3.8 (note, format is major.minor)')
+    params.add_param('needed_executable', '',
+                     'Only run test if needed executable is on path.')
     return params
 
   def __init__(self, _name, params):
@@ -400,6 +403,7 @@ class Tester:
     valid_params = self.get_valid_params()
     self.specs = valid_params.get_filled_dict(params)
     self.results = TestResult()
+    self._needed_executable = self.specs['needed_executable']
     self.__command_prefix = ""
     self.__python_command = sys.executable
     if os.name == "nt":
@@ -546,6 +550,10 @@ class Tester:
       self.results.group = self.group_skip
       self.results.message = "SKIPPED ("+str(self.__test_run_type)+\
         " is not a subset of "+str(self.__base_current_run_type)+")"
+      return self.results
+    if len(self._needed_executable) > 0 and \
+       shutil.which(self._needed_executable) is None:
+      self.set_skip('skipped (Missing executable: "'+self._needed_executable+'")')
       return self.results
     if not self.check_runnable():
       return self.results

--- a/tests/reg_self_tests/tests
+++ b/tests/reg_self_tests/tests
@@ -48,4 +48,10 @@
     alt_root = './matching'
    [../]
  [../]
+ [./check_needed_executable]
+   #Checks that this is skipped
+   type = 'GenericExecutable'
+   executable = 'no_such_executable'
+   needed_executable = 'no_such_executable'
+ [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2003


##### What are the significant changes in functionality due to this change request?
Adds a needed_executable parameter for to check if there is a executable on the path before running the test.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

