### PR TITLE
A step of finding optimal solutions in Genetic Algorithm has been changed

### DIFF
--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -500,6 +500,7 @@ class GeneticAlgorithm(RavenSampled):
                                                                                                           newRlz=rlz,
                                                                                                           offSpringsFitness=offSpringFitness,
                                                                                                           popObjectiveVal=self.objectiveVal,
+                                                                                                          offObjectiveVal=objectiveVal,
                                                                                                           offSpringsg = g,
                                                                                                           parentg = self.gParent)
         self.popAge = age
@@ -511,7 +512,7 @@ class GeneticAlgorithm(RavenSampled):
         self.gParent = g
 
       self._collectOptPoint(rlz, self.population, self.fitness, self.objectiveVal, self.gParent)
-      self._resolveNewGeneration(traj, rlz, objectiveVal, offSpringFitness, self.gParent, info)
+      self._resolveNewGeneration(traj, rlz, self.objectiveVal, self.fitness, self.gParent, info)
 
       # 1 @ n: Parent selection from population
       # pair parents together by indexes
@@ -633,7 +634,7 @@ class GeneticAlgorithm(RavenSampled):
         varList = self._solutionExport.getVars('input') + self._solutionExport.getVars('output') + list(self.toBeSampled.keys())
         # rlzDict = dict((var,np.atleast_1d(rlz[var].data)[i]) for var in set(varList) if var in rlz.data_vars)
         rlzDict = dict((var,self.population.data[i][j]) for j, var in enumerate(self.population.Gene.data))
-        rlzDict[self._objectiveVar] = np.atleast_1d(rlz[self._objectiveVar].data)[i]
+        rlzDict[self._objectiveVar] = np.atleast_1d(objectiveVal)[i]
         rlzDict['fitness'] = np.atleast_1d(fitness.data)[i]
         for ind, consName in enumerate(g['Constraint'].values):
           rlzDict['ConstraintEvaluation_'+consName] = g[i,ind]

--- a/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
+++ b/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
@@ -100,19 +100,23 @@ def fitnessBased(newRlz,**kwargs):
   offSprings = np.atleast_2d(newRlz[kwargs['variables']].to_array().transpose().data)
   population = np.atleast_2d(kwargs['population'].data)
   popFitness = np.atleast_1d(kwargs['fitness'].data)
+  offSpringsg = np.atleast_1d(kwargs['offSpringsg'].data)
+  parentg = np.atleast_1d(kwargs['parentg'].data)
 
   newPopulation = population
   newFitness = popFitness
   newAge = list(map(lambda x:x+1, popAge))
   newPopulationMerged = np.concatenate([newPopulation,offSprings])
   newFitness = np.concatenate([newFitness,offSpringsFitness])
+  newG = np.concatenate([parentg, offSpringsg])
   newAge.extend([0]*len(offSpringsFitness))
 
   # sort population, popFitness according to age
-  sortedFitness,sortedAge,sortedPopulation = zip(*[(x,y,z) for x,y,z in sorted(zip(newFitness,newAge,newPopulationMerged),reverse=True,key=lambda x: (x[0], -x[1]))])
-  sortedFitnessT,sortedAgeT,sortedPopulationT = np.atleast_1d(list(sortedFitness)),list(sortedAge),np.atleast_1d(list(sortedPopulation))
+  sortedFitness,sortedAge,sortedPopulation, sortedG = zip(*[(x,y,z,a) for x,y,z,a in sorted(zip(newFitness,newAge,newPopulationMerged,newG),reverse=True,key=lambda x: (x[0], -x[1]))])
+  sortedFitnessT,sortedAgeT,sortedPopulationT, sortedGT = np.atleast_1d(list(sortedFitness)),list(sortedAge),np.atleast_1d(list(sortedPopulation)),np.atleast_1d(list(sortedG))
   newPopulationSorted = sortedPopulationT[:-len(offSprings)]
   newFitness = sortedFitnessT[:-len(offSprings)]
+  newG = sortedGT[:-len(offSprings)]
   newAge = sortedAgeT[:-len(offSprings)]
 
   newPopulationArray = xr.DataArray(newPopulationSorted,
@@ -123,8 +127,14 @@ def fitnessBased(newRlz,**kwargs):
                             dims=['chromosome'],
                             coords={'chromosome':np.arange(np.shape(newFitness)[0])})
 
+  newG = [item for sublist in newG for item in sublist]
+
+  newG = xr.DataArray(newG,
+                      dims=['chromosome'],
+                      coords={'chromosome':np.arange(np.shape(newG)[0])})
+
   #return newPopulationArray,newFitness,newAge
-  return newPopulationArray,newFitness,newAge,kwargs['popObjectiveVal']
+  return newPopulationArray,newFitness,newAge,kwargs['popObjectiveVal'], newG
 
 __survivorSelectors = {}
 __survivorSelectors['ageBased'] = ageBased

--- a/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
+++ b/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
@@ -96,10 +96,12 @@ def fitnessBased(newRlz,**kwargs):
   else:
     popAge = kwargs['age']
 
-  offSpringsFitness = np.atleast_1d(kwargs['offSpringsFitness'])
-  offSprings = np.atleast_2d(newRlz[kwargs['variables']].to_array().transpose().data)
-  population = np.atleast_2d(kwargs['population'].data)
   popFitness = np.atleast_1d(kwargs['fitness'].data)
+  offSpringsFitness = np.atleast_1d(kwargs['offSpringsFitness'])
+  population = np.atleast_2d(kwargs['population'].data)
+  offSprings = np.atleast_2d(newRlz[kwargs['variables']].to_array().transpose().data)
+  popObj = np.atleast_1d(kwargs['popObjectiveVal'].data)
+  offObj = np.atleast_1d(kwargs['offObjectiveVal'])
   offSpringsg = np.atleast_1d(kwargs['offSpringsg'].data)
   parentg = np.atleast_1d(kwargs['parentg'].data)
 
@@ -108,15 +110,17 @@ def fitnessBased(newRlz,**kwargs):
   newAge = list(map(lambda x:x+1, popAge))
   newPopulationMerged = np.concatenate([newPopulation,offSprings])
   newFitness = np.concatenate([newFitness,offSpringsFitness])
+  newObj = np.concatenate([popObj,offObj])
   newG = np.concatenate([parentg, offSpringsg])
   newAge.extend([0]*len(offSpringsFitness))
 
   # sort population, popFitness according to age
-  sortedFitness,sortedAge,sortedPopulation, sortedG = zip(*[(x,y,z,a) for x,y,z,a in sorted(zip(newFitness,newAge,newPopulationMerged,newG),reverse=True,key=lambda x: (x[0], -x[1]))])
-  sortedFitnessT,sortedAgeT,sortedPopulationT, sortedGT = np.atleast_1d(list(sortedFitness)),list(sortedAge),np.atleast_1d(list(sortedPopulation)),np.atleast_1d(list(sortedG))
+  sortedFitness,sortedAge,sortedPopulation,sortedG,sortedObj = zip(*[(x,y,z,a,b) for x,y,z,a,b in sorted(zip(newFitness,newAge,newPopulationMerged,newG,newObj),reverse=True,key=lambda x: (x[0], -x[1]))])
+  sortedFitnessT,sortedAgeT,sortedPopulationT,sortedGT,sortedObjT = np.atleast_1d(list(sortedFitness)),list(sortedAge),np.atleast_1d(list(sortedPopulation)),np.atleast_1d(list(sortedG)),np.atleast_1d(list(sortedObj))
   newPopulationSorted = sortedPopulationT[:-len(offSprings)]
   newFitness = sortedFitnessT[:-len(offSprings)]
   newG = sortedGT[:-len(offSprings)]
+  newObj = sortedObjT[:-len(offSprings)]
   newAge = sortedAgeT[:-len(offSprings)]
 
   newPopulationArray = xr.DataArray(newPopulationSorted,
@@ -133,7 +137,7 @@ def fitnessBased(newRlz,**kwargs):
                               'Constraint':kwargs['parentg'].coords['Constraint'].values})
 
   #return newPopulationArray,newFitness,newAge
-  return newPopulationArray,newFitness,newAge,kwargs['popObjectiveVal'], newG
+  return newPopulationArray,newFitness,newAge,newObj, newG
 
 __survivorSelectors = {}
 __survivorSelectors['ageBased'] = ageBased

--- a/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
+++ b/ravenframework/Optimizers/survivorSelectors/survivorSelectors.py
@@ -127,11 +127,10 @@ def fitnessBased(newRlz,**kwargs):
                             dims=['chromosome'],
                             coords={'chromosome':np.arange(np.shape(newFitness)[0])})
 
-  newG = [item for sublist in newG for item in sublist]
-
   newG = xr.DataArray(newG,
-                      dims=['chromosome'],
-                      coords={'chromosome':np.arange(np.shape(newG)[0])})
+                      dims=['chromosome','Constraint'],
+                      coords={'chromosome':np.arange(np.shape(newG)[0]),
+                              'Constraint':kwargs['parentg'].coords['Constraint'].values})
 
   #return newPopulationArray,newFitness,newAge
   return newPopulationArray,newFitness,newAge,kwargs['popObjectiveVal'], newG


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2069 

##### What are the significant changes in functionality due to this change request?
GA can converge faster after finding solutions among (parent solutions and offspring solutions). 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

