### PR TITLE
Addressed inconsistency between RFE-DMDc and GA-DMDc

### DIFF
--- a/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
+++ b/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
@@ -724,7 +724,6 @@ class RFE(FeatureSelectionBase):
       # calculate the average and standard deviation for each realization
       avgArray = np.atleast_1d(np.average(y, axis=0) if len(y.shape) < 3 else np.average(y[samp,:,:], axis=0))
       stdArray = np.atleast_1d(np.std(y, axis=0, ddof=1) if len(y.shape) < 3 else np.std(y[samp,:,:], axis=0, ddof=1))
-      # realizationScore = 0.0
       evaluated = estimator._evaluateLocal(X[samp:samp+1, features] if len(X.shape) < 3 else np.atleast_2d(X[samp:samp+1, :,features]))
       for target in evaluated:
         if target in targetsIds:

--- a/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
+++ b/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
@@ -720,9 +720,11 @@ class RFE(FeatureSelectionBase):
                                             estimator, support_, originalParams, parametersToInclude)
     # evaluate
     score = 0.0
-    avgArray = np.atleast_1d(np.average(y, axis=(0,) if len(y.shape) < 3 else (0, 1)))
-    stdArray = np.atleast_1d(np.std(y, axis=(0,) if len(y.shape) < 3 else (0, 1), ddof=1))
     for samp in range(X.shape[0]):
+      # calculate the average and standard deviation for each realization
+      avgArray = np.atleast_1d(np.average(y, axis=0) if len(y.shape) < 3 else np.average(y[samp,:,:], axis=0))
+      stdArray = np.atleast_1d(np.std(y, axis=0, ddof=1) if len(y.shape) < 3 else np.std(y[samp,:,:], axis=0, ddof=1))
+      # realizationScore = 0.0
       evaluated = estimator._evaluateLocal(X[samp:samp+1, features] if len(X.shape) < 3 else np.atleast_2d(X[samp:samp+1, :,features]))
       for target in evaluated:
         if target in targetsIds:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2230 

##### What are the significant changes in functionality due to this change request?

Extraction of PR #2224:

	•	Identified the reason to have inconsistent score between RFE-DMDc and GA-DMDc.
	•	The avgArray and stdArray need to be calculated for each realization. That's the reason of inconsistency.

No new test is added since the inconsistency does not modify the search pattern of the algorithm

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

