### PR TITLE
Some updates for RAVEN 3.0 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 *.ravenStatus
 *.so
 *~
+*.inp
+*.fls
+*.fdb_latexmk
 build_out*
 build/
 install/
@@ -54,6 +57,15 @@ dist/
 #coverage
 tests/framework/.coverage
 tests/framework/htmlcov/
+
+# test
+tests/framework/CodeInterfaceTests/PARCS/PARCS-RAVEN-GA/sampleGA-PARCS/
+tests/framework/CodeInterfaceTests/Scale/SCALE_csas/sampleScale/
+tests/framework/CodeInterfaceTests/Simulate/Simulate_RAVEN-GA/sampleGA-Simulate/
+tests/framework/ROM/TimeSeries/ARMA/InterpolatedMaxCycles/
+tests/framework/ROM/TimeSeries/SyntheticHistory/LogARMA/
+tests/framework/ROM/TimeSeries/SyntheticHistory/VARMA/
+tests/framework/ROM/TimeSeries/SyntheticHistory/ZeroFilterDiscontinuous/
 
 # hpc
 node_*[0-9]

--- a/doc/user_manual/raven_user_manual.tex
+++ b/doc/user_manual/raven_user_manual.tex
@@ -272,13 +272,16 @@ showstringspaces=false            %
 \\Paul W. Talbot
 \\Mohammad G. Abdo
 \\Dylan J. McDowell
-\\Ramon K. Yoshiura\\
+\\Ramon K. Yoshiura
+\\Junyung Kim\\
 \textbf{\textit{Former Developers:}}
 \\Cristian Rabiti
 \\Daniel P. Maljovec
 \\Sonat Sen
 \\Robert Kinoshita
-\\Jun Chen\\
+\\Jun Chen
+\\Jia Zhou
+\\Daniel Garrett\\
 \textbf{\textit{Contributors:}}
 \\Alessandro Bandini (Post-Processor)
 \\Ivan Rinaldi (documentation)
@@ -286,8 +289,10 @@ showstringspaces=false            %
 \\James B. Tompkins (new external code interface)
 \\Matteo Donorio (new external code interface)
 \\Fabio Giannetti (new external code interface)
-\\Jia Zhou (conjugate gradient optimizer)
-\\Junyung Kim (Genetic Algorithm)
+\\Alp Tezbasaran (new external code interface)
+\\Anthoney A. Griffith (Bayesian optimization)
+\\Jacob A. Bryan (TSA module)
+\\Haoyu Wang (DMD amd DMDc)
 }
 
 % There is a "Printed" date on the title page of a SAND report, so
@@ -301,8 +306,8 @@ showstringspaces=false            %
 \SANDnum{INL/EXT-15-34123}
 \SANDprintDate{\today}
 \SANDauthor{Cristian Rabiti, Andrea Alfonsi, Joshua Cogliati, Diego Mandelli, Congjian Wang, Paul W. Talbot,
-Mohammad G. Abdo, Dylan J. McDowell, Ramon K. Yoshiura, Robert Kinoshita, Sonat Sen, Daniel P. Maljovec}
-\SANDreleaseType{Revision 8}
+Mohammad G. Abdo, Dylan J. McDowell, Ramon K. Yoshiura, Robert Kinoshita, Sonat Sen, Daniel P. Maljovec, Jun Chen, Jia Zhou, Junyung Kim}
+\SANDreleaseType{Revision 9}
 
 % ---------------------------------------------------------------------------- %
 % Include the markings required for your SAND report. The default is "Unlimited

--- a/doc/user_manual/raven_user_manual.tex
+++ b/doc/user_manual/raven_user_manual.tex
@@ -293,6 +293,7 @@ showstringspaces=false            %
 \\Anthoney A. Griffith (Bayesian optimization)
 \\Jacob A. Bryan (TSA module)
 \\Haoyu Wang (DMD amd DMDc)
+\\Khang Nguyen (new external code interface)
 }
 
 % There is a "Printed" date on the title page of a SAND report, so

--- a/ravenframework/Models/ExternalModel.py
+++ b/ravenframework/Models/ExternalModel.py
@@ -187,7 +187,7 @@ class ExternalModel(Dummy):
       # check if there are variables and, in case, load them
       for child in paramInput.subparts:
         if child.getName() == 'variables':
-          self.raiseAWarning(DeprecationWarning ,'"variables" node inputted but has been deprecated!  Please list variables in the "inputs" and "outputs" nodes instead.  This Warning will result in an error in RAVEN 3.0!')
+          self.raiseAWarning(DeprecationWarning ,'"variables" node inputted but has been deprecated!  Please list variables in the "inputs" and "outputs" nodes instead.')
           self.modelVariableType = dict.fromkeys(child.value)
         elif child.getName() == 'inputs':
           self._setVariableList('input', child.value)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
General maintenance see issue #1806 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

