### PR TITLE
update manual

### DIFF
--- a/doc/user_manual/raven_user_manual.tex
+++ b/doc/user_manual/raven_user_manual.tex
@@ -248,19 +248,22 @@ showstringspaces=false            %
 
 \author{
 \textbf{\textit{Project Manager:}}
- \\Cristian Rabiti\\
+ \\Diego Mandelli\\
  \textbf{\textit{Principal Investigator and Technical Leader:}}
- \\Andrea Alfonsi\\
+ \\Congjian Wang\\
 \textbf{\textit{Main Developers:}}
 \\Andrea Alfonsi
 \\Diego Mandelli
 \\Joshua Cogliati
 \\Congjian Wang
 \\Paul W. Talbot
+\\Mohammad G. Abdo
+\\Ramon K. Yoshiura\\
+\textbf{\textit{Former Developers:}}
+\\Cristian Rabiti
 \\Daniel P. Maljovec
+\\Sonat Sen
 \\Robert Kinoshita
-\\Mohammad G. Abdo\\
-\textbf{\textit{Former Developers:}} \\Sonat Sen
 \\Jun Chen\\
 \textbf{\textit{Contributors:}}
 \\Alessandro Bandini (Post-Processor)
@@ -270,23 +273,8 @@ showstringspaces=false            %
 \\Matteo Donorio (new external code interface)
 \\Fabio Giannetti (new external code interface)
 \\Jia Zhou (conjugate gradient optimizer)
-\\Ramon K. Yoshiura (DSS validation code)
+\\Junyung Kim (Genetic Algorithm)
 }
-% \\James B. Tompkins}   Just people who actually ``developed'' a significant capability in the code should be placed here. Andrea
-%\author{\textbf{\textit{Main Developers:}}  \\Andrea Alfonsi}
-%\author{\\Joshua Cogliati}
-%\author{\\Diego Mandelli}
-%\author{\\Robert Kinoshita}
-%\author{\\Sonat Sen}
-%
-%\author{Cristian Rabiti}
-%\author{Andrea Alfonsi}
-%\author{Joshua Cogliati}
-%\author{Diego Mandelli}
-%\author{Robert Kinoshita}
-%\author{Sonat Sen}
-%\affil{Idaho National Laboratory, Idaho Falls, ID 83402}
-%\\\{cristian.rabiti, andrea.alfonsi, joshua.cogliati, diego.mandelli, robert.kinoshita, ramazan.sen\}@inl.gov}
 
 % There is a "Printed" date on the title page of a SAND report, so
 % the generic \date should [WorkingDir:]generally be empty.


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#1806 
Update user manual 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

