### PR TITLE
Allow only starting ray but not using it directly

### DIFF
--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -235,6 +235,27 @@ class JobHandler(BaseType):
           self.raiseADebug("Remote servers      : ", " , ".join(servers))
       else:
         self.raiseADebug("JobHandler initialized without ray")
+    elif self.runInfoDict['startRay']:
+      #XXX experimenting with what to do here?
+      availableNodes = [nodeId.strip() for nodeId in self.runInfoDict['Nodes']]
+      localHostName = self.__getLocalHost()
+      self.raiseADebug("Head host name is   : ", localHostName)
+      # number of processors
+      nProcsHead = availableNodes.count(localHostName)
+      # create head node cluster
+      # port 0 lets ray choose an available port
+      address = self.__runHeadNode(nProcsHead, 0)
+      # add names in runInfo
+      self.runInfoDict['headNode'] = address
+      servers = self.__runRemoteListeningSockets(address, localHostName)
+      # add names in runInfo
+      self.runInfoDict['remoteNodes'] = servers
+      #headNode and remoteNodes can be passed to subravens (in RAVENInterface)
+      self.raiseADebug(f"headNode {address}, remoteNodes {servers}")
+
+      ## In this RAVEN instance, just using threading
+      self.rayServer = None
+      self.raiseADebug("JobHandler initialized ray server but using threading")
     else:
       ## We are just using threading
       self.rayServer = None
@@ -856,6 +877,9 @@ class JobHandler(BaseType):
             # want to revisit this on the next iteration of this code.
             if len(item.args) > 0 and isinstance(item.args[0], Models.Code):
               kwargs = {}
+              if self.runInfoDict['startRay']:
+                kwargs['headNode'] = self.runInfoDict['headNode']
+                kwargs['remoteNodes'] = self.runInfoDict['remoteNodes']
               if self.rayServer is not None and 'headNode' in self.runInfoDict:
                 kwargs['headNode'] = self.runInfoDict['headNode']
               if self.rayServer is not None and 'remoteNodes' in self.runInfoDict:

--- a/ravenframework/Runners/DistributedMemoryRunner.py
+++ b/ravenframework/Runners/DistributedMemoryRunner.py
@@ -85,6 +85,8 @@ class DistributedMemoryRunner(InternalRunner):
             self.hasBeenAdded = True
             if self.runReturn is None:
               self.returnCode = -1
+            del self.__func
+            self.__func = None
             return True
           except ray.exceptions.GetTimeoutError:
             #Timeout, so still running.

--- a/ravenframework/Runners/DistributedMemoryRunner.py
+++ b/ravenframework/Runners/DistributedMemoryRunner.py
@@ -96,6 +96,8 @@ class DistributedMemoryRunner(InternalRunner):
             # I assume it means the task has unfixably died,
             # and so is done, and set return code to failed.
             self.returnCode = -1
+            del self.__func
+            self.__func = None
             return True
           #Alternative that was tried:
           #return self.__func in ray.wait([self.__func], timeout=waitTimeOut)[0]

--- a/ravenframework/Runners/SharedMemoryRunner.py
+++ b/ravenframework/Runners/SharedMemoryRunner.py
@@ -133,7 +133,7 @@ class SharedMemoryRunner(InternalRunner):
     """
     if self.thread is not None:
       self.raiseADebug('Terminating job thread "{}" and RAVEN identifier "{}"'.format(self.thread.ident, self.identifier))
-      while self.thread is not None and self.thread.isAlive():
+      while self.thread is not None and self.thread.is_alive():
         time.sleep(0.1)
         try:
           self.thread.raiseException(RuntimeError)
@@ -174,7 +174,7 @@ class InterruptibleThread(threading.Thread):
        t = InterruptibleThread( ... )
         ...
         t.raiseException( SomeException )
-        while t.isAlive():
+        while t.is_alive():
           time.sleep( 0.1 )
           t.raiseException( SomeException )
       If the exception is to be caught by the thread, you need a way to check that your thread has caught it.
@@ -183,7 +183,7 @@ class InterruptibleThread(threading.Thread):
       @ In, exceptionType, Exception, the type of exception to raise in this thread
       @ Out, None
     """
-    if self.isAlive():
+    if self.is_alive():
       ## Assuming Python 2.6+, we can remove the need for the _get_my_tid as
       ## specifed in the Stack Overflow answer
       _asyncRaise( self.ident, exceptionType )

--- a/ravenframework/Simulation.py
+++ b/ravenframework/Simulation.py
@@ -242,6 +242,7 @@ class Simulation(MessageUser):
     self.runInfoDict['numProcByRun'      ] = 1      # Total number of core used by one run (number of threads by number of mpi)
     self.runInfoDict['batchSize'         ] = 1      # number of contemporaneous runs
     self.runInfoDict['internalParallel'  ] = False  # activate internal parallel (parallel python). If True parallel python is used, otherwise multi-threading is used
+    self.runInfoDict['startRay' ] = False # Start ray (automatic if internalParallel is true)
     self.runInfoDict['ParallelCommand'   ] = ''     # the command that should be used to submit jobs in parallel (mpi)
     self.runInfoDict['ThreadingCommand'  ] = ''     # the command that should be used to submit multi-threaded
     self.runInfoDict['totalNumCoresUsed' ] = 1      # total number of cores used by driver
@@ -656,6 +657,8 @@ class Simulation(MessageUser):
         self.runInfoDict['internalParallel'] = utils.interpretBoolean(element.text)
         dashboard = element.attrib.get("dashboard",'False')
         self.runInfoDict['includeDashboard'  ] = utils.interpretBoolean(dashboard)
+      elif element.tag == 'startRay':
+        self.runInfoDict['startRay'] = utils.interpretBoolean(element.text)
       elif element.tag == 'batchSize':
         self.runInfoDict['batchSize'] = int(element.text)
       elif element.tag.lower() == 'maxqueuesize':


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 


##### What are the significant changes in functionality due to this change request?
Adds a `<startRay>True</startRay>` that just starts ray, but otherwise uses threads.


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

