### PR TITLE
Xarray updates

### DIFF
--- a/ravenframework/DataObjects/DataSet.py
+++ b/ravenframework/DataObjects/DataSet.py
@@ -664,7 +664,7 @@ class DataSet(DataObject):
     noColl = self._collector is None or len(self._collector) == 0
     # remove from self._data
     if not noData:
-      self._data = self._data.drop(variable)
+      self._data = self._data.drop_vars(variable)
     # remove from self._collector
     if not noColl:
       varIndex = self._orderedVars.index(variable)
@@ -1755,7 +1755,7 @@ class DataSet(DataObject):
       @ Out, rlz, dict, realization as {var:value} where value is a DataArray with only coordinate dimensions
     """
     assert(self._data is not None)
-    rlz = self._data[{self.sampleTag:index}].drop(self.sampleTag).data_vars
+    rlz = self._data[{self.sampleTag:index}].drop_vars(self.sampleTag).data_vars
     rlz = self._convertFinalizedDataRealizationToDict(rlz, unpackXArray)
     return rlz
 
@@ -2101,7 +2101,7 @@ class DataSet(DataObject):
       mode = 'w'
 
     #Errors when dropping don't matter since it means they were removed before
-    data = data.drop(toDrop, errors='ignore')
+    data = data.drop_vars(toDrop, errors='ignore')
     self.raiseADebug(f'Printing data from "{self.name}" to CSV: "{filenameLocal}.csv"')
     # get the list of elements the user requested to write
     # order data according to user specs # TODO might be time-inefficient, allow user to skip?
@@ -2132,7 +2132,7 @@ class DataSet(DataObject):
     # write sub files as point sets
     ordered = list(var for var in itertools.chain(self._inputs,self._outputs,self._metavars) if (var != clusterLabel and var in keep))
     for ID in clusterIDs:
-      data = self._data.where(self._data[clusterLabel] == ID, drop = True).drop(clusterLabel)
+      data = self._data.where(self._data[clusterLabel] == ID, drop = True).drop_vars(clusterLabel)
       subName = f'{fileName}_{ID}'
       self._usePandasWriteCSV(subName, data, ordered, keepSampleTag=self.sampleTag in keep, mode='w') # TODO append mode
       self.raiseADebug(f'Wrote sub-cluster file to "{subName}.csv"')

--- a/tests/framework/unit_tests/DataObjects/TestDataSet.py
+++ b/tests/framework/unit_tests/DataObjects/TestDataSet.py
@@ -215,7 +215,7 @@ def checkNone(comment,entry,update=True):
       print("checking answer",comment,'|','"{}" is not None!'.format(entry))
       results["fail"] += 1
 
-def checkFails(comment,errstr,function,update=True,args=None,kwargs=None):
+def checkFails(comment,errstr,function,update=True,args=None,kwargs=None,exact=True):
   """
     Checks if expected error occurs
     @ In, comment, string, a comment printed out if it fails
@@ -224,6 +224,7 @@ def checkFails(comment,errstr,function,update=True,args=None,kwargs=None):
     @ In, update, bool, optional, if False then don't update results counter
     @ In, args, list, arguments to pass to function
     @ In, kwargs, dict, keyword arguments to pass to function
+    @ In, exact, bool, optional, defaults to True, but if False, only check if errstr in the full error string.
     @ Out, res, bool, True if failed as expected
   """
   print('Error testing ...')
@@ -236,7 +237,10 @@ def checkFails(comment,errstr,function,update=True,args=None,kwargs=None):
     res = False
     msg = 'Function call did not error!'
   except Exception as e:
-    res = checkSame('',e.args[0],errstr,update=False)
+    if exact:
+      res = checkSame('',e.args[0],errstr,update=False)
+    else:
+      res = errstr in e.args[0]
     if not res:
       msg = 'Unexpected error message.  \n    Received: "{}"\n    Expected: "{}"'.format(e.args[0],errstr)
   if update:
@@ -635,7 +639,7 @@ dataCSV.load(csvname,style='CSV')
 for var in data.getVars():
   if var == 'z':
     # not included in XML input specs, so should be left out
-    checkFails('CSV var z','z',dataCSV.getVarValues,args=var)
+    checkFails('CSV var z','z',dataCSV.getVarValues,args=var, exact=False)
   elif isinstance(data.getVarValues(var).item(0),(float,int)):
     checkTrue('CSV var {}'.format(var),(dataCSV._data[var] - data._data[var]).sum()<1e-20) #necessary due to roundoff
   else:
@@ -710,7 +714,7 @@ seed['b'] = np.array([ np.array([1.00]),
                        np.array([1.70, 1.71, 1.72, 1.73, 1.74, 1.75, 1.76, 1.77]),
                        np.array([1.80, 1.81, 1.82, 1.83, 1.84, 1.85, 1.86, 1.87, 1.88]),
                        np.array([1.90, 1.91, 1.92, 1.93, 1.94, 1.95, 1.96, 1.97, 1.98, 1.99])
-                       ])
+                       ], dtype=object)
 # coordinate, as vector
 seed['t'] = np.array([ np.linspace(0,1,1),
                        np.linspace(0,1,2),
@@ -721,7 +725,7 @@ seed['t'] = np.array([ np.linspace(0,1,1),
                        np.linspace(0,1,7),
                        np.linspace(0,1,8),
                        np.linspace(0,1,9),
-                       np.linspace(0,1,10) ])
+                       np.linspace(0,1,10) ], dtype=object)
 # set up data object
 xml = createElement('DataSet',attrib={'name':'test'})
 xml.append(createElement('Input',text='a'))


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2226 


##### What are the significant changes in functionality due to this change request?
Removes some deprecated features, and makes the error check more flexible in TestDataSet.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

