### PR TITLE
XML Diff in Rook now can ignore nodes provided by user

### DIFF
--- a/rook/XMLDiff.py
+++ b/rook/XMLDiff.py
@@ -354,9 +354,10 @@ def ignore_subnodes_from_root(a_element, b_element, ignored_nodes):
     @ In, b_element, ET.Element.Tree, the second element tree
     @ In, ignored_nodes, str, address of ignored subnodes of XPath format, e.g.,
                               `.//parentNode/childNode[@name:<>]/grandchildNode`
-    @ Out, a_element, ET.Element.Tree, the first element tree
-    @ Out, b_element, ET.Element.Tree, the second element tree
-    @ Out, success, bool, was the removal successful?
+    @ Out, ignore_subnodes_from_root, (ET.Element.Tree, ET.Element.Tree, bool), (a_element,
+          b_element, success) where a_element and b_element are the two input element trees which
+          are modified if successful (otherwise returned as is) and success is a boolean noting if
+          removal of ignored nodes was successful
   """
   # internal check of ignored nodes already conducted by this point
   for ignored in ignored_nodes:

--- a/rook/XMLDiff.py
+++ b/rook/XMLDiff.py
@@ -90,7 +90,8 @@ def compare_list_entry(a_list, b_list, **kwargs):
     else:
       num_match += 1
     #match text
-    #if (a_entry.text is None or len(a_entry.text)>0) and (b_item.text is None or len(b_item.text)>0):
+    #if (a_entry.text is None or len(a_entry.text)>0) and \
+    #   (b_item.text is None or len(b_item.text)>0):
     same, _ = cswf(a_entry.text,
                    b_item.text,
                    rel_err=options["rel_err"],
@@ -366,8 +367,8 @@ def ignore_subnodes_from_root(a_element, b_element, ignored_nodes):
         parentnode = element.find(parentpath)
         parentnode.remove(parentnode.find(childpath))
       success = True
-    except Exception as e:
-      print((f"Could not find XPath {ignored} in elements with exception:{e}"))
+    except Exception as exp:
+      print((f"Could not find XPath {ignored} in elements with exception:{exp}"))
       return a_element, b_element, False
   return a_element, b_element, success
 

--- a/rook/XMLDiff.py
+++ b/rook/XMLDiff.py
@@ -528,7 +528,9 @@ class XML(Differ):
 
   def check_xpath(self):
     """
-      Converts xpath given if not correct.
+      Converts xpath given if not correct. This assumes that the xpath coming in looks like
+      "Parent|Child@name:value|Grandchild" and converts to
+      "./Parent/Child[@name:'value']/Grandchild".
       @ In, None
       @ Out, None
     """
@@ -554,8 +556,9 @@ class XML(Differ):
           if add_params:
             tpath += f'[@{tag}=\'{value}\']'
         self.__xmlopts['ignored_nodes'][i] = tpath
-      if not self.__xmlopts['ignored_nodes'][i].startswith('./'):
-        self.__xmlopts['ignored_nodes'][i] = './' + self.__xmlopts['ignored_nodes'][i]
+      # NOTE: might be changed in future? makes starting position relative to current node
+      if not self.__xmlopts['ignored_nodes'][i].startswith('.'):
+        self.__xmlopts['ignored_nodes'][i] = '.' + self.__xmlopts['ignored_nodes'][i]
       # sometimes the [@name:'value'] comes in as [@name:\'value\']
       if "\\" in self.__xmlopts['ignored_nodes'][i]:
         self.__xmlopts['ignored_nodes'][i] = self.__xmlopts['ignored_nodes'][i].replace("\\", "")

--- a/rook/XMLDiff.py
+++ b/rook/XMLDiff.py
@@ -345,15 +345,17 @@ def compare_ordered_element(a_element, b_element, *args, **kwargs):
   return (same, message)
 
 
-def remove_subnodes_from_root(a_element, b_element, ignored_nodes):
+def ignore_subnodes_from_root(a_element, b_element, ignored_nodes):
   """
     Compares two element trees and returns (same,message) where same is true
       if they are the same, and message is a list of the differences
-    @ In, a_element, ET.Element, the first element tree
-    @ In, b_element, ET.Element, the second element tree
+    @ In, a_element, ET.Element.Tree, the first element tree
+    @ In, b_element, ET.Element.Tree, the second element tree
     @ In, ignored_nodes, str, address of ignored subnodes of XPath format, e.g.,
                               `.//parentNode/childNode[@name:<>]/grandchildNode`
-    @ Out, element, ET.Element, an element tree
+    @ Out, a_element, ET.Element.Tree, the first element tree
+    @ Out, b_element, ET.Element.Tree, the second element tree
+    @ Out, success, bool, was the removal successful?
   """
   # internal check of ignored nodes already conducted by this point
   for ignored in ignored_nodes:
@@ -430,7 +432,7 @@ class XMLDiff:
         if files_read:
           # need access to element tree here rather than root
           if self.__options['ignored_nodes']:
-            test_root, gold_root, same = remove_subnodes_from_root(test_root, gold_root,
+            test_root, gold_root, same = ignore_subnodes_from_root(test_root, gold_root,
                                           self.__options['ignored_nodes'])
             if not same:
               messages = ["Removing subnodes failed."]

--- a/tests/framework/TestDiffer/TestXMLDiffer.py
+++ b/tests/framework/TestDiffer/TestXMLDiffer.py
@@ -80,20 +80,20 @@ same,message = XMLDiff.compare_unordered_element(ET.fromstring("<test>Hello  Wor
 checkAnswer("whitespace with remove unordered",same,True)
 
 a_element,b_element,success = XMLDiff.ignore_subnodes_from_root(
-                          ET.ElementTree(ET.fromstring("<test> <c1>a</c1> <c2>a</c2> </test>")),
-                          ET.ElementTree(ET.fromstring("<test> <c1>a</c1> <c2>b</c2> </test>")),
-                          ignored_nodes=["./c2"])
-checkAnswer("test ignore with single child node",success,True)
+                          ET.ElementTree(ET.fromstring("<test> <a>0</a> <b>0</b> </test>")),
+                          ET.ElementTree(ET.fromstring("<test> <a>0</a> <b>1</b> </test>")),
+                          ignored_nodes=["./b"])
+checkAnswer("ignoring child node in both elements",success,True)
 same,message = XMLDiff.compare_unordered_element(a_element.getroot(),b_element.getroot())
-checkAnswer("compare test with single child node",same,True)
+checkAnswer("comparing elements after ignoring child node",same,True)
 
 a_element,b_element,success = XMLDiff.ignore_subnodes_from_root(
-                          ET.ElementTree(ET.fromstring('<test><c1 n="0">a</c1><c1 n="1"/></test>')),
-                          ET.ElementTree(ET.fromstring('<test><c1 n="0">b</c1><c1 n="1"/></test>')),
-                          ignored_nodes=['./c1[@n="0"]'])
-checkAnswer("test ignore with repeat nodes and attributes",success,True)
+                          ET.ElementTree(ET.fromstring('<test><a n="0">1</a><a n="1"/></test>')),
+                          ET.ElementTree(ET.fromstring('<test><a n="0">2</a><a n="1"/></test>')),
+                          ignored_nodes=['./a[@n="0"]'])
+checkAnswer("ignoring child node in both elements via attribute",success,True)
 same,message = XMLDiff.compare_unordered_element(a_element.getroot(),b_element.getroot())
-checkAnswer("compare test with repeat nodes and attributes",same,True)
+checkAnswer("comparing elements after ignoring child node via attribute",same,True)
 
 sys.exit(results["fail"])
 """

--- a/tests/framework/TestDiffer/TestXMLDiffer.py
+++ b/tests/framework/TestDiffer/TestXMLDiffer.py
@@ -79,21 +79,29 @@ same,message = XMLDiff.compare_unordered_element(ET.fromstring("<test>Hello  Wor
 
 checkAnswer("whitespace with remove unordered",same,True)
 
-a_element,b_element,success = XMLDiff.ignore_subnodes_from_root(
+a_tree,b_tree,success = XMLDiff.ignore_subnodes_from_tree(
                           ET.ElementTree(ET.fromstring("<test> <a>0</a> <b>0</b> </test>")),
                           ET.ElementTree(ET.fromstring("<test> <a>0</a> <b>1</b> </test>")),
                           ignored_nodes=["./b"])
-checkAnswer("ignoring child node in both elements",success,True)
-same,message = XMLDiff.compare_unordered_element(a_element.getroot(),b_element.getroot())
-checkAnswer("comparing elements after ignoring child node",same,True)
+checkAnswer("ignoring child node in both trees",success,True)
+same,message = XMLDiff.compare_unordered_element(a_tree.getroot(),b_tree.getroot())
+checkAnswer("comparing roots after ignoring child node in both trees",same,True)
 
-a_element,b_element,success = XMLDiff.ignore_subnodes_from_root(
+a_tree,b_tree,success = XMLDiff.ignore_subnodes_from_tree(
                           ET.ElementTree(ET.fromstring('<test><a n="0">1</a><a n="1"/></test>')),
                           ET.ElementTree(ET.fromstring('<test><a n="0">2</a><a n="1"/></test>')),
                           ignored_nodes=['./a[@n="0"]'])
-checkAnswer("ignoring child node in both elements via attribute",success,True)
-same,message = XMLDiff.compare_unordered_element(a_element.getroot(),b_element.getroot())
-checkAnswer("comparing elements after ignoring child node via attribute",same,True)
+checkAnswer("ignoring child node in both trees via attribute",success,True)
+same,message = XMLDiff.compare_unordered_element(a_tree.getroot(),b_tree.getroot())
+checkAnswer("comparing roots after ignoring child node in both trees via attribute",same,True)
+
+a_tree,b_tree,success = XMLDiff.ignore_subnodes_from_tree(
+                          ET.ElementTree(ET.fromstring('<test> <a/> </test>')),
+                          ET.ElementTree(ET.fromstring('<test> <a/> <b/> </test>')),
+                          ignored_nodes=['./b'])
+checkAnswer("ignoring child node in one tree",success,True)
+same,message = XMLDiff.compare_unordered_element(a_tree.getroot(),b_tree.getroot())
+checkAnswer("comparing roots after ignoring child node in one tree",same,True)
 
 sys.exit(results["fail"])
 """
@@ -107,7 +115,7 @@ sys.exit(results["fail"])
     </description>
     <revisions>
       <revision author="alfoa" date="2017-01-21">Adding this test description.</revision>
-      <revision author="sotogj" date="2023-08-23">Adding tests for ignoring nodes.</revision>
+      <revision author="sotogj" date="2023-09-07">Adding tests for ignoring nodes.</revision>
     </revisions>
   </TestInfo>
 """

--- a/tests/framework/TestDiffer/TestXMLDiffer.py
+++ b/tests/framework/TestDiffer/TestXMLDiffer.py
@@ -96,12 +96,12 @@ same,message = XMLDiff.compare_unordered_element(a_tree.getroot(),b_tree.getroot
 checkAnswer("comparing roots after ignoring child node in both trees via attribute",same,True)
 
 a_tree,b_tree,success = XMLDiff.ignore_subnodes_from_tree(
-                          ET.ElementTree(ET.fromstring('<test> <a/> </test>')),
+                          ET.ElementTree(ET.fromstring('<test> <a/> <c/> </test>')),
                           ET.ElementTree(ET.fromstring('<test> <a/> <b/> </test>')),
-                          ignored_nodes=['./b'])
-checkAnswer("ignoring child node in one tree",success,True)
+                          ignored_nodes=['./b', './c'])
+checkAnswer("ignoring multiple nodes exclusive to trees",success,True)
 same,message = XMLDiff.compare_unordered_element(a_tree.getroot(),b_tree.getroot())
-checkAnswer("comparing roots after ignoring child node in one tree",same,True)
+checkAnswer("comparing roots after ignoring multiple nodes exclusive to trees",same,True)
 
 sys.exit(results["fail"])
 """

--- a/tests/framework/TestDiffer/TestXMLDiffer.py
+++ b/tests/framework/TestDiffer/TestXMLDiffer.py
@@ -79,6 +79,21 @@ same,message = XMLDiff.compare_unordered_element(ET.fromstring("<test>Hello  Wor
 
 checkAnswer("whitespace with remove unordered",same,True)
 
+a_element,b_element,success = XMLDiff.ignore_subnodes_from_root(
+                          ET.ElementTree(ET.fromstring("<test> <c1>a</c1> <c2>a</c2> </test>")),
+                          ET.ElementTree(ET.fromstring("<test> <c1>a</c1> <c2>b</c2> </test>")),
+                          ignored_nodes=["./c2"])
+checkAnswer("test ignore with single child node",success,True)
+same,message = XMLDiff.compare_unordered_element(a_element.getroot(),b_element.getroot())
+checkAnswer("compare test with single child node",same,True)
+
+a_element,b_element,success = XMLDiff.ignore_subnodes_from_root(
+                          ET.ElementTree(ET.fromstring('<test><c1 n="0">a</c1><c1 n="1"/></test>')),
+                          ET.ElementTree(ET.fromstring('<test><c1 n="0">b</c1><c1 n="1"/></test>')),
+                          ignored_nodes=['./c1[@n="0"]'])
+checkAnswer("test ignore with repeat nodes and attributes",success,True)
+same,message = XMLDiff.compare_unordered_element(a_element.getroot(),b_element.getroot())
+checkAnswer("compare test with repeat nodes and attributes",same,True)
 
 sys.exit(results["fail"])
 """
@@ -92,6 +107,7 @@ sys.exit(results["fail"])
     </description>
     <revisions>
       <revision author="alfoa" date="2017-01-21">Adding this test description.</revision>
+      <revision author="sotogj" date="2023-08-23">Adding tests for ignoring nodes.</revision>
     </revisions>
   </TestInfo>
 """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #2170 

##### What are the significant changes in functionality due to this change request?
1) `XMLDiff` now has new parameter for `ignored_nodes` which is an xpath format list of strings for ignoring specified child nodes when comparing XML data
2) `XMLDiff` removes the nodes from the loaded XML data (in-memory) before conducting a comparison study
3) Testing this new functionality in `TestXMLDiffer.py`
4) Some linting corrections to existing code, no change in ( range(len(array)) -> enumerate(array) kind of stuff)

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

