### PR TITLE
Mamba alternative to conda

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -315,7 +315,7 @@ else
     INSTALL_MANAGER="$INSTALLATION_MANAGER"
 fi
 PROXY_COMM="" # proxy is none
-USE_MAMBA=FALSE # Use Mamba for installation
+USE_MAMBA=TRUE # Use Mamba for installation
 
 # parse command-line arguments
 while test $# -gt 0
@@ -342,6 +342,10 @@ do
     --mamba)
       echo ... using mamba
       USE_MAMBA=TRUE
+      ;;
+    --no-mamba)
+      echo ... not using mamba
+      USE_MAMBA=FALSE
       ;;
     --optional)
       echo ... Including optional libraries ...

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -107,8 +107,17 @@ function install_libraries()
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
-    if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
-    ${COMMAND}
+    echo USE_MAMBA $USE_MAMBA
+    if [[ $USE_MAMBA == TRUE ]]; then
+        conda install -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
+        activate_env
+        local MCOMMAND=${COMMAND/#conda /mamba } #Replace conda at start with mamba
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${MCOMMAND}; fi
+        ${MCOMMAND}
+    else
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
+        ${COMMAND}
+    fi
     # pip only
     activate_env
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from PIP-ONLY ...; fi
@@ -165,9 +174,21 @@ function create_libraries()
     if [[ $ECE_VERBOSE == 0 && $WORKING_PYTHON_COMMAND != $PYTHON_COMMAND ]]; then
         echo ... temporarily using Python $WORKING_PYTHON_COMMAND for installation
     fi
-    local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create --subset forge)`
-    if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
-    ${COMMAND}
+    echo USE_MAMBA $USE_MAMBA
+    if [[ $USE_MAMBA == TRUE ]]; then
+        echo conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
+        conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
+        activate_env
+        local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
+        local MCOMMAND=${COMMAND/#conda /mamba }
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${MCOMMAND}; fi
+        ${MCOMMAND}
+    else
+        local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create --subset forge)`
+
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
+        ${COMMAND}
+    fi
     # pip only
     activate_env
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from PIP-ONLY ...; fi
@@ -294,6 +315,7 @@ else
     INSTALL_MANAGER="$INSTALLATION_MANAGER"
 fi
 PROXY_COMM="" # proxy is none
+USE_MAMBA=FALSE # Use Mamba for installation
 
 # parse command-line arguments
 while test $# -gt 0
@@ -316,6 +338,10 @@ do
       ;;
     --install)
       ECE_MODE=2
+      ;;
+    --mamba)
+      echo ... using mamba
+      USE_MAMBA=TRUE
       ;;
     --optional)
       echo ... Including optional libraries ...


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2107 

##### What are the significant changes in functionality due to this change request?
Uses mamba instead of conda for installation

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

