### PR TITLE
Forcing the lapack build.

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -94,6 +94,7 @@ Note all install methods after "main" take
     <python>remove</python>
     <nomkl>remove</nomkl>
     <numexpr>remove</numexpr>
+    <liblapack>remove</liblapack>
   </alternate>
   <alternate name="none">
     <hdf5>remove</hdf5>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -83,7 +83,10 @@ Note all install methods after "main" take
     <cyipopt optional='True'/>
     <pyomo-extensions source="pyomo" skip_check='True' optional='True'/>
     <setuptools/>
+    <!-- This is because liblapack 3.9.0 build 21 is broken (and can probably be removed if there ever is a build 22).  This can also be removed when scipy is updated to version 1.12 -->
     <liblapack skip_check='True' os='linux'>3.9.0=20_linux64_openblas</liblapack>
+    <liblapack skip_check='True' os='windows'>3.9.0=20_win64_mkl</liblapack>
+    <liblapack skip_check='True' os='mac'>3.9.0=20_osx64_openblas</liblapack>
     <!-- source="mamba" are the ones installed when mamba is installed -->
     <mamba source="mamba" skip_check='True'/>
   </main>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -83,6 +83,7 @@ Note all install methods after "main" take
     <cyipopt optional='True'/>
     <pyomo-extensions source="pyomo" skip_check='True' optional='True'/>
     <setuptools/>
+    <liblapack skip_check='True' os='linux'>3.9.0=20_linux64_openblas</liblapack>
     <!-- source="mamba" are the ones installed when mamba is installed -->
     <mamba source="mamba" skip_check='True'/>
   </main>

--- a/ravenframework/Metrics/metrics/ScipyMetric.py
+++ b/ravenframework/Metrics/metrics/ScipyMetric.py
@@ -45,7 +45,7 @@ class ScipyMetric(MetricInterface):
   availMetrics['boolean']['dice']               = spatialDistance.dice
   availMetrics['boolean']['hamming']            = spatialDistance.hamming
   availMetrics['boolean']['jaccard']            = spatialDistance.jaccard
-  availMetrics['boolean']['kulsinski']           = spatialDistance.kulsinski
+  availMetrics['boolean']['kulsinski']           = spatialDistance.kulczynski1
   availMetrics['boolean']['russellrao']         = spatialDistance.russellrao
   availMetrics['boolean']['sokalmichener']      = spatialDistance.sokalmichener
   availMetrics['boolean']['sokalsneath']        = spatialDistance.sokalsneath

--- a/ravenframework/Metrics/metrics/ScipyMetric.py
+++ b/ravenframework/Metrics/metrics/ScipyMetric.py
@@ -45,7 +45,9 @@ class ScipyMetric(MetricInterface):
   availMetrics['boolean']['dice']               = spatialDistance.dice
   availMetrics['boolean']['hamming']            = spatialDistance.hamming
   availMetrics['boolean']['jaccard']            = spatialDistance.jaccard
-  availMetrics['boolean']['kulsinski']           = spatialDistance.kulczynski1
+  #Note in scipy 1.12 this needs to be changed to
+  #availMetrics['boolean']['kulsinski']           = spatialDistance.kulczynski1
+  availMetrics['boolean']['kulsinski']           = spatialDistance.kulsinski
   availMetrics['boolean']['russellrao']         = spatialDistance.russellrao
   availMetrics['boolean']['sokalmichener']      = spatialDistance.sokalmichener
   availMetrics['boolean']['sokalsneath']        = spatialDistance.sokalsneath


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes  #2252

##### What are the significant changes in functionality due to this change request?
Forces the lapack build version to a working one.


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

