### PR TITLE
Change from testing 3.7 to testing 3.9 pip packages.

### DIFF
--- a/developer_tools/check_pip_packages.sh
+++ b/developer_tools/check_pip_packages.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script tests that the 3.7 and 3.8 wheels built in directory dist
+# This script tests that the 3.9 and 3.8 wheels built in directory dist
 # are installable. It will not work if there is more than one
 # version of the wheel for a python version (including for other os's)
 # It is designed to be run after (or similar):
@@ -28,16 +28,16 @@ ls -l dist
 #python -m pip install -f file://${RAVEN_DIR}/dist raven_framework || exit -1
 
 echo
-echo Checking Python 3.7
-
-conda activate python37_pip
-python -m pip uninstall -y raven_framework || echo not installed
-python -m pip install dist/raven_framework*cp37*.whl || exit -1
-
-
-echo
 echo Checking Python 3.8
 
 conda activate python38_pip
 python -m pip uninstall -y raven_framework || echo not installed
 python -m pip install dist/raven_framework*cp38*.whl || exit -1
+
+
+echo
+echo Checking Python 3.9
+
+conda activate python39_pip
+python -m pip uninstall -y raven_framework || echo not installed
+python -m pip install dist/raven_framework*cp39*.whl || exit -1

--- a/developer_tools/make_pip_packages.sh
+++ b/developer_tools/make_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# This script builds 3.7 and 3.8 wheels and puts them in the dist directory
-# It will create python37_pip and python38_pip conda environments
+# This script builds 3.9 and 3.8 wheels and puts them in the dist directory
+# It will create python39_pip and python38_pip conda environments
 # and use them for building pip packages.
 # It requires that .ravenrc has a working CONDA_DEFS statement.
 # To run from the raven directory:
@@ -18,24 +18,24 @@ source $RAVEN_DIR/scripts/read_ravenrc.sh
 CONDA_DEFS=$(read_ravenrc "CONDA_DEFS")
 source ${CONDA_DEFS}
 
-conda env remove --name python37_pip
-conda create -y --name python37_pip python=3.7 swig
-
 conda env remove --name python38_pip
 conda create -y --name python38_pip python=3.8 swig
+
+conda env remove --name python39_pip
+conda create -y --name python39_pip python=3.9 swig
 
 cd $RAVEN_DIR
 
 rm -f setup.cfg
 python ./scripts/library_handler.py pip --action=setup.cfg > setup.cfg
 
-conda activate python37_pip
+conda activate python38_pip
 command -v python
 python -m ensurepip
 python -m pip install --upgrade build
 python -m build
 
-conda activate python38_pip
+conda activate python39_pip
 command -v python
 python -m ensurepip
 python -m pip install --upgrade build


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2062 

##### What are the significant changes in functionality due to this change request?
Changes the pip tests to 3.8 and 3.9

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

