### PR TITLE
Forcing using mamba.

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -379,8 +379,8 @@ do
       USE_MAMBA=TRUE
       ;;
     --no-mamba)
-      echo ... not using mamba
-      USE_MAMBA=FALSE
+      echo ... OVERRIDE using mamba
+      USE_MAMBA=TRUE
       ;;
     --optional)
       echo ... Including optional libraries ...

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -108,10 +108,6 @@ function install_libraries()
     if [[ $ECE_VERBOSE == 0 ]]; then echo ... Installing libraries from conda-forge ...; fi
     if [[ $USE_MAMBA == TRUE ]]; then
         local PRECOMMAND=`$PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset mamba`" $SET_PYTHON"
-        if [  "$MAMBA_SKIP" == "true" ]
-        then
-            PRECOMMAND=${PRECOMMAND/mamba/}
-        fi
         if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge pre-command: ${PRECOMMAND}; fi
         ${PRECOMMAND}
         local COMMAND=`echo $($PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
@@ -183,10 +179,6 @@ function create_libraries()
     fi
     if [[ $USE_MAMBA == TRUE ]]; then
         local PRECOMMAND=`$PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action create --subset mamba`" $SET_PYTHON"
-        if [  "$MAMBA_SKIP" == "true" ]
-        then
-            PRECOMMAND=${PRECOMMAND/mamba/}
-        fi
         if [[ $ECE_VERBOSE == 0 ]]; then echo ... conda-forge pre-command: $PRECOMMAND; fi
         ${PRECOMMAND}
         local COMMAND=`echo $($WORKING_PYTHON_COMMAND ${RAVEN_LIB_HANDLER} ${INSTALL_OPTIONAL} ${OSOPTION} conda --action install --subset forge --no-name)`
@@ -342,15 +334,6 @@ fi
 PROXY_COMM="" # proxy is none
 USE_MAMBA=TRUE # Use Mamba for installation
 
-#Note this complexity is because on one computer in 2023, mamba failed to
-# install correctly when mamba was in the base conda install.
-if command -v mamba;
-then
-    #This is used to skip installing mamba
-    MAMBA_SKIP="true"
-else
-    MAMBA_SKIP="false"
-fi
 
 # parse command-line arguments
 while test $# -gt 0

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -332,7 +332,7 @@ else
     INSTALL_MANAGER="$INSTALLATION_MANAGER"
 fi
 PROXY_COMM="" # proxy is none
-USE_MAMBA=TRUE # Use Mamba for installation
+USE_MAMBA=FALSE # Use Mamba for installation
 
 
 # parse command-line arguments
@@ -358,12 +358,12 @@ do
       ECE_MODE=2
       ;;
     --mamba)
-      echo ... using mamba
-      USE_MAMBA=TRUE
+      echo ... OVERRIDE using mamba
+      USE_MAMBA=FALSE
       ;;
     --no-mamba)
       echo ... OVERRIDE using mamba
-      USE_MAMBA=TRUE
+      USE_MAMBA=FALSE
       ;;
     --optional)
       echo ... Including optional libraries ...


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?
This originally forces mamba to check if this works on all the computers.
It was changed to force mamba off to check if this works on all the computers.
DO NOT MERGE.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

