### PR TITLE
Better error message if input variables (opt) not present in SolutionExport

### DIFF
--- a/raven_framework.py
+++ b/raven_framework.py
@@ -19,7 +19,6 @@ Created on Feb 14, 2022
 
 This is a package that properly imports Driver and runs it.
 """
-import re
 import sys
 from ravenframework.Driver import main
 if __name__ == '__main__':

--- a/ravenframework/DataObjects/DataSet.py
+++ b/ravenframework/DataObjects/DataSet.py
@@ -2073,7 +2073,8 @@ class DataSet(DataObject):
       data = self._data
       mode = 'w'
 
-    data = data.drop(toDrop)
+    #Errors when dropping don't matter since it means they were removed before
+    data = data.drop(toDrop, errors='ignore')
     self.raiseADebug(f'Printing data from "{self.name}" to CSV: "{filenameLocal}.csv"')
     # get the list of elements the user requested to write
     # order data according to user specs # TODO might be time-inefficient, allow user to skip?

--- a/ravenframework/DataObjects/DataSet.py
+++ b/ravenframework/DataObjects/DataSet.py
@@ -1669,7 +1669,14 @@ class DataSet(DataObject):
     # TODO slow double loop
     matchVars, matchVals = zip(*toMatch.items()) if toMatch else ([], [])
     avoidVars, avoidVals = zip(*noMatch.items()) if noMatch else ([], [])
-    matchIndices = tuple(self._orderedVars.index(var) for var in matchVars)# What did we use this in?
+    try:
+      matchIndices = tuple(self._orderedVars.index(var) for var in matchVars)# What did we use this in?
+    except ValueError as e:
+      # str(e) returns an error such as 'varName' is not in list so the error below reads as
+      # 'varName' is not in list of DataObject self.name
+      self.raiseAnError(ValueError, f"Variable {str(e)} of DataObject '{self.name}'. "
+                        f"Available variables are: {', '.join(self._orderedVars)}. "
+                        "Check <Input>/<Output> sections." )
     if not first:
       rr, rlz = [], []
     for r, _ in enumerate(self._collector[:]): #TODO: CAN WE MAKE R START FROM LAST MATCHINDEXES ?
@@ -2066,8 +2073,7 @@ class DataSet(DataObject):
       data = self._data
       mode = 'w'
 
-    #Errors when dropping don't matter since it means they were removed before
-    data = data.drop(toDrop, errors='ignore')
+    data = data.drop(toDrop)
     self.raiseADebug(f'Printing data from "{self.name}" to CSV: "{filenameLocal}.csv"')
     # get the list of elements the user requested to write
     # order data according to user specs # TODO might be time-inefficient, allow user to skip?

--- a/tests/framework/unit_tests/DataObjects/TestDataSet.py
+++ b/tests/framework/unit_tests/DataObjects/TestDataSet.py
@@ -329,7 +329,6 @@ rlz2 = {'a' :21.0,
        }
 matchDict = {'abc': 1.0,
         'b': 2.0,
-        'c': np.array([3.0, 3.1, 3.2]),
        }
 formatRealization(rlz0)
 formatRealization(rlz1)

--- a/tests/framework/unit_tests/DataObjects/TestDataSet.py
+++ b/tests/framework/unit_tests/DataObjects/TestDataSet.py
@@ -327,9 +327,14 @@ rlz2 = {'a' :21.0,
         'prefix': 'third',
         'time':[23.1e-6,23.2e-6,23.3e-6],
        }
+matchDict = {'abc': 1.0,
+        'b': 2.0,
+        'c': np.array([3.0, 3.1, 3.2]),
+       }
 formatRealization(rlz0)
 formatRealization(rlz1)
 formatRealization(rlz2)
+formatRealization(matchDict)
 # test missing data
 rlzMissing = dict(rlz0)
 rlz0['z'] = 6.0
@@ -341,8 +346,9 @@ rlzFormat['c'] = list(rlzFormat['c'])
 checkFails('DataSet addRealization err format','Realization was not formatted correctly for "DataSet"! See warnings above.',data.addRealization,args=[rlzFormat])
 # test appending
 data.addRealization(dict(rlz0))
-
-
+# test error if requested match not in variable list
+rlzMissing = dict(matchDict)
+checkFails('DataSet _getRealizationFromCollectorByValue err missing',"Variable 'abc' is not in list of DataObject 'DataSet'. Available variables are: a, b, c, x, y, z, prefix. Check <Input>/<Output> sections.",data._getRealizationFromCollectorByValue,args=[rlzMissing,{}])
 # get realization by index, from collector
 checkRlz('Dataset append 0',data.realization(index=0),rlz0,skip=['time', '_indexMap'])
 # try to access the inaccessible


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2039

##### What are the significant changes in functionality due to this change request?

Better error message if input variables in an optimization problem 
are not among the variables in the SolutionExport 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

