### PR TITLE
Moving skip_if_OS from RavenFramework to Tester

### DIFF
--- a/rook/Tester.py
+++ b/rook/Tester.py
@@ -390,6 +390,7 @@ class Tester:
                      ' Example 3.8 (note, format is major.minor)')
     params.add_param('needed_executable', '',
                      'Only run test if needed executable is on path.')
+    params.add_param('skip_if_OS', '', 'Skip test if the operating system defined')
     return params
 
   def __init__(self, _name, params):
@@ -536,6 +537,18 @@ class Tester:
       self.results.group = self.group_skip
       self.results.message = self.specs['skip']
       return self.results
+    ## OS
+    if len(self.specs['skip_if_OS']) > 0:
+      skip_os = [x.strip().lower() for x in self.specs['skip_if_OS'].split(',')]
+      # get simple-name platform (options are Linux, Windows, Darwin, or SunOS that I've seen)
+      current_os = platform.system().lower()
+      # replace Darwin with more expected "mac"
+      if current_os == 'darwin':
+        current_os = 'mac'
+      if current_os in skip_os:
+        self.set_skip('skipped (OS is "{}")'.format(current_os))
+        return self.results
+
     if self.specs['min_python_version'].strip().lower() != 'none':
       major, minor = self.specs['min_python_version'].strip().split(".")
       #check to see if current version of python too old.

--- a/rook/doc/rook.tex
+++ b/rook/doc/rook.tex
@@ -46,6 +46,7 @@ example above.
   \item[expected\_fail] if true, then the test should fails, and if it passes, it fails
   \item[run\_types] The run types of this test, separated by spaces. Example: 'heavy qsub' The default is 'normal'
   \item[output\_wait\_time] Number of seconds to wait for output
+  \item[skip\_if\_OS] Skip the test if the OS in the list Examples: 'mac,linux' or 'windows'
 \end{description}
 
 \subsection{GenericExecutable}
@@ -71,8 +72,8 @@ check for output.
   \item[gold\_files] Gold filenames, if different from the default. These are 1 to 1 mappings with the
       \texttt{output} files listed above, and use the same relative pathing. Using the example under
       \textbf{output} above, including \texttt{gold\_files = 'gold/path/to/file2'} would compare the file
-      \texttt{path/to/file1} to the file \texttt{gold/path/to/file2}. \nb Unlike the default,
-      \texttt{gold} is not automatically added to the \textttt{gold\_files} path.
+      \texttt{path/to/file1} to the file \texttt{gold/path/to/file2}. Note: Unlike the default,
+      \texttt{gold} is not automatically added to the \texttt{gold\_files} path.
 \end{description}
 
 \subsection{Exists}

--- a/scripts/TestHarness/testers/RavenFramework.py
+++ b/scripts/TestHarness/testers/RavenFramework.py
@@ -84,7 +84,6 @@ class RavenFramework(Tester):
                      'Skip test if the library listed is below the supplied'+
                      ' version (e.g. minimum_library_versions = \"name1 version1 name2 version2\")')
     params.add_param('skip_if_env', '', 'Skip test if this environmental variable is defined')
-    params.add_param('skip_if_OS', '', 'Skip test if the operating system defined')
     params.add_param('test_interface_only', False,
                      'Test the interface only (without running the driven code')
     params.add_param('check_absolute_value', False,
@@ -179,17 +178,6 @@ class RavenFramework(Tester):
       envVar = self.specs['skip_if_env']
       if envVar in os.environ:
         self.set_skip('skipped (found environmental variable "'+envVar+'")')
-        return False
-    ## OS
-    if len(self.specs['skip_if_OS']) > 0:
-      skipOs = [x.strip().lower() for x in self.specs['skip_if_OS'].split(',')]
-      # get simple-name platform (options are Linux, Windows, Darwin, or SunOS that I've seen)
-      currentOs = platform.system().lower()
-      # replace Darwin with more expected "mac"
-      if currentOs == 'darwin':
-        currentOs = 'mac'
-      if currentOs in skipOs:
-        self.set_skip('skipped (OS is "{}")'.format(currentOs))
         return False
     for lib in self.required_libraries:
       found, _, _ = library_handler.checkSingleLibrary(lib)

--- a/tests/reg_self_tests/only_not_windows.py
+++ b/tests/reg_self_tests/only_not_windows.py
@@ -1,0 +1,12 @@
+"""
+  this only runs successfully in when not in windows
+"""
+
+import platform
+import sys
+
+if platform.system().lower() == 'windows':
+  sys.exit(-1)
+
+#Otherwise succeed
+sys.exit(0)

--- a/tests/reg_self_tests/only_windows.py
+++ b/tests/reg_self_tests/only_windows.py
@@ -1,0 +1,12 @@
+"""
+  this only runs successfully in windows
+"""
+
+import platform
+import sys
+
+if platform.system().lower() == 'windows':
+  sys.exit(0)
+
+#Otherwise fail
+sys.exit(-1)

--- a/tests/reg_self_tests/tests
+++ b/tests/reg_self_tests/tests
@@ -4,6 +4,18 @@
   input = 'test_ordered_csv.py'
  [../]
 
+ [./check_windows]
+   type = 'RavenPython'
+   input = 'only_windows.py'
+   skip_if_OS = 'mac,linux'
+ [../]
+
+ [./check_not_windows]
+   type = 'RavenPython'
+   input = 'only_not_windows.py'
+   skip_if_OS = 'windows'
+ [../]
+
  [./simple_exec]
   type = 'GenericExecutable'
   executable = 'python'


### PR DESCRIPTION
This allows test types besides RavenFramework to use skip_if_OS

--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2071 


##### What are the significant changes in functionality due to this change request?
* Removes skip_if_OS from RavenFramework
* Adds skip_if_OS to Tester
* adds documentation to rook.tex
* Adds tests for this in reg_self_tests

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

