### PR TITLE
MultivariateNormal pickling fix

### DIFF
--- a/ravenframework/Distributions.py
+++ b/ravenframework/Distributions.py
@@ -3614,6 +3614,7 @@ class MultivariateNormal(NDimensionalDistributions):
       @ In, pdict, dict, the namespace state
       @ Out, None
     """
+    super()._localSetState(pdict)
     self.method = pdict.pop('method')
     self.dimension = pdict.pop('dimension')
     self.rank = pdict.pop('rank')

--- a/tests/framework/ROM/TimeSeries/SyntheticHistory/tests
+++ b/tests/framework/ROM/TimeSeries/SyntheticHistory/tests
@@ -228,6 +228,26 @@
     [../]
   [../]
 
+  [./VARMASample]
+    prereq = VARMA
+    type = 'RavenFramework'
+    input = 'varma_sample.xml'
+    [./csv0]
+      type = OrderedCSV
+      output = 'VARMA/pk_samples_0.csv'
+      gold_files = '../VARMA/samples_0.csv'
+      rel_err = 8.8e-1 # thank you, Windows and Linux diffs
+      zero_threshold = 1e-12
+    [../]
+    [./csv1]
+      type = OrderedCSV
+      output = 'VARMA/pk_samples_1.csv'
+      gold_files = '../VARMA/samples_1.csv'
+      rel_err = 8.8e-1 # thank you, Windows and Linux diffs
+      zero_threshold = 1e-12
+    [../]
+  [../]
+
   [./VARMAInterpolated]
     type = 'RavenFramework'
     input = 'varma_interpolated.xml'

--- a/tests/framework/ROM/TimeSeries/SyntheticHistory/varma_sample.xml
+++ b/tests/framework/ROM/TimeSeries/SyntheticHistory/varma_sample.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" ?>
+<Simulation verbosity="debug">
+  <TestInfo>
+    <name>framework/ROM/TimeSeries/SyntheticHistory.VARMASample</name>
+    <author>j-bryan</author>
+    <created>2024-01-26</created>
+    <classesTested>SupervisedLearning.SyntheticHistory,TSA.VARMA</classesTested>
+    <description>Tests the ability to load and sample VARMA created by SyntheticHistory ROM.</description>
+  </TestInfo>
+
+  <RunInfo>
+    <WorkingDir>VARMA</WorkingDir>
+    <Sequence>read, sample</Sequence>
+    <batchSize>1</batchSize>
+  </RunInfo>
+
+  <Steps>
+    <IOStep name="read">
+      <Input class="Files" type="">pk</Input>
+      <Output class="Models" type="ROM">synth</Output>
+    </IOStep>
+    <MultiRun name="sample">
+      <Input class="DataObjects" type="PointSet">placeholder</Input>
+      <Model class="Models" type="ROM">synth</Model>
+      <Sampler class="Samplers" type="MonteCarlo">mc</Sampler>
+      <Output class="DataObjects" type="HistorySet">samples</Output>
+      <Output class="OutStreams" type="Print">pk_samples</Output>
+    </MultiRun>
+  </Steps>
+
+  <Files>
+    <Input name="pk">varma.pk</Input>
+  </Files>
+
+  <Samplers>
+    <MonteCarlo name="mc">
+      <samplerInit>
+        <limit>2</limit>
+        <initialSeed>42</initialSeed>
+      </samplerInit>
+      <constant name="scaling">1.0</constant>
+    </MonteCarlo>
+  </Samplers>
+
+  <Models>
+    <ROM name="synth" subType="SyntheticHistory">
+      <Target>signal0, signal1, seconds</Target>
+      <Features>scaling</Features>
+      <pivotParameter>seconds</pivotParameter>
+      <varma target="signal0, signal1" seed='42'>
+        <P>1</P>
+        <Q>0</Q>
+      </varma>
+    </ROM>
+  </Models>
+
+  <OutStreams>
+    <Print name="pk_samples">
+      <type>csv</type>
+      <source>samples</source>
+    </Print>
+  </OutStreams>
+
+  <DataObjects>
+    <PointSet name="placeholder"/>
+    <HistorySet name="samples">
+      <Input>scaling</Input>
+      <Output>signal0, signal1</Output>
+      <options>
+        <pivotParameter>seconds</pivotParameter>
+      </options>
+    </HistorySet>
+  </DataObjects>
+
+</Simulation>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2253 

##### What are the significant changes in functionality due to this change request?
Fixes issue with pickling/unpickling the MultivariateNormal distribution class. No change in output is expected.

Shoutout to @AnthoneyGriffith for bringing this bug to my attention.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

