### PR TITLE
Adding locking to HybridModel.

### DIFF
--- a/ravenframework/Models/ROM.py
+++ b/ravenframework/Models/ROM.py
@@ -284,6 +284,7 @@ class ROM(Dummy):
       @ In,  None
       @ Out, None
     """
+    self.raiseADebug("resetting ROM")
     for rom in self.supervisedContainer:
       rom.reset()
     self.amITrained = False
@@ -416,7 +417,7 @@ class ROM(Dummy):
     """
     request = self._inputToInternal(request)
     if not self.amITrained:
-      self.raiseAnError(RuntimeError, "ROM "+self.name+" has not been trained yet and, consequentially, can not be evaluated!")
+      self.raiseAnError(RuntimeError, "ROM "+self.name+" has not been trained yet and, consequentially, can not calculate confidence")
     confidenceDict = {}
     for rom in self.supervisedContainer:
       sliceEvaluation = rom.confidence(request)
@@ -473,7 +474,7 @@ class ROM(Dummy):
     if self.pickled:
       self.raiseAnError(RuntimeError,'ROM "', self.name, '" has not been loaded yet!  Use an IOStep to load it.')
     if not self.amITrained:
-      self.raiseAnError(RuntimeError, "ROM ", self.name, " has not been trained yet and, consequentially, can not be evaluated!")
+      self.raiseAnError(RuntimeError, "ROM ", self.name, " has not been trained yet and, consequentially, can not calculate derivatives!")
     derivatives = {}
     if self.segment:
       derivatives = mathUtils.derivatives(self.supervisedContainer[0].evaluate, request, var=feats, n=order)


### PR DESCRIPTION

--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2139


##### What are the significant changes in functionality due to this change request?
Adding locking to HybridModel.
This locking prevents resetting the ROM while it is being used. Also, some additional debugging information is added.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

