### PR TITLE
LaTeX _ escape improvement

### DIFF
--- a/doc/user_manual/generated/internalRom.tex
+++ b/doc/user_manual/generated/internalRom.tex
@@ -2056,6 +2056,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
       The \xmlNode{fourier} node recognizes the following subnodes:
@@ -2068,8 +2076,8 @@ Example:
     \item \xmlNode{arma}:
       characterizes the signal using Auto-Regressive and Moving Average         coefficients to
       stochastically fit the training signal.         The ARMA representation has the following
-      form:         \begin{equation*}           A\_t = \sum\_{i=1}^P \phi\_i A\_{t-i} + \epsilon\_t +
-      \sum\_{j=1}^Q \theta\_j \epsilon\_{t-j},         \end{equation*}         where $t$ indicates a
+      form:         \begin{equation*}           A\_t = \sum_{i=1}^P \phi\_i A_{t-i} + \epsilon\_t +
+      \sum_{j=1}^Q \theta\_j \epsilon_{t-j},         \end{equation*}         where $t$ indicates a
       discrete time step, $\phi$ are the signal lag (or auto-regressive)         coefficients, $P$
       is the number of signal lag terms to consider, $\epsilon$ is a random noise         term,
       $\theta$ are the noise lag (or moving average) coefficients, and $Q$ is the number of
@@ -2081,6 +2089,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
           \item \xmlAttr{reduce\_memory}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
             activates a lower memory usage ARMA training. This does tend to result
             in a slightly slower training time, at the benefit of lower memory usage. For
@@ -2114,8 +2130,8 @@ Example:
     \item \xmlNode{varma}:
       characterizes the vector-valued signal using Auto-Regressive and Moving         Average
       coefficients to stochastically fit the training signal.         The VARMA representation has
-      the following form:         \begin{equation*}           A\_t = \sum\_{i=1}^P \phi\_i A\_{t-i} +
-      \epsilon\_t + \sum\_{j=1}^Q \theta\_j \epsilon\_{t-j},         \end{equation*}         where $t$
+      the following form:         \begin{equation*}           A\_t = \sum_{i=1}^P \phi\_i A_{t-i} +
+      \epsilon\_t + \sum_{j=1}^Q \theta\_j \epsilon_{t-j},         \end{equation*}         where $t$
       indicates a discrete time step, $\phi$ are the signal lag (or auto-regressive)
       coefficients, $P$ is the number of signal lag terms to consider, $\epsilon$ is a random noise
       term, $\theta$ are the noise lag (or moving average) coefficients, and $Q$ is the number of
@@ -2129,6 +2145,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
       The \xmlNode{varma} node recognizes the following subnodes:
@@ -2146,14 +2170,14 @@ Example:
       characterizes the signal using autoregressive (AR) coefficients conditioned         on the
       state of a hidden Markov model (HMM) to stochastically fit the training signal.         The
       Markov-switching autoregressive model (MSAR) has the following form:         \begin{equation*}
-      Y\_t = \mu\_{S\_t} \sum\_{i=1}^p \phi\_{i,{S\_t}} \left(Y\_{t-i} - \mu\_{S\_{t-i}}\right) +
-      \varepsilon\_{t,{S\_t}},         \end{equation*}         where $t$ indicates a discrete time
+      Y\_t = \mu_{S\_t} \sum_{i=1}^p \phi_{i,{S\_t}} \left(Y_{t-i} - \mu_{S_{t-i}}\right) +
+      \varepsilon_{t,{S\_t}},         \end{equation*}         where $t$ indicates a discrete time
       step, $\phi$ are the signal lag (or auto-regressive)         coefficients, $p$ is the number
       of signal lag terms to consider, $\varepsilon$ is a random noise         term with mean 0 and
-      variance $\sigma^2\_{S\_t}$, and $S\_t$ is the HMM state at time $t$.         The HMM state is
+      variance $\sigma^2_{S\_t}$, and $S\_t$ is the HMM state at time $t$.         The HMM state is
       determined by the transition probabilities between states, which are conditioned         on
       the previous state. The transition probabilities are stored in a transition matrix $P$,
-      where entry $p\_{ij}$ is the probability of transitioning from state $i$ to state $j$
+      where entry $p_{ij}$ is the probability of transitioning from state $i$ to state $j$
       conditional         on being in state $i$. For a MSAR model with HMM state dimensionality $r$,
       the transition matrix         $P$ is of size $r \times r$. Each of the mean, autoregressive,
       and noise variance terms may be         switching or non-switching parameters.
@@ -2163,6 +2187,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
           \item \xmlAttr{switching\_ar}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
             indicates whether the autoregressive coefficients are switching parameters. \default{True}
           \item \xmlAttr{switching\_variance}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
@@ -2190,6 +2222,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
       The \xmlNode{STL} node recognizes the following subnodes:
@@ -2214,6 +2254,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
       The \xmlNode{wavelet} node recognizes the following subnodes:
@@ -2250,6 +2298,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
       The \xmlNode{PolynomialRegression} node recognizes the following subnodes:
@@ -2266,6 +2322,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
       The \xmlNode{rwd} node recognizes the following subnodes:
@@ -2294,6 +2358,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{minmaxscaler}:
@@ -2305,6 +2377,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{robustscaler}:
@@ -2316,6 +2396,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{standardscaler}:
@@ -2327,6 +2415,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{preserveCDF}:
@@ -2340,6 +2436,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{differencing}:
@@ -2350,6 +2454,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
       The \xmlNode{differencing} node recognizes the following subnodes:
@@ -2369,6 +2481,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{logtransformer}:
@@ -2380,6 +2500,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{arcsinhtransformer}:
@@ -2391,6 +2519,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{tanhtransformer}:
@@ -2402,6 +2538,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{sigmoidtransformer}:
@@ -2413,6 +2557,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
       \end{itemize}
 
     \item \xmlNode{outtruncation}:
@@ -2424,6 +2576,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
           \item \xmlAttr{domain}: \xmlDesc{[positive, negative], required}, 
             -- no description yet --
       \end{itemize}
@@ -2436,6 +2596,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
           \item \xmlAttr{nQuantiles}: \xmlDesc{integer, optional}, 
             number of quantiles to use in the transformation. If \xmlAttr{nQuantiles}
             is greater than the number of data, then the number of data is used instead. \default{1000}
@@ -2450,6 +2618,14 @@ Example:
             indicates the variables for which this algorithm will be used for characterization.
           \item \xmlAttr{seed}: \xmlDesc{integer, optional}, 
             sets a seed for the underlying random number generator, if present.
+          \item \xmlAttr{global}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0], optional}, 
+            designates this algorithm to be used on full signal instead of per
+            segment. NOTE: because this is intended to be used when some algorithms are
+            applied segment-wise and others are applied globally, this is meant to be an
+            advanced feature and it is important to be mindful of the segments lengths.
+            E.g., some Fourier periods may be longer than the intended segment length, in
+            which case the this 'global' parameter should be set to True for better
+            fitting. \default{False}
           \item \xmlAttr{nQuantiles}: \xmlDesc{integer, optional}, 
             number of quantiles to use in the transformation. If \xmlAttr{nQuantiles}
             is greater than the number of data, then the number of data is used instead. \default{1000}
@@ -2489,7 +2665,7 @@ Example:
   Fourier signal processing, sometimes referred to as a FARMA.                         ARMA is a
   type of time dependent model that characterizes the autocorrelation between time series data. The
   mathematic description of ARMA is given as                         \begin{equation*}
-  x\_t = \sum\_{i=1}^p\phi\_ix\_{t-i}+\alpha\_t+\sum\_{j=1}^q\theta\_j\alpha\_{t-j},
+  x\_t = \sum_{i=1}^p\phi\_ix_{t-i}+\alpha\_t+\sum_{j=1}^q\theta\_j\alpha_{t-j},
   \end{equation*}                         where $x$ is a vector of dimension $n$, and $\phi\_i$ and
   $\theta\_j$ are both $n$ by $n$ matrices. When $q=0$, the above is
   autoregressive (AR); when $p=0$, the above is moving average (MA).                         When
@@ -3062,11 +3238,11 @@ General ARMA Example:
 \subsubsection{PolyExponential}
   The \xmlNode{PolyExponential} contains a single ROM type, aimed to construct a     time-dependent
   (or any other monotonic variable) surrogate model based on polynomial sum of exponential term.
-  This surrogate have the form:     \begin{equation}       SM(X,z) = \sum\_{i=1}^{N} P\_{i}(X) \times
-  \exp ( - Q\_{i}(X) \times z )     \end{equation}     where:     \begin{itemize}       \item
+  This surrogate have the form:     \begin{equation}       SM(X,z) = \sum_{i=1}^{N} P_{i}(X) \times
+  \exp ( - Q_{i}(X) \times z )     \end{equation}     where:     \begin{itemize}       \item
   $\mathbf{z}$ is the independent  monotonic variable (e.g. time)       \item $\mathbf{X}$  is the
-  vector of the other independent (parametric) variables  (Features)       \item $\mathbf{P\_{i}}(X)$
-  is a polynomial of rank M function of the parametric space X       \item  $\mathbf{Q\_{i}}(X)$ is a
+  vector of the other independent (parametric) variables  (Features)       \item $\mathbf{P_{i}}(X)$
+  is a polynomial of rank M function of the parametric space X       \item  $\mathbf{Q_{i}}(X)$ is a
   polynomial of rank M function of the parametric space X       \item  $\mathbf{N}$ is the number of
   requested exponential terms.     \end{itemize}     It is crucial to notice that this model is
   quite suitable for FOMs whose drivers are characterized by an exponential-like behavior.     In

--- a/doc/user_manual/generated/optimizer.tex
+++ b/doc/user_manual/generated/optimizer.tex
@@ -24,6 +24,7 @@
              \item \texttt{accepted}: string acceptance status of the potential optimal point (algorithm dependent)
              \item \texttt{rejectReason}: description of reject reason, 'noImprovement' means rejected the new optimization point for no improvement from last point, 'implicitConstraintsViolation' means rejected by implicit constraints violation, return None if the point is accepted
              \item \texttt{\{VAR\}}: any variable from the \xmlNode{TargetEvaluation} input or output; gives the value of that variable at the optimal candidate for this iteration.
+             \item \texttt{modelRuns}: integer identifying the number of times the model is evaluated up to the current step
              \item \texttt{stepSize}: the size of step taken in the normalized input space to arrive at each optimal point
              \item \texttt{conv\_\{CONV\}}: status of each given convergence criteria
              \item \texttt{CG\_task}: for ConjugateGradient, current task of line search. FD suggests continuing the search, and CONV indicates the line search converged and will pivot.
@@ -430,6 +431,20 @@
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
+    \item \xmlNode{ROM}: \xmlDesc{string}, 
+      Name of a Model that optimizers may want to use during optimization. For example, the
+      Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
+      in                                           detail with in the \xmlNode{Models} as in other
+      uses. This node should be provided a string referencing
+      the model definition's name.
+      The \xmlNode{ROM} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
+      \end{itemize}
+
     \item \xmlNode{Sampler}: \xmlDesc{string}, 
       name of a Sampler that can be used to initialize the starting points for the trajectories
       of some of the variables. From a practical point of view, this XML node must contain the
@@ -557,6 +572,7 @@ Gradient Descent Example:
              \item \texttt{accepted}: string acceptance status of the potential optimal point (algorithm dependent)
              \item \texttt{rejectReason}: description of reject reason, 'noImprovement' means rejected the new optimization point for no improvement from last point, 'implicitConstraintsViolation' means rejected by implicit constraints violation, return None if the point is accepted
              \item \texttt{\{VAR\}}: any variable from the \xmlNode{TargetEvaluation} input or output; gives the value of that variable at the optimal candidate for this iteration.
+             \item \texttt{modelRuns}: integer identifying the number of times the model is evaluated up to the current step
              \item \texttt{conv\_\{CONV\}}: status of each given convergence criteria
              \item \texttt{amp\_\{VAR\}}: amplitude associated to each variable used to compute step size based on cooling method and the corresponding next neighbor
              \item \texttt{delta\_\{VAR\}}: step size associated to each variable
@@ -823,6 +839,20 @@ Gradient Descent Example:
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
+    \item \xmlNode{ROM}: \xmlDesc{string}, 
+      Name of a Model that optimizers may want to use during optimization. For example, the
+      Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
+      in                                           detail with in the \xmlNode{Models} as in other
+      uses. This node should be provided a string referencing
+      the model definition's name.
+      The \xmlNode{ROM} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
+      \end{itemize}
+
     \item \xmlNode{Sampler}: \xmlDesc{string}, 
       name of a Sampler that can be used to initialize the starting points for the trajectories
       of some of the variables. From a practical point of view, this XML node must contain the
@@ -953,6 +983,7 @@ Simulated Annealing Example:
              \item \texttt{accepted}: string acceptance status of the potential optimal point (algorithm dependent)
              \item \texttt{rejectReason}: description of reject reason, 'noImprovement' means rejected the new optimization point for no improvement from last point, 'implicitConstraintsViolation' means rejected by implicit constraints violation, return None if the point is accepted
              \item \texttt{\{VAR\}}: any variable from the \xmlNode{TargetEvaluation} input or output; gives the value of that variable at the optimal candidate for this iteration.
+             \item \texttt{modelRuns}: integer identifying the number of times the model is evaluated up to the current step
              \item \texttt{conv\_\{CONV\}}: status of each given convergence criteria
              \item \texttt{fitness}: fitness of the current chromosome
              \item \texttt{age}: age of current chromosome
@@ -1302,6 +1333,20 @@ Simulated Annealing Example:
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
+    \item \xmlNode{ROM}: \xmlDesc{string}, 
+      Name of a Model that optimizers may want to use during optimization. For example, the
+      Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
+      in                                           detail with in the \xmlNode{Models} as in other
+      uses. This node should be provided a string referencing
+      the model definition's name.
+      The \xmlNode{ROM} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
+      \end{itemize}
+
     \item \xmlNode{Sampler}: \xmlDesc{string}, 
       name of a Sampler that can be used to initialize the starting points for the trajectories
       of some of the variables. From a practical point of view, this XML node must contain the
@@ -1445,6 +1490,534 @@ Genetic Algorithm Example:
       <TargetEvaluation class="DataObjects" type="PointSet">optOut</TargetEvaluation>
     </GeneticAlgorithm>
     ...
+  </Optimizers>
+\end{lstlisting}
+
+
+
+\subsection{BayesianOptimizer}
+  The \xmlNode{BayesianOptimizer} optimizer is a method for black-box optimization.
+  This approach utilizes a surrogate model, in the form of a Gaussian Process Regression,
+  to find the global optima of expensive functions. Furthermore, this approach easily
+  incorporates noisy observations of the function. This approach tends to offer the
+  tradeoff of additional backend calculation (training regressions and selecting samples) in
+  favor of reducing the number of function or 'model' evaluations.
+\vspace{7pt} \\When used as part of a \xmlNode{MultiRun} step, this entity provides
+        additional information through the \xmlNode{SolutionExport} DataObject. The
+        following variables can be requested within the \xmlNode{SolutionExport}:
+        \begin{itemize}
+          \item \texttt{trajID}: integer identifier for different optimization starting locations and paths
+             \item \texttt{iteration}: integer identifying which iteration (or step, or generation) a trajectory is on
+             \item \texttt{accepted}: string acceptance status of the potential optimal point (algorithm dependent)
+             \item \texttt{rejectReason}: description of reject reason, 'noImprovement' means rejected the new optimization point for no improvement from last point, 'implicitConstraintsViolation' means rejected by implicit constraints violation, return None if the point is accepted
+             \item \texttt{\{VAR\}}: any variable from the \xmlNode{TargetEvaluation} input or output; gives the value of that variable at the optimal candidate for this iteration.
+             \item \texttt{modelRuns}: integer identifying the number of times the model is evaluated up to the current step
+             \item \texttt{conv\_\{CONV\}}: status of each given convergence criteria
+             \item \texttt{acquisition}: value of acquisition at each iteration
+             \item \texttt{radiusFromBest}: radius of current point from current best point
+             \item \texttt{radiusFromLast}: radius of current point from previous point
+             \item \texttt{solutionValue}: Expected value of objective var at recommended solution point
+             \item \texttt{solutionDeviation}: Standard deviation of recommended solution
+           
+         \end{itemize}
+
+  The \xmlNode{BayesianOptimizer} node recognizes the following parameters:
+    \begin{itemize}
+      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+        User-defined name to designate this entity in the RAVEN input file.
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+        Desired verbosity of messages coming from this entity
+  \end{itemize}
+
+  The \xmlNode{BayesianOptimizer} node recognizes the following subnodes:
+  \begin{itemize}
+    \item \xmlNode{objective}: \xmlDesc{string}, 
+      Name of the response variable (or ``objective function'') that should be optimized
+      (minimized or maximized).
+
+    \item \xmlNode{variable}:
+      defines the input space variables to be sampled through various means.
+      The \xmlNode{variable} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{name}: \xmlDesc{string, optional}, 
+            user-defined name of this Sampler. \nb As for the other objects,               this is
+            the name that can be used to refer to this specific entity from other input blocks
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+            determines the number of samples and shape of samples               to be taken.  For
+            example, \xmlAttr{shape}=``2,3'' will provide a 2 by 3               matrix of values,
+            while \xmlAttr{shape}=``10'' will produce a vector of 10 values.               Omitting
+            this optional attribute will result in a single scalar value instead.               Each
+            of the values in the matrix or vector will be the same as the single sampled value.
+            \nb A model interface must be prepared to handle non-scalar inputs to use this option.
+      \end{itemize}
+
+      The \xmlNode{variable} node recognizes the following subnodes:
+      \begin{itemize}
+        \item \xmlNode{distribution}: \xmlDesc{string}, 
+          name of the distribution that is associated to this variable.               Its name needs
+          to be contained in the \xmlNode{Distributions} block explained               in Section
+          \ref{sec:distributions}. In addition, if NDDistribution is used,               the
+          attribute \xmlAttr{dim} is required. \nb{Alternatively, this node must be omitted
+          if the \xmlNode{function} node is supplied.}
+          The \xmlNode{distribution} node recognizes the following parameters:
+            \begin{itemize}
+              \item \xmlAttr{dim}: \xmlDesc{integer, optional}, 
+                for an NDDistribution, indicates the dimension within the NDDistribution that
+                corresponds               to this variable.
+          \end{itemize}
+
+        \item \xmlNode{grid}: \xmlDesc{string}, 
+          -- no description yet --
+          The \xmlNode{grid} node recognizes the following parameters:
+            \begin{itemize}
+              \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+                -- no description yet --
+              \item \xmlAttr{construction}: \xmlDesc{string, optional}, 
+                -- no description yet --
+              \item \xmlAttr{steps}: \xmlDesc{integer, optional}, 
+                -- no description yet --
+          \end{itemize}
+
+        \item \xmlNode{function}: \xmlDesc{string}, 
+          name of the function that               defines the calculation of this variable from
+          other distributed variables.  Its name               needs to be contained in the
+          \xmlNode{Functions} block explained in Section               \ref{sec:functions}. This
+          function must implement a method named ``evaluate''.               \nb{Each
+          \xmlNode{variable} must contain only one \xmlNode{Function} or
+          \xmlNode{Distribution}, but not both.}
+
+        \item \xmlNode{initial}: \xmlDesc{comma-separated floats}, 
+          indicates the initial values where independent trajectories for this optimization
+          effort should begin. The number of entries should be the same for all variables, unless
+          a variable is initialized with a sampler (see \xmlNode{samplerInit} below). Note these
+          entries are ordered; that is, if the optimization variables are $x$ and $y$, and the
+          initial               values for $x$ are \xmlString{1, 2, 3, 4} and initial values for $y$
+          are \xmlString{5, 6, 7, 8},               then there will be four starting trajectories
+          beginning at the locations (1, 5), (2, 6),               (3, 7), and (4, 8).
+      \end{itemize}
+
+    \item \xmlNode{TargetEvaluation}: \xmlDesc{string}, 
+      name of the DataObject where the sampled outputs of the Model will be collected.
+      This DataObject is the means by which the sampling entity obtains the results of requested
+      samples, and so should require all the input and output variables needed for adaptive
+      sampling.
+      The \xmlNode{TargetEvaluation} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
+      \end{itemize}
+
+    \item \xmlNode{samplerInit}:
+      collection of nodes that describe the initialization of the optimization algorithm.
+
+      The \xmlNode{samplerInit} node recognizes the following subnodes:
+      \begin{itemize}
+        \item \xmlNode{limit}: \xmlDesc{integer}, 
+          limits the number of Model evaluations that may be performed as part of this optimization.
+          For example, a limit of 100 means at most 100 total Model evaluations may be performed.
+
+        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]}, 
+          delineates when the \xmlNode{SolutionExport} DataObject should be written to. In case
+          of \xmlString{final}, only the final optimal solution for each trajectory will be written.
+          In case of \xmlString{every}, the \xmlNode{SolutionExport} will be updated with each
+          iteration               of the Optimizer.
+
+        \item \xmlNode{initialSeed}: \xmlDesc{integer}, 
+          seed for random number generation. Note that by default RAVEN uses an internal seed,
+          so this seed must be changed to observe changed behavior. \default{RAVEN-determined}
+
+        \item \xmlNode{type}: \xmlDesc{[min, max]}, 
+          the type of optimization to perform. \xmlString{min} will search for the lowest
+          \xmlNode{objective} value, while \xmlString{max} will search for the highest value.
+      \end{itemize}
+
+    \item \xmlNode{Acquisition}:
+      A required node for specifying                                                           the
+      details about the acquisition function
+      used in the policy of Bayesian Optimization.
+
+      The \xmlNode{Acquisition} node recognizes the following subnodes:
+      \begin{itemize}
+        \item \xmlNode{ExpectedImprovement}:
+          If this node is present within the acquisition node,                         the expected
+          improvement acqusition function is utilized.                         This function is
+          derived by applying Bayesian optimal decision making (Bellman's Principle of Optimality)
+          with a local reward utility function in conjunction with a one-step lookahead.
+          The approach weighs both expected reward and likely reward with the
+          following expression (for minimization):                         $EI(x) =
+          (f^*-\mu)\phi(\frac{f^*-\mu}{s}) + s \Phi(\frac{f^*-\mu}{s})$
+
+          The \xmlNode{ExpectedImprovement} node recognizes the following subnodes:
+          \begin{itemize}
+            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]}, 
+              String to specify routine used for the optimization of the acquisition function.
+              Acceptable options include: ('differentialEvolution', 'slsqp').
+              \default{'differentialEvolution'}.
+              \begin{itemize}                                                  \item Differential
+              Evolution: A style of evolutionary algorithm, which specializes in floating point
+              representations of decision variables. Works similar to its parent algorithm Genetic
+              Algorithm                                                  \item SLSQP: A Sequential
+              Least Squares algorithm, which uses an BFGS update and
+              Lawson and Hanson’s NNLS nonlinear least-squares solver.
+              \end{itemize}
+  \default{differentialEvolution}
+
+            \item \xmlNode{seedingCount}: \xmlDesc{integer}, 
+              If the method is gradient based or typically handled with singular
+              decisions (ex. slsqp approximates a quadratic program using the gradient), this number
+              represents the number of trajectories for a multi-start variant (default=2N).
+              N is the dimension of the input space.
+              If the method works on populations (ex. differential evolution simulates
+              natural selection on a population),
+              the number represents the population size (default=10N).
+          \end{itemize}
+
+        \item \xmlNode{ProbabilityOfImprovement}:
+          If this node is present within the acquisition node,                         the
+          probability of improvement acqusition function is utilized.                         This
+          function is derived by applying Bayesian optimal decision making (Bellman's Principle of
+          Optimality)                         with the probability of local reward utility function
+          in conjunction with a one-step lookahead.                         The approach weighs
+          values the probability of improving the solution past some thresh-hold and has the
+          following expression (for minimization):                         $PoI(x) = \frac{\tau -
+          \mu}{\sigma}$
+
+          The \xmlNode{ProbabilityOfImprovement} node recognizes the following subnodes:
+          \begin{itemize}
+            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]}, 
+              String to specify routine used for the optimization of the acquisition function.
+              Acceptable options include: ('differentialEvolution', 'slsqp').
+              \default{'differentialEvolution'}.
+              \begin{itemize}                                                  \item Differential
+              Evolution: A style of evolutionary algorithm, which specializes in floating point
+              representations of decision variables. Works similar to its parent algorithm Genetic
+              Algorithm                                                  \item SLSQP: A Sequential
+              Least Squares algorithm, which uses an BFGS update and
+              Lawson and Hanson’s NNLS nonlinear least-squares solver.
+              \end{itemize}
+  \default{differentialEvolution}
+
+            \item \xmlNode{seedingCount}: \xmlDesc{integer}, 
+              If the method is gradient based or typically handled with singular
+              decisions (ex. slsqp approximates a quadratic program using the gradient), this number
+              represents the number of trajectories for a multi-start variant (default=2N).
+              N is the dimension of the input space.
+              If the method works on populations (ex. differential evolution simulates
+              natural selection on a population),
+              the number represents the population size (default=10N).
+
+            \item \xmlNode{epsilon}: \xmlDesc{float}, 
+              Defines the threshold for PoI via the equation:
+              $\tau = min \mu(\textbf{X}) - \epsilon$. The larger $\epsilon$ is, the
+              more exploratory the algorithm and vice versa.
+  \default{1.0}
+
+            \item \xmlNode{rho}: \xmlDesc{float}, 
+              Provides a 'time-constant' for the Exploit and Explore transient settings.
+              Provides the period for the oscillate transient setting.
+  \default{1.0}
+
+            \item \xmlNode{transient}: \xmlDesc{[Constant, Exploit, Explore, Oscillate, DecayingOscillate]}, 
+              Determines how the threshold $\tau$ changes as optimization progresses.
+              \begin{itemize}                                                  \item Constant:
+              $\epsilon$ remains the provided value.
+              \item Exploit: $\epsilon$ exponentially decays to 0 encouraging exploitation.
+              \item Explore: $\epsilon$ exponentially grows from 0 to provided value.
+              \item Oscillate: $\epsilon$ varies between 0 and provided value.
+              \item DecayingOscillate: $\epsilon$ oscillates and decays, driving to exploitation.
+              \end{itemize}
+  \default{Constant}
+          \end{itemize}
+
+        \item \xmlNode{LowerConfidenceBound}:
+          If this node is present within the acquisition node,                         the lower
+          confidence bound acqusition function is utilized.                         This function is
+          derived by applying optimistic decision making in the infinite-armed bandit problem.
+          The approach assumes the model is conservative and values optimism through the following
+          equation (for minimization):                         $LCB(x) = \mu - \beta \sigma$, where
+          $\beta = \Phi^{-1}(\pi)$
+
+          The \xmlNode{LowerConfidenceBound} node recognizes the following subnodes:
+          \begin{itemize}
+            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]}, 
+              String to specify routine used for the optimization of the acquisition function.
+              Acceptable options include: ('differentialEvolution', 'slsqp').
+              \default{'differentialEvolution'}.
+              \begin{itemize}                                                  \item Differential
+              Evolution: A style of evolutionary algorithm, which specializes in floating point
+              representations of decision variables. Works similar to its parent algorithm Genetic
+              Algorithm                                                  \item SLSQP: A Sequential
+              Least Squares algorithm, which uses an BFGS update and
+              Lawson and Hanson’s NNLS nonlinear least-squares solver.
+              \end{itemize}
+  \default{differentialEvolution}
+
+            \item \xmlNode{seedingCount}: \xmlDesc{integer}, 
+              If the method is gradient based or typically handled with singular
+              decisions (ex. slsqp approximates a quadratic program using the gradient), this number
+              represents the number of trajectories for a multi-start variant (default=2N).
+              N is the dimension of the input space.
+              If the method works on populations (ex. differential evolution simulates
+              natural selection on a population),
+              the number represents the population size (default=10N).
+
+            \item \xmlNode{pi}: \xmlDesc{float}, 
+              Parameter that determines the lower confidence bound. Must be
+              between 0 and 1.
+  \default{0.98}
+
+            \item \xmlNode{rho}: \xmlDesc{float}, 
+              Provides a 'time-constant' for the Exploit and Explore transient settings.
+              Provides the period for the oscillate transient settings.
+  \default{1.0}
+
+            \item \xmlNode{transient}: \xmlDesc{[Constant, Exploit, Explore, Oscillate, DecayingOscillate]}, 
+              Determines how the threshold $\tau$ changes as optimization progresses.
+              \begin{itemize}                                                  \item Constant:
+              $\epsilon$ remains the provided value.
+              \item Exploit: $\epsilon$ exponentially decays to 0 encouraging exploitation.
+              \item Explore: $\epsilon$ exponentially grows from 0 to provided value.
+              \item Oscillate: $\epsilon$ varies between 0 and provided value.
+              \item DecayingOscillate: $\epsilon$ oscillates and decays, driving to exploitation.
+              \end{itemize}
+  \default{Constant}
+          \end{itemize}
+      \end{itemize}
+
+    \item \xmlNode{ModelSelection}:
+      An optional node allowing the user to specify the details of model selection.
+      For example, the manner in which hyperparameters are selected for the GPR model.
+
+      The \xmlNode{ModelSelection} node recognizes the following subnodes:
+      \begin{itemize}
+        \item \xmlNode{Duration}: \xmlDesc{integer}, 
+          Number of iterations between each reselection of the model. Default is 1
+
+        \item \xmlNode{Method}: \xmlDesc{[External, Internal, Average]}, 
+          Determines methodology for selecting the model. This methodology is applied
+          after every duration length.
+          \begin{itemize}                                                        \item External,
+          uses whatever method the model has internal to itself
+          \item Internal, selects the MAP point of the model using slsqp
+          \item Average, Approximate marginalization over model space
+          \end{itemize}. Default is Internal
+  \default{Internal}
+      \end{itemize}
+
+    \item \xmlNode{convergence}:
+      a node containing the desired convergence criteria for the optimization algorithm.
+      Note that convergence is met when any one of the convergence criteria is met. If no
+      convergence                                            criteria are given.
+
+      The \xmlNode{convergence} node recognizes the following subnodes:
+      \begin{itemize}
+        \item \xmlNode{acquisition}: \xmlDesc{float}, 
+          Provides convergence criteria in terms of the value of the acquisition
+          function at a given iteration. If the value falls below a provided threshhold,
+          the optimizer is considered converged; however, it is recommended to pair this
+          criteria with persistance. Default is 1e-8
+
+        \item \xmlNode{persistence}: \xmlDesc{integer}, 
+          provides the number of consecutive times convergence should
+          be reached before a trajectory is considered fully converged.
+          This helps in preventing early false convergence. Default is 5 (BO specific)
+  \default{5}
+      \end{itemize}
+
+    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats}, 
+      allows variables that do not change value to be part of the input space.
+      The \xmlNode{constant} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{name}: \xmlDesc{string, required}, 
+            variable name for this constant, which will be provided to the Model.
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+            determines the shape of samples of the constant value.               For example,
+            \xmlAttr{shape}=``2,3'' will shape the values into a 2 by 3               matrix, while
+            \xmlAttr{shape}=``10'' will shape into a vector of 10 values.               Unlike the
+            \xmlNode{variable}, the constant requires each value be entered; the number
+            of required values is equal to the product of the \xmlAttr{shape} values, e.g. 6 entries
+            for shape ``2,3'').               \nb A model interface must be prepared to handle non-
+            scalar inputs to use this option.
+          \item \xmlAttr{source}: \xmlDesc{string, optional}, 
+            the name of the DataObject containing the value to be used for this constant.
+            Requires \xmlNode{ConstantSource} node with a \xmlNode{DataObject} identified for this
+            Sampler/Optimizer.
+          \item \xmlAttr{index}: \xmlDesc{integer, optional}, 
+            the index of the realization in the \xmlNode{ConstantSource} \xmlNode{DataObject}
+            containing the value for this constant. Requires \xmlNode{ConstantSource} node with
+            a \xmlNode{DataObject} identified for this Sampler/Optimizer.
+      \end{itemize}
+
+    \item \xmlNode{ConstantSource}: \xmlDesc{string}, 
+      identifies a \xmlNode{DataObject} to provide \xmlNode{constant} values to the input
+      space of this entity while sampling. As an alternative to providing predefined values
+      for constants, the \xmlNode{ConstantSource} provides a dynamic means of always providing
+      the same value for a constant. This is often used as part of a larger multi-workflow
+      calculation.
+      The \xmlNode{ConstantSource} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+            The RAVEN class for this source. Options include \xmlString{DataObject}.
+          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+            The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
+            such as HistorySet or PointSet.
+      \end{itemize}
+
+    \item \xmlNode{Constraint}: \xmlDesc{string}, 
+      name of \xmlNode{Function} which contains explicit constraints for the sampling of
+      the input space of the Model. From a practical point of view, this XML node must contain
+      the name of a function defined in the \xmlNode{Functions} block (see
+      Section~\ref{sec:functions}).               This external function must contain a method
+      called ``constrain'', which returns True for               inputs satisfying the explicit
+      constraints and False otherwise. \nb Currently this accepts any number of constraints from the
+      user.
+      The \xmlNode{Constraint} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this source. Options include \xmlString{Functions}.
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this source. Options include \xmlNode{External}.
+      \end{itemize}
+
+    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string}, 
+      name of \xmlNode{Function} which contains implicit constraints of the Model. From a practical
+      point of view, this XML node must contain the name of a function defined in the
+      \xmlNode{Functions}               block (see Section~\ref{sec:functions}). This external
+      function must contain a method called               ``implicitConstrain'', which returns True
+      for outputs satisfying the implicit constraints and False otherwise.
+      The \xmlNode{ImplicitConstraint} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this source. Options include \xmlString{Functions}.
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this source. Options include \xmlNode{External}.
+      \end{itemize}
+
+    \item \xmlNode{ROM}: \xmlDesc{string}, 
+      Name of a Model that optimizers may want to use during optimization. For example, the
+      Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
+      in                                           detail with in the \xmlNode{Models} as in other
+      uses. This node should be provided a string referencing
+      the model definition's name.
+      The \xmlNode{ROM} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
+      \end{itemize}
+
+    \item \xmlNode{Sampler}: \xmlDesc{string}, 
+      name of a Sampler that can be used to initialize the starting points for the trajectories
+      of some of the variables. From a practical point of view, this XML node must contain the
+      name of a Sampler defined in the \xmlNode{Samplers} block (see
+      Section~\ref{subsec:onceThroughSamplers}).               The Sampler will be used to
+      initialize the trajectories' initial points for some or all               of the variables.
+      For example, if the Sampler selected samples only 2 of the 5 optimization
+      variables, the \xmlNode{initial} XML node is required only for the remaining 3 variables.
+      The \xmlNode{Sampler} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+            RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
+          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+            RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
+      \end{itemize}
+
+    \item \xmlNode{Restart}: \xmlDesc{string}, 
+      name of a DataObject. Used to leverage existing data when sampling a model. For
+      example, if a Model has               already been sampled, but some samples were not
+      collected, the successful samples can               be stored and used instead of rerunning
+      the model for those specific samples. This RAVEN               entity definition must be a
+      DataObject with contents including the input and output spaces               of the Model
+      being sampled.
+      The \xmlNode{Restart} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+            The RAVEN class for this source. Options include \xmlString{DataObject}.
+          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+            The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
+            such as HistorySet or PointSet.
+      \end{itemize}
+
+    \item \xmlNode{restartTolerance}: \xmlDesc{float}, 
+      specifies how strictly a matching point from a \xmlNode{Restart} DataObject must match
+      the desired sample point in order to be used. If a potential restart point is within a
+      relative Euclidean distance (as specified by the value in this node) of a desired sample
+      point,               the restart point will be used instead of sampling the Model.
+      \default{1e-15}
+
+    \item \xmlNode{variablesTransformation}:
+      Allows transformation of variables via translation matrices. This defines two spaces,
+      a ``latent'' transformed space sampled by RAVEN and a ``manifest'' original space understood
+      by the Model.
+      The \xmlNode{variablesTransformation} node recognizes the following parameters:
+        \begin{itemize}
+          \item \xmlAttr{distribution}: \xmlDesc{string, optional}, 
+            the name for the distribution defined in the XML node \xmlNode{Distributions}.
+            This attribute indicates the values of \xmlNode{manifestVariables} are drawn from
+            \xmlAttr{distribution}.
+      \end{itemize}
+
+      The \xmlNode{variablesTransformation} node recognizes the following subnodes:
+      \begin{itemize}
+        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings}, 
+          user-defined latent variables that are used for the variables transformation.
+          All the variables listed under this node should be also mentioned in \xmlNode{variable}.
+
+        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings}, 
+          user-defined manifest variables that can be used by the \xmlNode{Model}.
+
+        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings}, 
+          user-defined manifest variables indices paired with \xmlNode{manifestVariables}.
+          These indices indicate the position of manifest variables associated with multivariate
+          normal               distribution defined in the XML node \xmlNode{Distributions}.
+          The indices should be postive integer. If not provided, the code will use the positions
+          of manifest variables listed in \xmlNode{manifestVariables} as the indices.
+
+        \item \xmlNode{method}: \xmlDesc{string}, 
+          the method that is used for the variables transformation. The currently available method
+          is \xmlString{pca}.
+      \end{itemize}
+  \end{itemize}
+
+\hspace{24pt}
+Bayesian Optimizer Example:
+\begin{lstlisting}[style=XML]
+  <Optimizers>
+    <BayesianOptimizer name="opter">
+
+      <objective>ans</objective>
+
+      <variable name="x">
+        <distribution>egg_dist</distribution>
+      </variable>
+
+      <variable name="y">
+        <distribution>egg_dist</distribution>
+      </variable>
+
+      <TargetEvaluation class="DataObjects" type="PointSet">optOut</TargetEvaluation>
+
+      <samplerInit>
+        <limit>50</limit>
+        <initialSeed>42</initialSeed>
+        <writeSteps>every</writeSteps>
+      </samplerInit>
+
+      <Sampler    class="Samplers"  type="Stratified" >LHS_samp</Sampler>
+
+      <ROM  class="Models" type="ROM">gpROM</ROM>
+
+      <Acquisition>
+        <ExpectedImprovement>
+          <optimizationMethod>differentialEvolution</optimizationMethod>
+          <seedingCount>30</seedingCount>
+        </ExpectedImprovement>
+      </Acquisition>
+
+    </BayesianOptimizer>
   </Optimizers>
 \end{lstlisting}
 

--- a/doc/user_manual/generated/sklRom.tex
+++ b/doc/user_manual/generated/sklRom.tex
@@ -51,7 +51,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -81,7 +81,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -147,7 +147,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -187,7 +187,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -312,7 +312,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -342,7 +342,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -408,7 +408,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -448,7 +448,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -556,7 +556,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -586,7 +586,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -652,7 +652,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -692,7 +692,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -781,7 +781,7 @@
   The \xmlNode{BayesianRidge} is Bayesian Ridge regression.                         It estimates a
   probabilistic model of the regression problem as                         described above. The
   prior for the coefficient is given by a                         spherical Gaussian:
-  $p(w|\lambda) = \mathcal{N}(w|0,\lambda^{-1}\mathbf{I}\_{p})$                         The
+  $p(w|\lambda) = \mathcal{N}(w|0,\lambda^{-1}\mathbf{I}_{p})$                         The
   parameters $w$, $\alpha$ and $\lambda$ are estimated jointly during                         the
   fit of the model, the regularization parameters $\alpha$ and $\lambda$
   being estimated by maximizing the log marginal likelihood.
@@ -830,7 +830,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -860,7 +860,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -926,7 +926,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -966,7 +966,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -1058,7 +1058,7 @@
 \subsubsection{ElasticNet}
   The \xmlNode{ElasticNet} employs                         Linear regression with combined L1 and L2
   priors as regularizer.                         It minimizes the objective function:
-  \begin{equation}                         1/(2*n\_{samples}) *||y - Xw||^2\_2+alpha*l1\_ratio*||w||\_1
+  \begin{equation}                         1/(2*n_{samples}) *||y - Xw||^2\_2+alpha*l1\_ratio*||w||\_1
   + 0.5 *alpha*(1 - l1\_ratio)*||w||^2\_2                         \end{equation}
   \zNormalizationNotPerformed{ElasticNet}
 
@@ -1105,7 +1105,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -1135,7 +1135,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -1201,7 +1201,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -1241,7 +1241,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -1376,7 +1376,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -1406,7 +1406,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -1472,7 +1472,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -1512,7 +1512,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -1655,7 +1655,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -1685,7 +1685,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -1751,7 +1751,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -1791,7 +1791,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -1912,7 +1912,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -1942,7 +1942,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2008,7 +2008,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2048,7 +2048,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -2171,7 +2171,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -2201,7 +2201,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2267,7 +2267,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2307,7 +2307,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -2438,7 +2438,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -2468,7 +2468,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2534,7 +2534,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2574,7 +2574,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -2712,7 +2712,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -2742,7 +2742,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2808,7 +2808,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -2848,7 +2848,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -2972,7 +2972,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -3002,7 +3002,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3068,7 +3068,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3108,7 +3108,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -3237,7 +3237,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -3267,7 +3267,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3333,7 +3333,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3373,7 +3373,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -3493,7 +3493,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -3523,7 +3523,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3589,7 +3589,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3629,7 +3629,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -3729,7 +3729,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -3759,7 +3759,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3825,7 +3825,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -3865,7 +3865,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -3979,9 +3979,9 @@
   The \xmlNode{MultiTaskElasticNet} employs                         Linear regression with combined
   L1 and L2 priors as regularizer.                         The optimization objective for
   MultiTaskElasticNet is:                         $(1 / (2 * n\_samples)) * ||Y - XW||^{Fro}\_2
-  + alpha * l1\_ratio * ||W||\_{21}                         + 0.5 * alpha * (1 - l1\_ratio) *
-  ||W||\_{Fro}^2$                         \\Where:                         $||W||\_{21} = \sum\_i
-  \sqrt{\sum\_j w\_{ij}^2}$                         i.e. the sum of norm of each row.
+  + alpha * l1\_ratio * ||W||_{21}                         + 0.5 * alpha * (1 - l1\_ratio) *
+  ||W||_{Fro}^2$                         \\Where:                         $||W||_{21} = \sum\_i
+  \sqrt{\sum\_j w_{ij}^2}$                         i.e. the sum of norm of each row.
   \zNormalizationNotPerformed{MultiTaskElasticNet}
 
   The \xmlNode{MultiTaskElasticNet} node recognizes the following parameters:
@@ -4027,7 +4027,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -4057,7 +4057,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4123,7 +4123,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4163,7 +4163,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -4243,9 +4243,9 @@
   The \xmlNode{MultiTaskElasticNetCV} employs                         linear regression with
   combined L1 and L2 priors as regularizer.                         The optimization objective for
   MultiTaskElasticNet is:                         $(1 / (2 * n\_samples)) * ||Y - XW||^{Fro}\_2
-  + alpha * l1\_ratio * ||W||\_{21}                         + 0.5 * alpha * (1 - l1\_ratio) *
-  ||W||\_{Fro}^2$                         \\Where:                         $||W||\_{21} = \sum\_i
-  \sqrt{\sum\_j w\_{ij}^2}$                         In this model, the cross-validation is embedded
+  + alpha * l1\_ratio * ||W||_{21}                         + 0.5 * alpha * (1 - l1\_ratio) *
+  ||W||_{Fro}^2$                         \\Where:                         $||W||_{21} = \sum\_i
+  \sqrt{\sum\_j w_{ij}^2}$                         In this model, the cross-validation is embedded
   for the automatic selection                         of the best hyper-parameters.
   \zNormalizationNotPerformed{MultiTaskElasticNetCV}
 
@@ -4292,7 +4292,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -4322,7 +4322,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4388,7 +4388,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4428,7 +4428,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -4509,8 +4509,8 @@
   The \xmlNode{MultiTaskLasso} (\textit{Multi-task Lasso model trained                         with
   L1/L2 mixed-norm as regularizer}) is an algorithm for regression problem
   where the optimization objective for Lasso is:                         $(1 / (2 * n\_samples)) *
-  ||Y - XW||^2\_{Fro} + alpha * ||W||\_{21}$                         \\Where:
-  $||W||\_{21} = \sum\_i \sqrt{\sum\_j w\_{ij}^2}$                         i.e. the sum of norm of each
+  ||Y - XW||^2_{Fro} + alpha * ||W||_{21}$                         \\Where:
+  $||W||_{21} = \sum\_i \sqrt{\sum\_j w_{ij}^2}$                         i.e. the sum of norm of each
   row.                         \zNormalizationNotPerformed{MultiTaskLasso}
 
   The \xmlNode{MultiTaskLasso} node recognizes the following parameters:
@@ -4556,7 +4556,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -4586,7 +4586,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4652,7 +4652,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4692,7 +4692,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -4766,8 +4766,8 @@
   The \xmlNode{MultiTaskLassoCV} (\textit{Multi-task Lasso model trained
   with L1/L2 mixed-norm as regularizer}) is an algorithm for regression problem
   where the optimization objective for Lasso is:                         $(1 / (2 * n\_samples)) *
-  ||Y - XW||^2\_{Fro} + alpha * ||W||\_{21}$                         \\Where:
-  $||W||\_{21} = \sum\_i \sqrt{\sum\_j w\_{ij}^2}$                         i.e. the sum of norm of each
+  ||Y - XW||^2_{Fro} + alpha * ||W||_{21}$                         \\Where:
+  $||W||_{21} = \sum\_i \sqrt{\sum\_j w_{ij}^2}$                         i.e. the sum of norm of each
   row.                         In this model, the cross-validation is embedded for the automatic
   selection                         of the best hyper-parameters.
   \zNormalizationNotPerformed{MultiTaskLassoCV}
@@ -4815,7 +4815,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -4845,7 +4845,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4911,7 +4911,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -4951,7 +4951,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -5074,7 +5074,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -5104,7 +5104,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5170,7 +5170,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5210,7 +5210,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -5321,7 +5321,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -5351,7 +5351,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5417,7 +5417,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5457,7 +5457,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -5566,7 +5566,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -5596,7 +5596,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5662,7 +5662,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5702,7 +5702,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -5838,7 +5838,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -5868,7 +5868,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5934,7 +5934,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -5974,7 +5974,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -6123,7 +6123,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -6153,7 +6153,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -6219,7 +6219,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -6259,7 +6259,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -6406,7 +6406,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -6436,7 +6436,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -6502,7 +6502,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -6542,7 +6542,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -6673,7 +6673,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -6703,7 +6703,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -6769,7 +6769,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -6809,7 +6809,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -6942,7 +6942,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -6972,7 +6972,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7038,7 +7038,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7078,7 +7078,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -7220,7 +7220,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -7250,7 +7250,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7316,7 +7316,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7356,7 +7356,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -7487,7 +7487,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -7517,7 +7517,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7583,7 +7583,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7623,7 +7623,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -7835,7 +7835,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -7865,7 +7865,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7931,7 +7931,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -7971,7 +7971,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -8165,7 +8165,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -8195,7 +8195,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -8261,7 +8261,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -8301,7 +8301,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -8400,7 +8400,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -8430,7 +8430,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -8496,7 +8496,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -8536,7 +8536,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -8644,7 +8644,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -8674,7 +8674,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -8740,7 +8740,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -8780,7 +8780,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -8837,15 +8837,15 @@
   variants used in text classification (where the data is typically represented
   as word vector counts, although tf-idf vectors are also known to work well in
   practice).                         The distribution is parametrized by vectors $\theta\_y =
-  (\theta\_{y1},\ldots,\theta\_{yn})$ for each class $y$, where $n$ is the number of
-  features (in text classification, the size of the vocabulary) and $\theta\_{yi}$
+  (\theta_{y1},\ldots,\theta_{yn})$ for each class $y$, where $n$ is the number of
+  features (in text classification, the size of the vocabulary) and $\theta_{yi}$
   is the probability $P(x\_i \mid y)$ of feature $i$ appearing in a sample
   belonging to class $y$.                         The parameters $\theta\_y$ are estimated by a
   smoothed version of maximum                         likelihood, i.e. relative frequency counting:
-  \begin{equation}                         \hat{\theta}\_{yi} = \frac{ N\_{yi} + \alpha}{N\_y + \alpha
-  n}                         \end{equation}                         where $N\_{yi} = \sum\_{x \in T}
+  \begin{equation}                         \hat{\theta}_{yi} = \frac{ N_{yi} + \alpha}{N\_y + \alpha
+  n}                         \end{equation}                         where $N_{yi} = \sum_{x \in T}
   x\_i$ is the number of times feature $i$ appears                         in a sample of class y in
-  the training set T, and                         $N\_{y} = \sum\_{i=1}^{|T|} N\_{yi}$ is the total
+  the training set T, and                         $N_{y} = \sum_{i=1}^{|T|} N_{yi}$ is the total
   count of all features for class                         $y$.                         The smoothing
   priors $\alpha \ge 0$ account for features not present in the                         learning
   samples and prevents zero probabilities in further computations.                         Setting
@@ -8895,7 +8895,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -8925,7 +8925,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -8991,7 +8991,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -9031,7 +9031,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -9129,7 +9129,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -9159,7 +9159,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -9225,7 +9225,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -9265,7 +9265,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -9357,7 +9357,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -9387,7 +9387,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -9453,7 +9453,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -9493,7 +9493,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -9703,7 +9703,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -9733,7 +9733,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -9799,7 +9799,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -9839,7 +9839,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -10070,7 +10070,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -10100,7 +10100,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -10166,7 +10166,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -10206,7 +10206,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -10253,7 +10253,7 @@
       The kernel is given by $k(x\_i, x\_j) = \text{exp}\left(-\frac{ 2\sin^2(\pi d(x\_i, x\_j)/p) }{ l^
       2} \right)$ where $d(\\cdot,\\cdot)$ is the Euclidean distance.
       \item Exponentiation, it takes one base kernel and a scalar parameter $p$ and combines them
-      via $k\_{exp}(X, Y) = k(X, Y) ^p$.                                                    \item
+      via $k_{exp}(X, Y) = k(X, Y) ^p$.                                                    \item
       Matern, is a generalization of the RBF. It has an additional parameter $\nu$ which controls
       the smoothness of the resulting function. The smaller $\nu$,
       the less smooth the approximated function is. As $\nu\rightarrow\infty$, the kernel becomes
@@ -10263,7 +10263,7 @@
       The kernel is given by $k(x\_i, x\_j) =  \frac{1}{\Gamma(\nu)2^{\nu-1}}\Bigg(
       \frac{\sqrt{2\nu}}{l} d(x\_i , x\_j ) \Bigg)^\nu K\_\nu\Bigg( \frac{\sqrt{2\nu}}{l} d(x\_i , x\_j
       )\Bigg)$                                                                  where
-      $d(\cdot,\cdot)$ is the Euclidean distance, $K\_{\nu}(\cdot)$ is a modified Bessel function and
+      $d(\cdot,\cdot)$ is the Euclidean distance, $K_{\nu}(\cdot)$ is a modified Bessel function and
       $\Gamma(\cdot)$ is the gamma function.
       \item PairwiseLinear, it is a thin wrapper around the functionality of the pairwise kernels.
       It uses the a linear metric to calculate kernel between instances
@@ -10419,7 +10419,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -10449,7 +10449,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -10515,7 +10515,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -10555,7 +10555,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -10584,7 +10584,7 @@
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{kernel}: \xmlDesc{[Constant, DotProduct, ExpSineSquared, Exponentiation, Matern, PairwiseLinear, PairwiseAdditiveChi2, PairwiseChi2, PairwisePoly, PairwisePolynomial, PairwiseRBF, PairwiseLaplassian, PairwiseSigmoid, PairwiseCosine, RBF, RationalQuadratic]}, 
+    \item \xmlNode{kernel}: \xmlDesc{[Constant, DotProduct, ExpSineSquared, WhiteNoise, Matern, PairwiseLinear, PairwiseAdditiveChi2, PairwiseChi2, PairwisePoly, PairwisePolynomial, PairwiseRBF, PairwiseLaplassian, PairwiseSigmoid, PairwiseCosine, RBF, RationalQuadratic, Custom]}, 
       The kernel specifying the covariance function of the GP. If None is passed,
       the kernel $Constant$ is used as default. The kernel hyperparameters are optimized during
       fitting and consequentially the hyperparameters are
@@ -10601,10 +10601,8 @@
       parameter $l>0$ and a periodicity parameter $p>0$.
       The kernel is given by $k(x\_i, x\_j) = \text{exp}\left(-\frac{ 2\sin^2(\pi d(x\_i, x\_j)/p) }{ l^
       2} \right)$ where $d(\\cdot,\\cdot)$ is the Euclidean distance.
-      \item Exponentiation, it takes one base kernel and a scalar parameter $p$ and combines them
-      via $k\_{exp}(X, Y) = k(X, Y) ^p$.                                                    \item
-      Matern, is a generalization of the RBF. It has an additional parameter $\nu$ which controls
-      the smoothness of the resulting function. The smaller $\nu$,
+      \item Matern, is a generalization of the RBF. It has an additional parameter $\nu$ which
+      controls the smoothness of the resulting function. The smaller $\nu$,
       the less smooth the approximated function is. As $\nu\rightarrow\infty$, the kernel becomes
       equivalent to the RBF kernel. When $\nu = 1/2$, the Matérn kernel becomes
       identical to the absolute exponential kernel. Important intermediate values are $\nu = 1.5$
@@ -10612,7 +10610,7 @@
       The kernel is given by $k(x\_i, x\_j) =  \frac{1}{\Gamma(\nu)2^{\nu-1}}\Bigg(
       \frac{\sqrt{2\nu}}{l} d(x\_i , x\_j ) \Bigg)^\nu K\_\nu\Bigg( \frac{\sqrt{2\nu}}{l} d(x\_i , x\_j
       )\Bigg)$                                                                  where
-      $d(\cdot,\cdot)$ is the Euclidean distance, $K\_{\nu}(\cdot)$ is a modified Bessel function and
+      $d(\cdot,\cdot)$ is the Euclidean distance, $K_{\nu}(\cdot)$ is a modified Bessel function and
       $\Gamma(\cdot)$ is the gamma function.
       \item PairwiseLinear, it is a thin wrapper around the functionality of the pairwise kernels.
       It uses the a linear metric to calculate kernel between instances
@@ -10661,7 +10659,11 @@
       $l>0$ and a scale mixture parameter $\alpha>0$ . The kernel is given by $k(x\_i, x\_j) = \left(1
       + \frac{d(x\_i, x\_j)^2 }{ 2\alpha  l^2}\right)^{-\alpha}$ where
       $d(\cdot,\cdot)$ is the Euclidean distance.
-      \end{itemize}.
+      \item WhiteNoise, This is a kernel representing observation noise in the GPR model and is
+      given by $k(x\_i, x\_j) = \epsilon\delta_{i,j}$
+      where $\delta$ is the dirac delta function
+      \item Custom, this option allows the user to specify any combination of the above kernels.
+      Still under construction                                                  \end{itemize}.
   \default{None}
 
     \item \xmlNode{alpha}: \xmlDesc{float}, 
@@ -10689,11 +10691,27 @@
       Seed for the internal random number generator.
   \default{None}
 
-    \item \xmlNode{optimizer}: \xmlDesc{[fmin\_l\_bfgs\_b]}, 
+    \item \xmlNode{optimizer}: \xmlDesc{[fmin\_l\_bfgs\_b, None]}, 
       Per default, the 'L-BFGS-B' algorithm from
       scipy.optimize.minimize is used. If None is passed, the kernel’s
       parameters are kept fixed.
   \default{fmin\_l\_bfgs\_b}
+
+    \item \xmlNode{anisotropic}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+      Boolean that determines if unique length-scales are used for each
+      axis of the input space (where applicable). The default is False.
+  \default{False}
+
+    \item \xmlNode{custom\_kernel}: \xmlDesc{string}, 
+      Defines the custom kernel constructed by the available base kernels.
+      Only applicable when 'kernel' is set to 'Custom'; therefore, the default is None.
+  \default{None}
+
+    \item \xmlNode{multioutput}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+      Determines whether model will track multiple targets through the
+      multiouput regressor wrapper class. For most RAVEN applications, this is expected;
+      therefore, the default is True.
+  \default{True}
   \end{itemize}
 
 
@@ -10746,7 +10764,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -10776,7 +10794,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -10842,7 +10860,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -10882,7 +10900,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -10982,7 +11000,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -11012,7 +11030,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11078,7 +11096,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11118,7 +11136,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -11219,7 +11237,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -11249,7 +11267,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11315,7 +11333,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11355,7 +11373,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -11468,7 +11486,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -11498,7 +11516,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11564,7 +11582,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11604,7 +11622,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -11730,7 +11748,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -11760,7 +11778,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11826,7 +11844,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -11866,7 +11884,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -11964,7 +11982,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -11994,7 +12012,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12060,7 +12078,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12100,7 +12118,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -12224,7 +12242,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -12254,7 +12272,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12320,7 +12338,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12360,7 +12378,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -12486,7 +12504,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -12516,7 +12534,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12582,7 +12600,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12622,7 +12640,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -12754,7 +12772,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -12784,7 +12802,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12850,7 +12868,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -12890,7 +12908,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -13047,7 +13065,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -13077,7 +13095,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13143,7 +13161,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13183,7 +13201,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -13303,7 +13321,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -13333,7 +13351,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13399,7 +13417,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13439,7 +13457,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -13590,7 +13608,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -13620,7 +13638,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13686,7 +13704,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13726,7 +13744,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -13853,7 +13871,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -13883,7 +13901,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13949,7 +13967,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -13989,7 +14007,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -14142,7 +14160,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -14172,7 +14190,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -14238,7 +14256,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -14278,7 +14296,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -14409,7 +14427,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -14439,7 +14457,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -14505,7 +14523,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -14545,7 +14563,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -14696,7 +14714,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -14726,7 +14744,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -14792,7 +14810,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -14832,7 +14850,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -14995,7 +15013,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -15025,7 +15043,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15091,7 +15109,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15131,7 +15149,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -15280,7 +15298,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -15310,7 +15328,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15376,7 +15394,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15416,7 +15434,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -15570,7 +15588,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -15600,7 +15618,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15666,7 +15684,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15706,7 +15724,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -15804,7 +15822,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -15834,7 +15852,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15900,7 +15918,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -15940,7 +15958,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -16065,7 +16083,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -16095,7 +16113,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -16161,7 +16179,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -16201,7 +16219,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
@@ -16313,7 +16331,7 @@
           wrapped by RFE, and used to help select features.         \\RFE works by searching for a
           subset of features by starting with all features in the training dataset and successfully
           removing         features until the desired number remains.         This is achieved by
-          fitting the given ROME used in the core of the model, ranking features by importance,
+          fitting the given ROM used in the core of the model, ranking features by importance,
           discarding the least important features, and re-fitting the model. This process is
           repeated until a specified number of         features remains.         When the full model
           is created, a measure of variable importance is computed that ranks the predictors from
@@ -16343,7 +16361,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -16409,7 +16427,7 @@
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[feature, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
@@ -16449,7 +16467,7 @@
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{string}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}

--- a/ravenframework/Optimizers/acquisitionFunctions/AcquisitionFunction.py
+++ b/ravenframework/Optimizers/acquisitionFunctions/AcquisitionFunction.py
@@ -55,7 +55,9 @@ class AcquisitionFunction(utils.metaclass_insert(abc.ABCMeta, object)):
                                                  \item Differential Evolution: A style of evolutionary algorithm, which specializes in floating point
                                                  representations of decision variables. Works similar to its parent algorithm Genetic Algorithm
                                                  \item SLSQP: A Sequential Least Squares algorithm, which uses an BFGS update and
-                                                 Lawson and Hanson’s NNLS nonlinear least-squares solver.""", default='differentialEvolution'))
+                                                 Lawson and Hanson’s NNLS nonlinear least-squares solver.
+                                                 \end{itemize}
+                                                 """, default='differentialEvolution'))
     specs.addSub(InputData.parameterInputFactory('seedingCount', contentType=InputTypes.IntegerType,
                                                  descr=r"""If the method is gradient based or typically handled with singular
                                                  decisions (ex. slsqp approximates a quadratic program using the gradient), this number

--- a/ravenframework/Optimizers/acquisitionFunctions/LowerConfidenceBound.py
+++ b/ravenframework/Optimizers/acquisitionFunctions/LowerConfidenceBound.py
@@ -47,7 +47,7 @@ class LowerConfidenceBound(AcquisitionFunction):
                         the lower confidence bound acqusition function is utilized.
                         This function is derived by applying optimistic decision making in the infinite-armed bandit problem.
                         The approach assumes the model is conservative and values optimism through the following equation (for minimization):
-                        $LCB(x) = \mu - \beta \sigma$, where $\beta = \Phi^{-1}(\pi)"""
+                        $LCB(x) = \mu - \beta \sigma$, where $\beta = \Phi^{-1}(\pi)$"""
     specs.addSub(InputData.parameterInputFactory('pi', contentType=InputTypes.FloatType,
                                                  descr=r"""Parameter that determines the lower confidence bound. Must be
                                                  between 0 and 1.""", default=0.98))
@@ -56,13 +56,13 @@ class LowerConfidenceBound(AcquisitionFunction):
                                                  Provides the period for the oscillate transient settings.""", default=1.0))
     specs.addSub(InputData.parameterInputFactory('transient', contentType=InputTypes.makeEnumType("transient", "transientType",
                                                  ['Constant', 'Exploit', 'Explore', 'Oscillate', 'DecayingOscillate']),
-                                                 descr=r"""Determines how the threshold \tau changes as optimization progresses.
+                                                 descr=r"""Determines how the threshold $\tau$ changes as optimization progresses.
                                                  \begin{itemize}
-                                                 \item Constant: \epsilon remains the provided value.
-                                                 \item Exploit: \epsilon exponentially decays to 0 encouraging exploitation.
-                                                 \item Explore: \epsilon exponentially grows from 0 to provided value.
-                                                 \item Oscillate: \epsilon varies between 0 and provided value.
-                                                 \item DecayingOscillate: \epsilon oscillates and decays, driving to exploitation.
+                                                 \item Constant: $\epsilon$ remains the provided value.
+                                                 \item Exploit: $\epsilon$ exponentially decays to 0 encouraging exploitation.
+                                                 \item Explore: $\epsilon$ exponentially grows from 0 to provided value.
+                                                 \item Oscillate: $\epsilon$ varies between 0 and provided value.
+                                                 \item DecayingOscillate: $\epsilon$ oscillates and decays, driving to exploitation.
                                                  \end{itemize}""", default='Constant'))
     return specs
 

--- a/ravenframework/Optimizers/acquisitionFunctions/ProbabilityOfImprovement.py
+++ b/ravenframework/Optimizers/acquisitionFunctions/ProbabilityOfImprovement.py
@@ -52,20 +52,20 @@ class ProbabilityOfImprovement(AcquisitionFunction):
                         $PoI(x) = \frac{\tau - \mu}{\sigma}$"""
     specs.addSub(InputData.parameterInputFactory('epsilon', contentType=InputTypes.FloatType,
                                                  descr=r"""Defines the threshold for PoI via the equation:
-                                                 $\tau = min \mu(\textbf{X}) - \epsilon$. The larger \epsilon is, the
+                                                 $\tau = min \mu(\textbf{X}) - \epsilon$. The larger $\epsilon$ is, the
                                                  more exploratory the algorithm and vice versa.""", default=1.0))
     specs.addSub(InputData.parameterInputFactory('rho', contentType=InputTypes.FloatType,
                                                  descr=r"""Provides a 'time-constant' for the Exploit and Explore transient settings.
                                                  Provides the period for the oscillate transient setting.""", default=1.0))
     specs.addSub(InputData.parameterInputFactory('transient', contentType=InputTypes.makeEnumType("transient", "transientType",
                                                  ['Constant', 'Exploit', 'Explore', 'Oscillate', 'DecayingOscillate']),
-                                                 descr=r"""Determines how the threshold \tau changes as optimization progresses.
+                                                 descr=r"""Determines how the threshold $\tau$ changes as optimization progresses.
                                                  \begin{itemize}
-                                                 \item Constant: \epsilon remains the provided value.
-                                                 \item Exploit: \epsilon exponentially decays to 0 encouraging exploitation.
-                                                 \item Explore: \epsilon exponentially grows from 0 to provided value.
-                                                 \item Oscillate: \epsilon varies between 0 and provided value.
-                                                 \item DecayingOscillate: \epsilon oscillates and decays, driving to exploitation.
+                                                 \item Constant: $\epsilon$ remains the provided value.
+                                                 \item Exploit: $\epsilon$ exponentially decays to 0 encouraging exploitation.
+                                                 \item Explore: $\epsilon$ exponentially grows from 0 to provided value.
+                                                 \item Oscillate: $\epsilon$ varies between 0 and provided value.
+                                                 \item DecayingOscillate: $\epsilon$ oscillates and decays, driving to exploitation.
                                                  \end{itemize}""", default='Constant'))
     return specs
 

--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -48,6 +48,16 @@ def checkQuantity(quantity, n):
     match = match and n <= 1
   return match
 
+def _escUnderscore(s):
+  """
+    Escapes underscores in LaTeX
+    @ In, s, string, the string to escape the underscores
+    @ Out, _escUnderscore, string, the string with underscores escaped
+  """
+  # assure underscore is escaped, but not doubly
+  # and never escape an underscore followed by a '{'
+  return re.sub(r'(?<!\\)_(?!{)', r'\_', s)
+
 class CheckClass(object):
   """
     This checks to figure out if a node is a ParameterInput type
@@ -677,8 +687,7 @@ class ParameterInput(object):
       msg += '{i}\\end{{itemize}}\n'.format(i=doDent(recDepth, 1))
     # TODO is this a good idea? -> disables underscores in math mode :(
     if recDepth == 0:
-      # assure underscore is escaped, but not doubly
-      msg = re.sub(r'(?<!\\)_', r'\_', msg)
+      msg = _escUnderscore(msg)
     return msg
 
   @classmethod
@@ -695,12 +704,12 @@ class ParameterInput(object):
     specName = cls.name
     if '_' in specName:
       # assure underscore is escaped, but not doubly
-      specName = re.sub(r'(?<!\\)_', r'\_', specName)
+      specName = _escUnderscore(specName)
     msg += '{i}The \\xmlNode{{{n}}} node recognizes the following parameters:'.format(i=doDent(recDepth), n=specName)
     msg += '\n{i}\\begin{{itemize}}'.format(i=doDent(recDepth, 1))
     for param, info in cls.parameters.items():
       # assure underscore is escaped, but not doubly
-      name = re.sub(r'(?<!\\)_', r'\_', param)
+      name = _escUnderscore(param)
       typ = info['type'].generateLatexType()
       req = 'required' if info['required'] else 'optional'
       default = '\\default{'+ str(info['default']) +'}' if info['default'] != 'no-default' else ""


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2291

##### What are the significant changes in functionality due to this change request?
Fixes various latex errors, updates generated documents, and does not escape _ in generateLatex if it is followed by a '{'

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

