### PR TITLE
Remove using distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from distutils.core import setup, Extension
-from distutils.command.build import build
+import setuptools
+from setuptools import setup, Extension
+from setuptools.command.build import build
 import os
 import sys
-import setuptools
+
 
 # Replicating the methods used in the RAVEN Makefile to find CROW_DIR,
 # If the Makefile changes to be more robust, so should this

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import setuptools
 from setuptools import setup, Extension
-from setuptools.command.build import build
+from setuptools.command.build_py import build_py
 import os
 import sys
 
@@ -32,11 +32,10 @@ UTIL_INCLUDE_DIR = os.path.join(CROW_DIR,'include', 'utilities')
 
 # We need a custom build order in order to ensure that amsc.py is available
 # before we try to copy it to the target location
-class CustomBuild(build):
-    sub_commands = [('build_ext', build.has_ext_modules),
-                    ('build_py', build.has_pure_modules),
-                    ('build_clib', build.has_c_libraries),
-                    ('build_scripts', build.has_scripts)]
+class CustomBuild(build_py):
+    def run(self):
+        self.run_command('build_ext')
+        super().run()
 
 
 include_dirs=[RAVEN_INCLUDE_DIR,BOOST_INCLUDE_DIR, DIST_INCLUDE_DIR, UTIL_INCLUDE_DIR]
@@ -88,4 +87,4 @@ setup(name='raven_framework',
                     include_dirs=include_dirs, swig_opts=swig_opts,extra_compile_args=extra_compile_args)],
       py_modules=['AMSC.amsc','crow_modules.distribution1D','crow_modules.randomENG','crow_modules.interpolationND', 'AMSC.AMSC_Object'],
       packages=['ravenframework.'+x for x in setuptools.find_packages('ravenframework')]+['ravenframework'],
-      cmdclass={'build': CustomBuild})
+      cmdclass={'build_py': CustomBuild})


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2203 

##### What are the significant changes in functionality due to this change request?
Removes use of distutils since it is removed in Python 3.12

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

