### PR TITLE
Allowing xarray and matplotlib to float.

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -47,9 +47,9 @@ Note all install methods after "main" take
          AttributeError: 'EntryPoints' object has no attribute 'get'
          so should be skipped.
     -->
-    <xarray>0.19</xarray>
+    <xarray/>
     <netcdf4>1.5</netcdf4>
-    <matplotlib>3.3</matplotlib>
+    <matplotlib/>
     <statsmodels>0.13</statsmodels>
     <cloudpickle>2.2</cloudpickle>
     <tensorflow>2.9</tensorflow>

--- a/ravenframework/OutStreams/PlotInterfaces/GeneralPlot.py
+++ b/ravenframework/OutStreams/PlotInterfaces/GeneralPlot.py
@@ -620,10 +620,23 @@ class GeneralPlot(PlotInterface):
       elif key == 'title':
         self.ax.set_title(self.options[key]['text'], **self.options[key].get('attributes', {}))
       elif key == 'scale':
+        major, minor = [int(x) for x in matplotlib.__version__.split('.')[:2]]
+        #matplotlib before 3.5 used nonpos instead of nonpositive
+        useNonpos = (major == 3 and minor < 5)
         if 'xscale' in self.options[key]:
-          self.ax.set_xscale(self.options[key]['xscale'], nonposx='clip')
+          if useNonpos:
+            self.ax.set_xscale(self.options[key]['xscale'], nonposx='clip')
+          elif self.options[key]['xscale'].lower() == 'log':
+            self.ax.set_xscale(self.options[key]['xscale'], nonpositive='clip')
+          else:
+            self.ax.set_xscale(self.options[key]['xscale'])
         if 'yscale' in self.options[key]:
-          self.ax.set_yscale(self.options[key]['yscale'], nonposy='clip')
+          if useNonpos:
+            self.ax.set_yscale(self.options[key]['yscale'], nonposy='clip')
+          elif self.options[key]['yscale'].lower() == 'log':
+            self.ax.set_yscale(self.options[key]['yscale'], nonpositive='clip')
+          else:
+            self.ax.set_yscale(self.options[key]['yscale'])
         if self.dim == 3:
           if 'zscale' in self.options[key]:
             self.ax.set_zscale(self.options[key]['zscale'])

--- a/rook/Tester.py
+++ b/rook/Tester.py
@@ -24,7 +24,7 @@ import shutil
 import time
 import threading
 import platform
-from distutils import spawn
+import shutil
 
 warnings.simplefilter('default', DeprecationWarning)
 
@@ -295,7 +295,7 @@ class _TimeoutThread(threading.Thread):
         #Time over
         #If we are on windows, process.kill() is insufficient, so using
         # taskkill instead.
-        if os.name == "nt" and spawn.find_executable("taskkill"):
+        if os.name == "nt" and shutil.which("taskkill"):
           subprocess.call(['taskkill', '/f', '/t', '/pid', str(self.__process.pid)])
         else:
           self.__process.kill()


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
For: https://github.com/gmlc-dispatches/dispatches/issues/173

##### What are the significant changes in functionality due to this change request?
Testing to see which versions of xarray and matplotlib work.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

