### PR TITLE
Removes writeTo option for message in MessageHandler

### DIFF
--- a/ravenframework/MessageHandler.py
+++ b/ravenframework/MessageHandler.py
@@ -234,7 +234,7 @@ class MessageHandler(object):
         sys.tracebacklimit = 0
       raise etype(message)
 
-  def message(self, caller, message, tag, verbosity, color=None, writeTo=sys.stdout, forcePrint=False):
+  def message(self, caller, message, tag, verbosity, color=None, forcePrint=False):
     """
       Print a message
       @ In, caller, object, the entity desiring to print a message
@@ -250,8 +250,7 @@ class MessageHandler(object):
     if tag.lower().strip() == 'warning':
       self.addWarning(message)
     if okay:
-      print(msg, file=writeTo)
-    sys.stdout.flush()
+      print(msg, flush=True)
 
   def addWarning(self, msg):
     """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2255 

##### What are the significant changes in functionality due to this change request?
When using ravenframework as a Python module, users are able to overwrite `sys.stdout` with another destination, and this is now honored by RAVEN. This was accomplished by simply removing the `writeTo` option from `MessageHandler.message()`.

Before settling on removing the option, I also tried to track the argument as an instance variable instead (`self._writeTo`). However, this approach was rejected for two major reasons. First, storing `sys.stdout` or a file object from using the `open()` function as an attribute led to problems pickling the class. While these two cases are simple enough to handle, if the user has supplied their own class for `writeTo`, it will be impossible to correctly reinstantiate the class upon unpickling. I felt this was then better left to the user to handle outside of RAVEN.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

