### PR TITLE
Echo command used for installing mamba for diagnostic purposes.

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -107,7 +107,9 @@ function install_libraries()
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     if [[ $USE_MAMBA == TRUE ]]; then
-        conda install -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD
+        local PRECOMMAND=`echo conda install -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD`
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge pre-command: ${PRECOMMAND}; fi
+        ${PRECOMMAND}
         local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
         activate_env
         local MCOMMAND=${COMMAND/#conda /mamba } #Replace conda at start with mamba
@@ -176,8 +178,9 @@ function create_libraries()
         echo ... temporarily using Python $WORKING_PYTHON_COMMAND for installation
     fi
     if [[ $USE_MAMBA == TRUE ]]; then
-        echo conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge mamba
-        conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD
+        local PRECOMMAND=`echo conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD`
+        if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge pre-command: $PRECOMMAND; fi
+        ${PRECOMMAND}
         local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
         activate_env
         local MCOMMAND=${COMMAND/#conda /mamba }

--- a/scripts/library_report
+++ b/scripts/library_report
@@ -72,11 +72,10 @@ except ImportError:
   print("randomENG not found\n")
 print()
 amsc_report = library_handler.checkSingleLibrary('AMSC', useImportCheck=True)
-for module, found, message, version in [('AMSC',amsc_report[0], amsc_report[1], "")]:
-  if found:
-    print(module,version,"\n",message,"\n")
-  else:
-    print(module+' not found\n')
+if amsc_report[0]:
+  print("AMSC\n",amsc_report[1],"\n")
+else:
+  print('AMSC not found\n')
 
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 s.connect(('8.8.8.8', 1))

--- a/scripts/library_report
+++ b/scripts/library_report
@@ -44,9 +44,7 @@ import library_handler
 from ravenframework.utils import utils
 
 report_list = library_handler.checkLibraries(buildReport=True)
-amsc_report = library_handler.checkSingleLibrary('AMSC', useImportCheck=True)
 tensorflow_report = library_handler.checkSingleLibrary('tensorflow', version='check', useImportCheck=True)
-report_list.append(('AMSC',amsc_report[0], amsc_report[1], ""))
 report_list.append(('tensorflow',) + tensorflow_report)
 print("\nLibraries report:\n")
 for module, found, message, version in report_list:
@@ -72,7 +70,13 @@ try:
   print("randomENG","\n",randomENG)
 except ImportError:
   print("randomENG not found\n")
-
+print()
+amsc_report = library_handler.checkSingleLibrary('AMSC', useImportCheck=True)
+for module, found, message, version in [('AMSC',amsc_report[0], amsc_report[1], "")]:
+  if found:
+    print(module,version,"\n",message,"\n")
+  else:
+    print(module+' not found\n')
 
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 s.connect(('8.8.8.8', 1))


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2148 


##### What are the significant changes in functionality due to this change request?
Echos the command used to install mamba.
Also fixes checking for the AMSC library.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

