### PR TITLE
Removing checking for swig with crow

### DIFF
--- a/tests/crow/tests
+++ b/tests/crow/tests
@@ -3,102 +3,85 @@
   type = 'CrowPython'
   #python_command = python3
   input = 'test_import.py'
-  requires_swig2 = True
  [../]
 
  [./test_utils]
   type = 'CrowPython'
   input = 'test_utils.py'
-  requires_swig2 = True
  [../]
 
 [./test_normal]
   type = 'CrowPython'
   input = 'test_normal.py'
-  requires_swig2 = True
  [../]
 
  [./test_laplace]
   type = 'CrowPython'
   input = 'test_laplace.py'
-  requires_swig2 = True
  [../]
 
  [./test_geometric]
   type = 'CrowPython'
   input = 'test_geometric.py'
-  requires_swig2 = True
  [../]
 
  [./test_svd]
   type = 'CrowPython'
   input = 'test_eigen_svd.py'
-  requires_swig2 = True
  [../]
 
  [./test_reduction]
   type = 'CrowPython'
   input = 'test_reduction.py'
-  requires_swig2 = True
  [../]
 
  [./test_pca_index]
   type = 'CrowPython'
   input = 'test_pca_index.py'
-  requires_swig2 = True
  [../]
 
  [./test_mvn_pca]
   type = 'CrowPython'
   input = 'test_mvn_pca.py'
-  requires_swig2 = True
  [../]
 
  [./test_inverseMarginalforPCA]
   type = 'CrowPython'
   input = 'test_inverseMarginalForPCA.py'
-  requires_swig2 = True
  [../]
 
  [./test_cellProbabilityWeight]
   type = 'CrowPython'
   input = 'test_cellProbabilityWeight.py'
-  requires_swig2 = True
  [../]
 
  [./test_marginalCdfForPCA]
   type = 'CrowPython'
   input = 'test_marginalCdfForPCA.py'
-  requires_swig2 = True
  [../]
 
  [./test_transformationMatrix]
   type = 'CrowPython'
   input = 'test_transformationMatrix.py'
-  requires_swig2 = True
  [../]
 
  [./test_svd_index]
   type = 'CrowPython'
   input = 'test_svd_index.py'
-  requires_swig2 = True
  [../]
 
  [./test_transformationMatrix_index]
   type = 'CrowPython'
   input = 'test_transformationMatrix_index.py'
-  requires_swig2 = True
  [../]
 
  [./test_inverse_transformationMatrix]
   type = 'CrowPython'
   input = 'test_inverse_transformation_matrix.py'
-  requires_swig2 = True
  [../]
- 
+
  [./test_symmetric_psd]
   type = 'CrowPython'
   input = 'test_symmetric_psd.py'
-  requires_swig2 = True
  [../]
 []


### PR DESCRIPTION
RAVEN will not build without swig, so checking for swig is unnecessary.

--------
Pull Request Description
--------
##### What issue does this change request address?
#1806 

##### What are the significant changes in functionality due to this change request?
This removes the check for swig before running crow tests, since swig is necessary for RAVEN, so this check is unnecessary.


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

