### PR TITLE
DET HybridSampler with Constant and Dependent Variables 

### DIFF
--- a/ravenframework/Samplers/DynamicEventTree.py
+++ b/ravenframework/Samplers/DynamicEventTree.py
@@ -686,6 +686,8 @@ class DynamicEventTree(Grid):
       self.inputInfo['PointProbability' ] = pointPb*subGroup.get('conditionalPb')
       self.inputInfo['ProbabilityWeight'] = self.inputInfo['PointProbability' ]
       self.inputInfo.update({'ProbabilityWeight-'+key.strip():value for key,value in self.inputInfo['SampledVarsPb'].items()})
+      ##### REDUNDANT FUNCTIONALS #####
+      self._functionalVariables()
       # Add some useful variable naming in the input
       self.inputInfo.update(self.__createVariablesInfoForKwargs(model))
       # Add the new input path into the RunQueue system

--- a/ravenframework/Samplers/DynamicEventTree.py
+++ b/ravenframework/Samplers/DynamicEventTree.py
@@ -721,7 +721,7 @@ class DynamicEventTree(Grid):
 
   def __createVariablesInfoForKwargs(self, model):
     """
-      This utility method is to create a variable infor block
+      This utility method is to create a variable info block
       useful to couple with DET external codes
       @ In, model, Model instance, model instance that can be a Code type, ROM, etc.
       @ Out, varInfo, dict, the dictionary containing the variable names
@@ -976,6 +976,9 @@ class DynamicEventTree(Grid):
       while hybridsampler.amIreadyToProvideAnInput():
         hybridsampler.counter +=1
         hybridsampler.localGenerateInput(None,None)
+        hybridsampler._constantVariables()
+        ##### REDUNDANT FUNCTIONALS #####
+        hybridsampler._functionalVariables()
         hybridsampler.inputInfo['prefix'] = hybridsampler.counter
         hybridlistoflist[cnt].append(copy.deepcopy(hybridsampler.inputInfo))
     if self.hybridNumberSamplers > 0:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #2025 

##### What are the significant changes in functionality due to this change request?
Enable DET HybridSampler to handle constant and dependent variables 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

