### PR TITLE
Explain how to get individual plugins in install documentation.

### DIFF
--- a/doc/user_manual/Installation/clone.tex
+++ b/doc/user_manual/Installation/clone.tex
@@ -25,7 +25,23 @@ the commands
 \begin{lstlisting}[language=bash]
 git clone https://github.com/idaholab/raven.git
 cd raven
+\end{lstlisting}
+
+\subsubsection{Getting Plugins}
+
+Individual plugins can be gotten with a command like (from the
+\texttt{raven} directory):
+
+\begin{lstlisting}[language=bash]
+git submodule update --init plugins/TEAL/
+python scripts/install_plugins.py -s plugins/TEAL
+\end{lstlisting}
+
+All the plugins can be gotten, but this may throw errors if there are non-open source ones currently:
+
+\begin{lstlisting}[language=bash]
 git submodule update --init
+python scripts/install_plugins.py -a
 \end{lstlisting}
 This will obtain RAVEN as well as other submodules that RAVEN uses.  In the future, whenever we declare a path
 starting with \texttt{raven/}, we refer to the cloned directory.
@@ -50,7 +66,7 @@ cd scripts
 cd scripts
 bash.exe establish_conda_env.sh --install
 \end{lstlisting}
-  
+
 \end{itemize}
 Assure that there are no errors in this process, then continue to compiling RAVEN.
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
#1806

##### What are the significant changes in functionality due to this change request?
This describes how to install an individual plugin, which was missing from the install documentation.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

