### PR TITLE
Method to Convert InputData.ParameterInput back to ElementTree XML node(s)

### DIFF
--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -24,6 +24,7 @@ from enum import Enum
 import xml.etree.ElementTree as ET
 from . import InputTypes
 import textwrap
+from ravenframework.utils import xmlUtils
 
 class Quantity(Enum):
   """
@@ -374,6 +375,24 @@ class ParameterInput(object):
     """
     cls.contentType = contentType
 
+  def convertToXML(self, recDepth=0):
+    """
+      Converts back to XML representation of the parameters (attributes) of this spec.
+      @ In, recDepth, int, recursion depth for subNodes
+      @ Out, xml, XML node
+    """
+    xml = xmlUtils.newNode(self.name)
+    if self.parameterValues:
+      xml.attrib = self.parameterValues
+    if self.value != '':
+      xml.text = str(self.value)
+    if self.subparts:
+      for sub in self.subparts:
+        if isinstance(sub,ParameterInput):
+          sub_node = sub.convertToXML(recDepth+1)
+          xml.append(sub_node)
+    return xml
+
   def parseNode(self, node, errorList=None, parentList=None):
     """
       Parses the xml node and puts the results in self.parameterValues and
@@ -701,7 +720,6 @@ class ParameterInput(object):
                                                                                      d=desc)
     msg += '\n{i}\\end{{itemize}}\n'.format(i=doDent(recDepth))
     return msg
-
 
 
 

--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -379,7 +379,7 @@ class ParameterInput(object):
     """
       Converts back to XML representation of the parameters (attributes) of this spec.
       @ In, recDepth, int, recursion depth for subNodes
-      @ Out, xml, XML node
+      @ Out, xml, xml.etree.ElementTree.Element, XML node representation of this input spec
     """
     xml = xmlUtils.newNode(self.name)
     if self.parameterValues:

--- a/tests/framework/unit_tests/utils/testInputDataToXml.py
+++ b/tests/framework/unit_tests/utils/testInputDataToXml.py
@@ -1,0 +1,122 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import copy
+
+ravenPath = os.path.join(os.path.dirname(__file__), *(['..']*4))
+sys.path.append(ravenPath)
+sys.path.append(os.path.join(ravenPath,"rook"))
+
+import xml.etree.ElementTree as ET
+from ravenframework.utils import InputData,InputTypes,xmlUtils
+from rook import XMLDiff
+print('Testing:', InputData)
+
+results = {'pass':0, 'fail':0}
+
+####################################
+class ObjectsInputData(object):
+  """
+  Helper class with matching input specs for XML test
+  """
+  def __init__(self):
+    """
+      initialization
+      @ In, None
+      @ Out, None
+    """
+
+  @classmethod
+  def get_input_specs(cls):
+    """
+      Method to get a reference to a class that specifies the input data for ObjectsInputData class.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    # parent node
+    spec = InputData.parameterInputFactory('Objects', ordered=False, baseNode=None)
+    # -- subnodes
+    Object = InputData.parameterInputFactory('Object', ordered=False, baseNode=None)
+    # -- subnode attributes
+    Object.addParam('name', required=True, param_type=InputTypes.StringType,descr=r"""Object attribute: name""")
+    Object.addParam('type', required=True, param_type=InputTypes.StringType,descr=r"""Object attribute: type""")
+    # -- -- subsubnode
+    paramsNode = InputData.parameterInputFactory('params', ordered=False, baseNode=None)
+    alphaNode = InputData.parameterInputFactory('alpha', ordered=False, baseNode=None)
+    # -- add subsubnodes to subnode
+    Object.addSub(paramsNode)
+    Object.addSub(alphaNode)
+    # add subnode to parent node
+    spec.addSub(Object)
+    return spec
+####################################
+
+# get original XML filepath
+XMLTestDir = os.path.join(os.path.dirname(__file__), 'parse')
+testXMLPath = os.path.join(XMLTestDir,'example_xml.xml')
+
+# load test XML and node to test
+with open(testXMLPath,'r',encoding="utf8") as f:
+  testXML, _ = xmlUtils.loadToTree(f)
+testXMLNode = testXML.find('Objects')
+
+# create an instance of testing object
+testObj = ObjectsInputData()
+# create input specs and load data from XML
+testInputData = testObj.get_input_specs()()
+testInputData.parseNode(testXMLNode)
+
+# convert back from InputDate to XML
+convertedXMLNode = testInputData.convertToXML()
+
+# write two XML scripts for test and converted XML
+gold_file = os.path.join(XMLTestDir,'inputDataToXML__gold.xml')
+out_file  = os.path.join(XMLTestDir,'inputDataToXML__out.xml')
+xmlUtils.toFile(gold_file, testXMLNode)
+xmlUtils.toFile(out_file,  convertedXMLNode)
+
+# COMPARISON TEST with XMLDiff from Rook
+differ = XMLDiff.XMLDiff([out_file],[gold_file], ignored_nodes=None, alt_root=None)
+same, msg = differ.diff()
+
+if same:
+  results['pass'] += 1
+else:
+  print(msg)
+  results['fail'] += 1
+
+# cleanup
+try:
+  os.remove(gold_file)
+  os.remove(out_file)
+except Exception:
+  print(f'Test files {gold_file} and {out_file} were not able to be removed; continuing ...')
+
+print(results)
+
+sys.exit(results["fail"])
+"""
+  <TestInfo>
+    <name>framework.inputData</name>
+    <author>sotogj</author>
+    <created>2024-03-19</created>
+    <classesTested>utils.InputData</classesTested>
+    <description>
+       This test performs Unit Tests for the InputData convertToXML method
+    </description>
+  </TestInfo>
+"""

--- a/tests/framework/unit_tests/utils/tests
+++ b/tests/framework/unit_tests/utils/tests
@@ -39,6 +39,10 @@
   type = 'RavenPython'
   input = 'testFrontUtils.py'
  [../]
+ [./inputDataToXML]
+  type = 'RavenPython'
+  input = 'testInputDataToXml.py'
+ [../]
 []
 
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2263 

##### What are the significant changes in functionality due to this change request?
Offers the ability for the `ravenframework.utils.InputData` `ParameterInput` class to loop through itself and subnodes and convert the data back to `xml.etree.ElementTree.Element` object/format. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

