### PR TITLE
modified by adaptive mutation&crossove(ILM/DHC method, DHM/ILC method…

### DIFF
--- a/ravenframework/Optimizers/crossOverOperators/crossovers.py
+++ b/ravenframework/Optimizers/crossOverOperators/crossovers.py
@@ -44,8 +44,6 @@ def onePointCrossover(parents,**kwargs):
                           dims=['chromosome','Gene'],
                           coords={'chromosome': np.arange(int(2*comb(nParents,2))),
                                   'Gene':kwargs['variables']})
-
-
   # defaults
   if (kwargs['crossoverProb'] == None) or ('crossoverProb' not in kwargs.keys()):
     crossoverProb = randomUtils.random(dim=1, samples=1)
@@ -54,11 +52,11 @@ def onePointCrossover(parents,**kwargs):
 
   # create children
   parentsPairs = list(combinations(parents,2))
-
   for ind,parent in enumerate(parentsPairs):
     parent = np.array(parent).reshape(2,-1) # two parents at a time
-
-    if randomUtils.random(dim=1,samples=1) <= crossoverProb:
+    new_crossoverProb=1-((2*ind)/len(children)) #ILM/DHC method
+    new_crossoverProb2=((2*ind)/len(children)) #DHM/ILC method
+    if randomUtils.random(dim=1,samples=1) <= new_crossoverProb2:
       if (kwargs['points'] == None) or ('points' not in kwargs.keys()):
         point = list([randomUtils.randomIntegers(1,nGenes-1,None)])
       elif (any(i>=nGenes-1 for i in kwargs['points'])):

--- a/ravenframework/Optimizers/mutators/mutators.py
+++ b/ravenframework/Optimizers/mutators/mutators.py
@@ -51,7 +51,10 @@ def swapMutator(offSprings, distDict, **kwargs):
   for i in range(np.shape(offSprings)[0]):
     children[i] = offSprings[i]
     ## TODO What happens if loc1 or 2 is out of range?! should we raise an error?
-    if randomUtils.random(dim=1,samples=1)<=kwargs['mutationProb']:
+    new_mutationProb=(i/len(children)) #ILM/DHC method
+    new_mutationProb2=1-(i/len(children)) #DHM/ILC method
+    if randomUtils.random(dim=1,samples=1)<=new_mutationProb2:
+      #kwargs['mutationProb']
       # convert loc1 and loc2 in terms on cdf values
       cdf1 = distDict[offSprings.coords['Gene'].values[loc1]].cdf(float(offSprings[i,loc1].values))
       cdf2 = distDict[offSprings.coords['Gene'].values[loc2]].cdf(float(offSprings[i,loc2].values))
@@ -136,9 +139,13 @@ def randomMutator(offSprings, distDict, **kwargs):
   """
   if kwargs['locs'] is not None and 'locs' in kwargs.keys():
     raise ValueError('Locs arguments are not being used by randomMutator')
+  k=0
   for child in offSprings:
     # the mutation is performed for each child independently
-    if randomUtils.random(dim=1,samples=1)<kwargs['mutationProb']:
+    new_mutationProb=(k/len(offSprings))
+    k=k+1
+    if randomUtils.random(dim=1,samples=1)<new_mutationProb:
+      # kwargs['mutationProb']
       # sample gene location to be flipped: i.e., determine loc
       chromosomeSize = child.values.shape[0]
       loc = randomUtils.randomIntegers(0, chromosomeSize, caller=None, engine=None)
@@ -217,3 +224,15 @@ def returnInstance(cls, name):
   if name not in __mutators:
     cls.raiseAnError (IOError, "{} MECHANISM NOT IMPLEMENTED!!!!!".format(name))
   return __mutators[name]
+
+# def adaptivemutator(**kwargs):
+#   """
+#     Method designed to adaptive mutation rate:
+#     @ In, kwargs['mutationProb']
+#     @ Out, kwargs['new_mutationProb']
+#   """
+#   for i in range():
+#     new_mutationProb=1-(i/len(children))
+#     kwargs['mutationProb']=new_mutationProb
+#     print(new_mutationProb)
+#   return new_mutationProb

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/GA_discreteIntWithReplacement.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/GA_discreteIntWithReplacement.xml
@@ -64,6 +64,7 @@
 
       <GAparams>
         <populationSize>17</populationSize>
+        <!-- 17 -->
         <reproduction>
           <crossover type="onePointCrossover">
             <crossoverProb>0.9</crossoverProb>

--- a/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/testGAMaxwoRepConvHDSM.xml
+++ b/tests/framework/Optimizers/GeneticAlgorithms/discrete/unconstrained/testGAMaxwoRepConvHDSM.xml
@@ -68,7 +68,7 @@
           <crossover type="onePointCrossover">
             <crossoverProb>0.8</crossoverProb>
           </crossover>
-          <mutation type="swapMutator">
+          <mutation type="randomMutator">
             <mutationProb>0.9</mutationProb>
           </mutation>
         </reproduction>


### PR DESCRIPTION
… added)

--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

