### PR TITLE
Add ability to specify mamba dependencies

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -84,8 +84,8 @@ Note all install methods after "main" take
     <pyomo-extensions source="pyomo" skip_check='True' optional='True'/>
     <setuptools/>
     <!-- source="mamba" are the ones installed when mamba is installed -->
-    <fmt source="mamba" os='windows'>10.1</fmt>
-    <mamba source="mamba"/>
+    <fmt source="mamba" os='windows' skip_check='True'>10.1</fmt>
+    <mamba source="mamba" skip_check='True'/>
   </main>
   <alternate name="pip">
     <hdf5>remove</hdf5>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -78,6 +78,7 @@ Note all install methods after "main" take
     <fmpy optional='True'/>
     <xmlschema source="pip"/>
     <pyomo optional='True'>6.4</pyomo>
+    <fmt source="mamba">10.1</fmt>
     <glpk skip_check='True' optional='True'/>
     <ipopt skip_check='True' optional='True'/>
     <cyipopt optional='True'/>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -78,12 +78,14 @@ Note all install methods after "main" take
     <fmpy optional='True'/>
     <xmlschema source="pip"/>
     <pyomo optional='True'>6.4</pyomo>
-    <fmt source="mamba">10.1</fmt>
     <glpk skip_check='True' optional='True'/>
     <ipopt skip_check='True' optional='True'/>
     <cyipopt optional='True'/>
     <pyomo-extensions source="pyomo" skip_check='True' optional='True'/>
     <setuptools/>
+    <!-- source="mamba" are the ones installed when mamba is installed -->
+    <fmt source="mamba" os='windows'>10.1</fmt>
+    <mamba source="mamba"/>
   </main>
   <alternate name="pip">
     <hdf5>remove</hdf5>

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -107,7 +107,11 @@ function install_libraries()
     # conda-forge
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     if [[ $USE_MAMBA == TRUE ]]; then
-        local PRECOMMAND=`echo conda install -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD $SET_PYTHON`
+        local PRECOMMAND=`$PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset mamba`" $SET_PYTHON"
+        if [  "$MAMBA_SKIP" == "true" ]
+        then
+            PRECOMMAND=${PRECOMMAND/mamba/}
+        fi
         if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge pre-command: ${PRECOMMAND}; fi
         ${PRECOMMAND}
         local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
@@ -178,7 +182,11 @@ function create_libraries()
         echo ... temporarily using Python $WORKING_PYTHON_COMMAND for installation
     fi
     if [[ $USE_MAMBA == TRUE ]]; then
-        local PRECOMMAND=`echo conda create -n ${RAVEN_LIBS_NAME} -y -c conda-forge $MAMBA_ECE_ADD $SET_PYTHON`
+        local PRECOMMAND=`$PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create --subset mamba`" $SET_PYTHON"
+        if [  "$MAMBA_SKIP" == "true" ]
+        then
+            PRECOMMAND=${PRECOMMAND/mamba/}
+        fi
         if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge pre-command: $PRECOMMAND; fi
         ${PRECOMMAND}
         local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
@@ -334,12 +342,14 @@ fi
 PROXY_COMM="" # proxy is none
 USE_MAMBA=TRUE # Use Mamba for installation
 
+#Note this complexity is because on one computer in 2023, mamba failed to
+# install correctly when mamba was in the base conda install.
 if command -v mamba;
 then
     #This is used to skip installing mamba
-    MAMBA_ECE_ADD=""
+    MAMBA_SKIP="true"
 else
-    MAMBA_ECE_ADD="mamba"
+    MAMBA_SKIP="false"
 fi
 
 # parse command-line arguments

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -378,7 +378,7 @@ def _getInstallMethod(override=None):
     @ In, override, str, optional, use given method if valid
     @ Out, install, str, type of install
   """
-  valid = ['conda', 'pip', 'pyomo'] #custom?
+  valid = ['conda', 'pip', 'pyomo', 'mamba'] #custom?
   if override is not None:
     if override.lower() not in valid:
       raise TypeError('Library Handler: Provided override install method not recognized: "{}"! Acceptable options: {}'.format(override, valid))
@@ -537,7 +537,7 @@ if __name__ == '__main__':
         help='Chooses whether to (create) a new environment, (install) in existing environment, ' +
              'or (list) installation libraries.')
   condaParser.add_argument('--subset', dest='subset',
-        choices=('core', 'forge', 'pip', 'pyomo'), default='core',
+        choices=('core', 'forge', 'pip', 'pyomo', 'mamba'), default='core',
         help='Use subset of installation libraries, divided by source.')
   condaParser.add_argument('--no-name', dest='noName',
                            action='store_true',
@@ -633,6 +633,12 @@ if __name__ == '__main__':
         actionArgs = ''
         addOptional = args.addOptional
         limit = ['pyomo']
+      elif args.subset == 'mamba':
+        # from defaults
+        src = '-c conda-forge'
+        addOptional = args.addOptional
+        limit = ['mamba']
+        installer = 'mamba'
       libs = getRequiredLibs(useOS=args.useOS,
                              installMethod='conda',
                              addOptional=addOptional,

--- a/scripts/library_handler.py
+++ b/scripts/library_handler.py
@@ -638,7 +638,7 @@ if __name__ == '__main__':
         src = '-c conda-forge'
         addOptional = args.addOptional
         limit = ['mamba']
-        installer = 'mamba'
+        installer = 'conda'
       libs = getRequiredLibs(useOS=args.useOS,
                              installMethod='conda',
                              addOptional=addOptional,


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes  #2236

##### What are the significant changes in functionality due to this change request?
This adds a new `--subset mamba` for things that should be installed when mamba is installed.
This also uses this to switch to fmt version 10.1 in windows, because version 10.2.0 is broken in windows.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

