### PR TITLE
Mamba doesn't like name

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -66,6 +66,7 @@ Note all install methods after "main" take
     <dask source="pip" pip_extra="[complete]"/>
     <ray source="pip" pip_extra="[default]" os='mac,linux'>2.2</ray>
     <ray source="pip" pip_extra="[default]" os='windows'>1.13</ray>
+    <pydantic source="pip">1</pydantic> <!-- ray 2.2 can't use pydantic 2 -->
     <!-- redis is needed by ray, but on windows, this seems to need to be explicitly stated -->
     <redis source="pip" os='windows'/>
     <imageio>2.22</imageio>

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -106,14 +106,16 @@ function install_libraries()
   then
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
-    local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
     if [[ $USE_MAMBA == TRUE ]]; then
         conda install -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD
+        local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
         activate_env
         local MCOMMAND=${COMMAND/#conda /mamba } #Replace conda at start with mamba
         if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${MCOMMAND}; fi
         ${MCOMMAND}
     else
+        local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
+
         if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${COMMAND}; fi
         ${COMMAND}
     fi
@@ -176,7 +178,7 @@ function create_libraries()
     if [[ $USE_MAMBA == TRUE ]]; then
         echo conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
         conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD
-        local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge)`
+        local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
         activate_env
         local MCOMMAND=${COMMAND/#conda /mamba }
         if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge command: ${MCOMMAND}; fi

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -531,6 +531,9 @@ if __name__ == '__main__':
   condaParser.add_argument('--subset', dest='subset',
         choices=('core', 'forge', 'pip', 'pyomo'), default='core',
         help='Use subset of installation libraries, divided by source.')
+  condaParser.add_argument('--no-name', dest='noName',
+                           action='store_true',
+                           help='Do not include --name in output (needed for mamba install)')
 
   pipParser = subParsers.add_parser('pip', help='use pip as installer')
   pipParser.add_argument('--action', dest='action', choices=('install', 'list', 'setup.cfg'), default='install',
@@ -596,7 +599,10 @@ if __name__ == '__main__':
     if args.installer == 'conda':
       installer = 'conda'
       equals = '='
-      actionArgs = '--name {env} -y {src}'
+      if args.noName:
+        actionArgs = '-y {src}'
+      else:
+        actionArgs = '--name {env} -y {src}'
       # which part of the install are we doing?
       if args.subset == 'core' or args.subset == 'forge':
         # from defaults


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
This works around:
https://github.com/mamba-org/mamba/issues/83

#1806 
##### What are the significant changes in functionality due to this change request?
This removes using --name with mamba since that currently causes an error sometimes in install. 
Instead the environment is activated before installing.



----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

