### PR TITLE
Fixes problems finding raven libraries with conda

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -531,7 +531,7 @@ if [[ "$INSTALL_MANAGER" == "CONDA" ]];
   # debug output conda version
   if [[ $ECE_VERBOSE == 0 ]]; then echo `conda -V`; fi
   # find RAVEN libraries environment
-  if conda env list | grep ${RAVEN_LIBS_NAME};
+  if conda env list | grep "^${RAVEN_LIBS_NAME} ";
   then
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Found library environment ...; fi
     LIBS_EXIST=0


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2217

##### What are the significant changes in functionality due to this change request?
Checks correctly for an existing environment.
If for example, the library name is raven_libraries but a raven_libraries_2_0 existed, the previous test would match, and then the conda remove could fail, but this is corrected by making sure the exact name is matched.



----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

