### PR TITLE
Update matplotlib35

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -49,7 +49,7 @@ Note all install methods after "main" take
     -->
     <xarray>0.19</xarray>
     <netcdf4>1.5</netcdf4>
-    <matplotlib>3.3</matplotlib>
+    <matplotlib>3.5</matplotlib>
     <statsmodels>0.13</statsmodels>
     <cloudpickle>2.2</cloudpickle>
     <tensorflow>2.9</tensorflow>

--- a/ravenframework/GridEntities.py
+++ b/ravenframework/GridEntities.py
@@ -225,7 +225,7 @@ class GridEntity(GridBase):
     """
       Size of the grid
       @ In, None
-      @ Out, len, np.int64, total number of nodes
+      @ Out, len, int, total number of nodes
     """
     return self.gridContainer['gridLength'] if 'gridLength' in self.gridContainer else 0
 
@@ -504,9 +504,9 @@ class GridEntity(GridBase):
       if self.gridContainer['transformationMethods'] is not None:
         if varName in self.gridContainer['transformationMethods']:
           self.gridContainer['gridVectors'][varName] = np.asarray([self.gridContainer['transformationMethods'][varName][0](coor) for coor in self.gridContainer['gridVectors'][varName]])
-      pointByVar[varId]                              = np.int(np.shape(self.gridContainer['gridVectors'][varName])[0])
+      pointByVar[varId]                              = int(np.shape(self.gridContainer['gridVectors'][varName])[0])
     self.gridContainer['gridShape']                  = tuple   (pointByVar)                             # tuple of the grid shape
-    self.gridContainer['gridLength']                 = np.int(np.prod (np.asarray(pointByVar, dtype=np.float64))) # total number of point on the grid
+    self.gridContainer['gridLength']                 = int(np.prod (np.asarray(pointByVar, dtype=np.float64))) # total number of point on the grid
     self.gridContainer['gridCoorShape']              = tuple   (pointByVar+[self.nVar])                # shape of the matrix containing all coordinate of all points in the grid
     if self.constructTensor:
       self.gridContainer['gridCoord'] = np.zeros(self.gridContainer['gridCoorShape'])   # the matrix containing all coordinate of all points in the grid

--- a/ravenframework/Models/PostProcessors/LimitSurfaceIntegral.py
+++ b/ravenframework/Models/PostProcessors/LimitSurfaceIntegral.py
@@ -253,7 +253,7 @@ class LimitSurfaceIntegral(PostProcessorInterface):
         if self.variableDist[varName] == None:
           randomMatrix[:, index] = randomMatrix[:, index] * (self.lowerUpperDict[varName]['upperBound'] - self.lowerUpperDict[varName]['lowerBound']) + self.lowerUpperDict[varName]['lowerBound']
         else:
-          f = np.vectorize(self.variableDist[varName].ppf, otypes=[np.float])
+          f = np.vectorize(self.variableDist[varName].ppf, otypes=[np.float64])
           randomMatrix[:, index] = f(randomMatrix[:, index])
         tempDict[varName] = randomMatrix[:, index]
       pb = self.stat.run({'targets':{self.target:xarray.DataArray(self.functionS.evaluate(tempDict)[self.target])}})[self.computationPrefix +"_"+self.target]

--- a/ravenframework/OutStreams/PlotInterfaces/GeneralPlot.py
+++ b/ravenframework/OutStreams/PlotInterfaces/GeneralPlot.py
@@ -620,10 +620,23 @@ class GeneralPlot(PlotInterface):
       elif key == 'title':
         self.ax.set_title(self.options[key]['text'], **self.options[key].get('attributes', {}))
       elif key == 'scale':
+        major, minor = [int(x) for x in matplotlib.__version__.split('.')[:2]]
+        #matplotlib before 3.5 used nonpos instead of nonpositive
+        useNonpos = (major == 3 and minor < 5)
         if 'xscale' in self.options[key]:
-          self.ax.set_xscale(self.options[key]['xscale'], nonposx='clip')
+          if useNonpos:
+            self.ax.set_xscale(self.options[key]['xscale'], nonposx='clip')
+          elif self.options[key]['xscale'].lower() == 'log':
+            self.ax.set_xscale(self.options[key]['xscale'], nonpositive='clip')
+          else:
+            self.ax.set_xscale(self.options[key]['xscale'])
         if 'yscale' in self.options[key]:
-          self.ax.set_yscale(self.options[key]['yscale'], nonposy='clip')
+          if useNonpos:
+            self.ax.set_yscale(self.options[key]['yscale'], nonposy='clip')
+          elif self.options[key]['yscale'].lower() == 'log':
+            self.ax.set_yscale(self.options[key]['yscale'], nonpositive='clip')
+          else:
+            self.ax.set_yscale(self.options[key]['yscale'])
         if self.dim == 3:
           if 'zscale' in self.options[key]:
             self.ax.set_zscale(self.options[key]['zscale'])

--- a/ravenframework/Samplers/CustomSampler.py
+++ b/ravenframework/Samplers/CustomSampler.py
@@ -173,7 +173,7 @@ class CustomSampler(Sampler):
       csvFile = self.assemblerDict['Source'][0][3]
       csvFile.open(mode='r')
       headers = [x.replace("\n","").strip() for x in csvFile.readline().split(",")]
-      data = np.loadtxt(self.assemblerDict['Source'][0][3], dtype=np.float, delimiter=',', skiprows=1, ndmin=2)
+      data = np.loadtxt(self.assemblerDict['Source'][0][3], dtype=np.float64, delimiter=',', skiprows=1, ndmin=2)
       lenRlz = len(data)
       csvFile.close()
       for var in self.toBeSampled:

--- a/ravenframework/utils/plotUtils.py
+++ b/ravenframework/utils/plotUtils.py
@@ -55,7 +55,7 @@ def generateParallelPlot(zs, batchID, ymins, ymaxs, ynames, fileID):
     @ Out, None
   """
   N = zs.shape[0]
-  zs = zs.astype(np.float)
+  zs = zs.astype(np.float64)
   dys = ymaxs - ymins
   zs[:, 0] = zs[:, 0]
   zs[:, 1:] = (zs[:, 1:] - ymins[1:]) / dys[1:] * dys[0] + ymins[1:]

--- a/rook/Tester.py
+++ b/rook/Tester.py
@@ -24,7 +24,6 @@ import shutil
 import time
 import threading
 import platform
-from distutils import spawn
 
 warnings.simplefilter('default', DeprecationWarning)
 
@@ -295,7 +294,7 @@ class _TimeoutThread(threading.Thread):
         #Time over
         #If we are on windows, process.kill() is insufficient, so using
         # taskkill instead.
-        if os.name == "nt" and spawn.find_executable("taskkill"):
+        if os.name == "nt" and shutil.which("taskkill"):
           subprocess.call(['taskkill', '/f', '/t', '/pid', str(self.__process.pid)])
         else:
           self.__process.kill()


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2059 

##### What are the significant changes in functionality due to this change request?
Updates matplotlib to 3.5 and fixes various deprecations.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

