### PR TITLE
Mamba alternative to conda

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -46,7 +46,7 @@ Note all install methods after "main" take
     <matplotlib>3.5</matplotlib>
     <statsmodels>0.13</statsmodels>
     <cloudpickle>2.2</cloudpickle>
-    <tensorflow>2.10</tensorflow>
+    <tensorflow source="pip">2.10</tensorflow>
     <!-- conda is really slow on windows if the version is not specified.-->
     <python skip_check='True' os='windows'>3.8</python>
     <python skip_check='True' os='mac,linux'>3</python>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -46,7 +46,8 @@ Note all install methods after "main" take
     <matplotlib>3.5</matplotlib>
     <statsmodels>0.13</statsmodels>
     <cloudpickle>2.2</cloudpickle>
-    <tensorflow source="pip">2.10</tensorflow>
+    <tensorflow os='mac,linux'>2.10</tensorflow>
+    <tensorflow source="pip" os='windows'>2.10</tensorflow>
     <!-- conda is really slow on windows if the version is not specified.-->
     <python skip_check='True' os='windows'>3.8</python>
     <python skip_check='True' os='mac,linux'>3</python>

--- a/doc/user_manual/Installation/clone.tex
+++ b/doc/user_manual/Installation/clone.tex
@@ -76,6 +76,14 @@ bash.exe establish_conda_env.sh --install
 
 replacing \texttt{/path/to} with the install path for \texttt{conda}.
 
+\nb Various options exist for \texttt{establish\_conda\_env.sh}, which
+can be found by using the \texttt{--help} option.  These options
+include \texttt{--mamba} which uses the mamba instead of conda for
+resolving dependencies, \texttt{--load} which can be used with
+\verb'source ./scripts/establish_conda_env.sh --load' to switch to the
+raven environment in a shell, \texttt{--installation-manager PIP} which
+uses pip instead of conda.
+
 \subsubsection{Compiling RAVEN}
 Once Python libraries are established and the source code present, navigate to \texttt{raven} and run
 

--- a/doc/user_manual/Installation/conda.tex
+++ b/doc/user_manual/Installation/conda.tex
@@ -6,6 +6,6 @@ The standard installation procedure for RAVEN includes using Miniconda (often si
 operating system, refer to the wiki (listed above) for alternatives.  To install miniconda, follow the
 instructions for your operating system at \url{https://conda.io/miniconda.html}.
 
-\nb RAVEN currently works with Python 2.7, but it is recommended that Python 3 be used, so unless you have a reason to use 2.7, we recommend installing the 64 bit Python 3 version of miniconda.
+\nb RAVEN only works with Python 3, we recommend installing the 64 bit Python 3 version of miniconda.
 
 Once conda is installed, proceed to installing RAVEN itself (section \ref{sec:clone raven}).

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -315,7 +315,7 @@ else
     INSTALL_MANAGER="$INSTALLATION_MANAGER"
 fi
 PROXY_COMM="" # proxy is none
-USE_MAMBA=FALSE # Use Mamba for installation
+USE_MAMBA=TRUE # Use Mamba for installation
 
 # parse command-line arguments
 while test $# -gt 0
@@ -342,6 +342,10 @@ do
     --mamba)
       echo ... using mamba
       USE_MAMBA=TRUE
+      ;;
+    --no-mamba)
+      echo ... not using mamba
+      USE_MAMBA=FALSE
       ;;
     --optional)
       echo ... Including optional libraries ...

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -107,8 +107,17 @@ function install_libraries()
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
-    if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
-    ${COMMAND}
+    echo USE_MAMBA $USE_MAMBA
+    if [[ $USE_MAMBA == TRUE ]]; then
+        conda install -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
+        activate_env
+        local MCOMMAND=${COMMAND/#conda /mamba } #Replace conda at start with mamba
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${MCOMMAND}; fi
+        ${MCOMMAND}
+    else
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
+        ${COMMAND}
+    fi
     # pip only
     activate_env
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from PIP-ONLY ...; fi
@@ -165,9 +174,21 @@ function create_libraries()
     if [[ $ECE_VERBOSE == 0 && $WORKING_PYTHON_COMMAND != $PYTHON_COMMAND ]]; then
         echo ... temporarily using Python $WORKING_PYTHON_COMMAND for installation
     fi
-    local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create --subset forge)`
-    if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
-    ${COMMAND}
+    echo USE_MAMBA $USE_MAMBA
+    if [[ $USE_MAMBA == TRUE ]]; then
+        echo conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
+        conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
+        activate_env
+        local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
+        local MCOMMAND=${COMMAND/#conda /mamba }
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${MCOMMAND}; fi
+        ${MCOMMAND}
+    else
+        local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create --subset forge)`
+
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
+        ${COMMAND}
+    fi
     # pip only
     activate_env
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from PIP-ONLY ...; fi
@@ -294,6 +315,7 @@ else
     INSTALL_MANAGER="$INSTALLATION_MANAGER"
 fi
 PROXY_COMM="" # proxy is none
+USE_MAMBA=FALSE # Use Mamba for installation
 
 # parse command-line arguments
 while test $# -gt 0
@@ -316,6 +338,10 @@ do
       ;;
     --install)
       ECE_MODE=2
+      ;;
+    --mamba)
+      echo ... using mamba
+      USE_MAMBA=TRUE
       ;;
     --optional)
       echo ... Including optional libraries ...

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -243,6 +243,12 @@ function display_usage()
 	echo '    --installation-manager'
 	echo '      Package installation manager. (CONDA, PIP). If not provided, default to CONDA'
 	echo ''
+        echo '    --mamba'
+        echo '      Use mamba instead of conda for package installation'
+        echo ''
+        echo '    --no-mamba'
+        echo '      Do not use mamba for package installation.'
+        echo ''
 	echo '    --proxy <proxy>'
 	echo '      Specify a proxy to be used in the form [user:passwd@]proxy.server:port.'
 	echo ''
@@ -315,7 +321,7 @@ else
     INSTALL_MANAGER="$INSTALLATION_MANAGER"
 fi
 PROXY_COMM="" # proxy is none
-USE_MAMBA=TRUE # Use Mamba for installation
+USE_MAMBA=FALSE # Use Mamba for installation
 
 # parse command-line arguments
 while test $# -gt 0

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -107,7 +107,6 @@ function install_libraries()
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
-    echo USE_MAMBA $USE_MAMBA
     if [[ $USE_MAMBA == TRUE ]]; then
         conda install -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
         activate_env
@@ -174,7 +173,6 @@ function create_libraries()
     if [[ $ECE_VERBOSE == 0 && $WORKING_PYTHON_COMMAND != $PYTHON_COMMAND ]]; then
         echo ... temporarily using Python $WORKING_PYTHON_COMMAND for installation
     fi
-    echo USE_MAMBA $USE_MAMBA
     if [[ $USE_MAMBA == TRUE ]]; then
         echo conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
         conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba

--- a/tests/cluster_tests/test_qsubs.sh
+++ b/tests/cluster_tests/test_qsubs.sh
@@ -48,7 +48,7 @@ echo Current directory: `pwd`
 
 cd ${RAVEN_FRAMEWORK_DIR}/..
 # TODO running plugin qsub tests?
-./run_tests -j6 --raven --only-run-types="qsub" --re=cluster_tests
+./run_tests -j3 --raven --only-run-types="qsub" --re=cluster_tests
 EXIT=$?
 
 ## Find output files and print them

--- a/tests/framework/pca_adaptive_sgc/tests
+++ b/tests/framework/pca_adaptive_sgc/tests
@@ -33,6 +33,7 @@
   input = 'test_adaptive_sgc_poly_pca_analytic.xml'
   UnorderedCsv = 'polynomial/csv_database.csv'
   UnorderedXml = 'polynomial/stats_td1.xml'                    #analytic, "Tensor Polynomial (First-Order) with Multivariate Normal Distribution"
+  max_time = 500 # windows test box is slow, so very slow
  [../]
 
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2107 

##### What are the significant changes in functionality due to this change request?
Uses mamba instead of conda for installation

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

