### PR TITLE
Use the raven installation manager if available.

### DIFF
--- a/clean_raven
+++ b/clean_raven
@@ -19,7 +19,8 @@ rm -f ${RAVEN_DIR}/src/AMSC/_amsc*.so \
     ${RAVEN_DIR}/src/AMSC/amsc_wrap.cpp
 rm -Rf ${RAVEN_DIR}/build  \
    ${RAVEN_DIR}/crow/install/ \
-   ${RAVEN_DIR}/install/
+   ${RAVEN_DIR}/install/ \
+   ${RAVEN_DIR}/setup.cfg
 rm -f ${RAVEN_DIR}/src/crow_modules/*.so \
    ${RAVEN_DIR}/src/crow_modules/[dir]*.py \
    ${RAVEN_DIR}/src/crow_modules/*.cpp

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -285,7 +285,14 @@ ECE_MODE=1 # 1 for loading, 2 for install, 0 for help
 INSTALL_OPTIONAL="" # --optional if installing optional, otherwise blank
 ECE_VERBOSE=0 # 0 for printing, anything else for no printing
 ECE_CLEAN=0 # 0 for yes (remove raven libs env before installing), 1 for don't remove it
-INSTALL_MANAGER="CONDA" # CONDA (default) or PIP
+INSTALLATION_MANAGER=$(read_ravenrc "INSTALLATION_MANAGER")
+if [[ -z "$INSTALLATION_MANAGER" ]];
+then
+    INSTALL_MANAGER="CONDA" # CONDA (default) or PIP
+else
+    #use installation manager from .ravenrc
+    INSTALL_MANAGER="$INSTALLATION_MANAGER"
+fi
 PROXY_COMM="" # proxy is none
 
 # parse command-line arguments
@@ -348,10 +355,10 @@ fi
 if [[ $ECE_VERBOSE == 0 ]];
 then
   echo ... Run Options:
-  echo ...    Mode: $ECE_MODE
+  echo ...    ECE Mode: $ECE_MODE
   echo ...   Verbosity: $ECE_VERBOSE
   echo ...   Clean: $ECE_CLEAN
-  echo ...    Mode: $INSTALL_MANAGER
+  echo ...    Install Mode: $INSTALL_MANAGER
   if [[ "$INSTALL_MANAGER" == "CONDA" ]];
   then
     echo ...   Conda Defs: $CONDA_DEFS

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -188,6 +188,8 @@ def findLibAndVersion(lib, version=None):
   if lib not in metaExceptions:
     try:
       foundVersion = importlib_metadata.version(lib)
+      #The following line can be used for debugging library problems
+      #print(lib, importlib_metadata.files(lib)[0].locate())
       found = True
       output = 'Library found.'
     except importlib_metadata.PackageNotFoundError:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2090 

##### What are the significant changes in functionality due to this change request?
Uses the INSTALLATION_MANAGER from .ravenrc if it exists.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

