### PR TITLE
modified the Dymola interface to write the file path of the text file (it was #1904)

### DIFF
--- a/ravenframework/CodeInterfaceClasses/Dymola/DymolaInterface.py
+++ b/ravenframework/CodeInterfaceClasses/Dymola/DymolaInterface.py
@@ -333,7 +333,8 @@ class Dymola(CodeInterfaceBase):
           initDescripIndex = i
       if fileNameInitIndex > 0:
         filePathIndex = initDescripIndex + fileNameInitIndex - initVarIndex #index of path
-        text = text.replace(splitLines[filePathIndex], currentInputFiles[indexVect].getAbsFile().replace(os.sep, '/'))
+        # text = text.replace(splitLines[filePathIndex], currentInputFiles[indexVect].getAbsFile().replace(os.sep, '/'))
+        text = text.replace(splitLines[filePathIndex], currentInputFiles[indexVect].getAbsFile())
       else:
         self.raiseAWarning('Dymola INTERFACE WARNING -> Check subfolers containing the RAVEN samples to see whether they are correctly sampled!')
 

--- a/ravenframework/CodeInterfaceClasses/Dymola/DymolaInterface.py
+++ b/ravenframework/CodeInterfaceClasses/Dymola/DymolaInterface.py
@@ -318,6 +318,25 @@ class Dymola(CodeInterfaceBase):
           "Parameter %s does not exist or is not formatted as expected "
           "in %s." % (name, originalPath))
 
+    # set fileName parameter which points Dymola to vector table
+    if bool(vectorsToPass):
+      initVarIndex = 0
+      fileNameInitIndex = 0
+      initDescripIndex = 0
+      splitLines = text.splitlines()
+      for i, line in enumerate(splitLines):  #find location of path
+        if "char initialName" in line:
+          initVarIndex = i
+        if line == 'fileName' and initVarIndex > 0 and fileNameInitIndex == 0:
+          fileNameInitIndex = i
+        if "char initialDescription" in line:
+          initDescripIndex = i
+      if fileNameInitIndex > 0:
+        filePathIndex = initDescripIndex + fileNameInitIndex - initVarIndex #index of path
+        text = text.replace(splitLines[filePathIndex], currentInputFiles[indexVect].getAbsFile().replace(os.sep, '/'))
+      else:
+        raise AssertionError("Parameter fileName does not exist or is not formatted as expected "  "in %s." % originalPath)
+
     # Re-write the file.
     with open(currentInputFiles[indexInit].getAbsFile(), 'w') as src:
       src.write(text)

--- a/ravenframework/CodeInterfaceClasses/Dymola/DymolaInterface.py
+++ b/ravenframework/CodeInterfaceClasses/Dymola/DymolaInterface.py
@@ -318,7 +318,7 @@ class Dymola(CodeInterfaceBase):
           "Parameter %s does not exist or is not formatted as expected "
           "in %s." % (name, originalPath))
 
-    # set fileName parameter which points Dymola to vector table
+    ## set fileName parameter which points Dymola to vector table
     if bool(vectorsToPass):
       initVarIndex = 0
       fileNameInitIndex = 0
@@ -335,7 +335,7 @@ class Dymola(CodeInterfaceBase):
         filePathIndex = initDescripIndex + fileNameInitIndex - initVarIndex #index of path
         text = text.replace(splitLines[filePathIndex], currentInputFiles[indexVect].getAbsFile().replace(os.sep, '/'))
       else:
-        raise AssertionError("Parameter fileName does not exist or is not formatted as expected "  "in %s." % originalPath)
+        self.raiseAWarning('Dymola INTERFACE WARNING -> Check subfolers containing the RAVEN samples to see whether they are correctly sampled!')
 
     # Re-write the file.
     with open(currentInputFiles[indexInit].getAbsFile(), 'w') as src:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#1903 

##### What are the significant changes in functionality due to this change request?
The interface now writes the path to the file containing vectors passed into Dymola into the Dymola initialization file.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

