### PR TITLE
Fix GradientDescent Opt to not require FiniteDiff type

### DIFF
--- a/doc/workshop/optimizer/Inputs/1_grad_desc.xml
+++ b/doc/workshop/optimizer/Inputs/1_grad_desc.xml
@@ -14,7 +14,7 @@
 
   <Steps>
     <MultiRun name="optimize">
-      <Optimizer class="Optimizers" type="FiniteDifference">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">projectile</Model>
       <SolutionExport class="DataObjects" type="PointSet">search_path</SolutionExport>

--- a/ravenframework/Models/Model.py
+++ b/ravenframework/Models/Model.py
@@ -131,10 +131,7 @@ class Model(utils.metaclass_insert(abc.ABCMeta, BaseEntity, Assembler, InputData
   validateDict['Optimizer'][0]['class'       ] ='Optimizers'
   validateDict['Optimizer'][0]['required'    ] = False
   validateDict['Optimizer'][0]['multiplicity'] = 1
-  validateDict['Optimizer'][0]['type'] = ['SPSA',
-                                          'FiniteDifference',
-                                          'ConjugateGradient',
-                                          'SimulatedAnnealing',
+  validateDict['Optimizer'][0]['type'] = ['GradientDescent',
                                           'GeneticAlgorithm',
                                           'BayesianOptimizer']
 

--- a/ravenframework/Models/Model.py
+++ b/ravenframework/Models/Model.py
@@ -133,6 +133,7 @@ class Model(utils.metaclass_insert(abc.ABCMeta, BaseEntity, Assembler, InputData
   validateDict['Optimizer'][0]['multiplicity'] = 1
   validateDict['Optimizer'][0]['type'] = ['GradientDescent',
                                           'GeneticAlgorithm',
+                                          'SimulatedAnnealing',
                                           'BayesianOptimizer']
 
   @classmethod

--- a/tests/framework/CodeInterfaceTests/RAVEN/optimizer.xml
+++ b/tests/framework/CodeInterfaceTests/RAVEN/optimizer.xml
@@ -26,7 +26,7 @@
       <Input class="Files" type="raven">inner_input</Input>
       <Model class="Models" type="Code">raven</Model>
       <!-- <Sampler class="Samplers" type="Grid">grid</Sampler> -->
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">outer_samples</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/1_variable_gradient.xml
+++ b/tests/framework/Optimizers/GradientDescent/1_variable_gradient.xml
@@ -26,21 +26,21 @@
     <MultiRun name="optimize_fd">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter_fd</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter_fd</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export_fd</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut_fd</Output>
     </MultiRun>
     <MultiRun name="optimize_cd">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter_cd</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter_cd</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export_cd</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut_cd</Output>
     </MultiRun>
     <MultiRun name="optimize_spsa">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter_spsa</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter_spsa</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export_spsa</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut_spsa</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/basic.xml
+++ b/tests/framework/Optimizers/GradientDescent/basic.xml
@@ -27,7 +27,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/central_diff.xml
+++ b/tests/framework/Optimizers/GradientDescent/central_diff.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/constrain_boundary.xml
+++ b/tests/framework/Optimizers/GradientDescent/constrain_boundary.xml
@@ -25,7 +25,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">slant</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/constrain_function.xml
+++ b/tests/framework/Optimizers/GradientDescent/constrain_function.xml
@@ -25,7 +25,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">goal</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/converge_gradient.xml
+++ b/tests/framework/Optimizers/GradientDescent/converge_gradient.xml
@@ -24,7 +24,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/converge_objective.xml
+++ b/tests/framework/Optimizers/GradientDescent/converge_objective.xml
@@ -24,7 +24,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/converge_stepsize.xml
+++ b/tests/framework/Optimizers/GradientDescent/converge_stepsize.xml
@@ -24,7 +24,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/fd_conjgrad.xml
+++ b/tests/framework/Optimizers/GradientDescent/fd_conjgrad.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/init_sampler.xml
+++ b/tests/framework/Optimizers/GradientDescent/init_sampler.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/initial_step.xml
+++ b/tests/framework/Optimizers/GradientDescent/initial_step.xml
@@ -26,7 +26,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/max.xml
+++ b/tests/framework/Optimizers/GradientDescent/max.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/minimal.xml
+++ b/tests/framework/Optimizers/GradientDescent/minimal.xml
@@ -24,7 +24,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/multitraj.xml
+++ b/tests/framework/Optimizers/GradientDescent/multitraj.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/spsa.xml
+++ b/tests/framework/Optimizers/GradientDescent/spsa.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/stuck_corner.xml
+++ b/tests/framework/Optimizers/GradientDescent/stuck_corner.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">goal</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
       <Output class="OutStreams" type="Print">opt_export</Output>

--- a/tests/framework/Optimizers/GradientDescent/valley.xml
+++ b/tests/framework/Optimizers/GradientDescent/valley.xml
@@ -24,7 +24,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">valley</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/Optimizers/GradientDescent/write_final.xml
+++ b/tests/framework/Optimizers/GradientDescent/write_final.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">dummyIN</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/ensembleModelTests/test_ensemble_model_linear_internal_parallel_with_optimizer.xml
+++ b/tests/framework/ensembleModelTests/test_ensemble_model_linear_internal_parallel_with_optimizer.xml
@@ -95,7 +95,7 @@
     <MultiRun name="testMetamodelHeatTransfer">
       <Input class="DataObjects" type="PointSet">inputHolder</Input>
       <Model class="Models" type="EnsembleModel">heatTransferEnsembleModel</Model>
-      <Optimizer class="Optimizers" type="SPSA">opt_smp</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opt_smp</Optimizer>
       <SolutionExport class="DataObjects" type="PointSet">optData</SolutionExport>
       <Output class="DataObjects" type="PointSet">metaModelOutputTest</Output>
       <Output class="DataObjects" type="PointSet">optOutput</Output>

--- a/tests/framework/user_guide/optimizing/constrain.xml
+++ b/tests/framework/user_guide/optimizing/constrain.xml
@@ -23,7 +23,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="HistorySet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/user_guide/optimizing/multiple_trajectories.xml
+++ b/tests/framework/user_guide/optimizing/multiple_trajectories.xml
@@ -22,7 +22,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="HistorySet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/user_guide/optimizing/simple.xml
+++ b/tests/framework/user_guide/optimizing/simple.xml
@@ -22,7 +22,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="HistorySet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>

--- a/tests/framework/user_guide/optimizing/step_size.xml
+++ b/tests/framework/user_guide/optimizing/step_size.xml
@@ -22,7 +22,7 @@
     <MultiRun name="optimize">
       <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">beale</Model>
-      <Optimizer class="Optimizers" type="SPSA">opter</Optimizer>
+      <Optimizer class="Optimizers" type="GradientDescent">opter</Optimizer>
       <SolutionExport class="DataObjects" type="HistorySet">opt_export</SolutionExport>
       <Output class="DataObjects" type="PointSet">optOut</Output>
     </MultiRun>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

#2175 

##### What are the significant changes in functionality due to this change request?

This PR removes the requirement for GradientDescent optimizer to be of `type="FiniteDifference"`

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

