### PR TITLE
Allow no precommand

### DIFF
--- a/developer_tools/XSDSchemas/raven.xsd
+++ b/developer_tools/XSDSchemas/raven.xsd
@@ -80,8 +80,10 @@
                         <xsd:element name="memory"       type="xsd:string" minOccurs="0"/>
                         <xsd:element name="coresneeded"  type="xsd:string" minOccurs="0"/>
                         <xsd:element name="runQSUB"                        minOccurs="0"/>
+			<xsd:element name="noPrecommand"                   minOccurs="0"/>
                         <xsd:element name="nodefile"     type="xsd:string" minOccurs="0"/>
                         <xsd:element name="nodefileenv"  type="xsd:string" minOccurs="0"/>
+			<xsd:element name="MPIParam"     type="xsd:string" minOccurs="0"/>
                         <xsd:element name="NoSplitNode" minOccurs="0">
                           <xsd:complexType>
                             <xsd:attribute name="maxOnNode" type="xsd:integer" />

--- a/doc/user_manual/runInfo.tex
+++ b/doc/user_manual/runInfo.tex
@@ -376,6 +376,12 @@ RAVEN currently supports one pre-defined ``mode'':
          \item The max memory needed can be specified with the
            \xmlNode{memory} XML node.  This will be used in the
            \texttt{qsub} command select statement.
+         \item If the automaticly generated mpi command is not needed,
+           \xmlNode{noPrecommand} can be used to completely disable
+           generating a precommand. This can be useful if calling a
+           script that will call \texttt{mpiexec} itself.  Note that
+           the machine host file is located at
+           \texttt{\%BASE\_WORKING\_DIR\%/node\_\%INDEX\%}
          \item The placement can be specified with the \xmlNode{place}
            XML node.  This will be used in the \texttt{qsub} place
            statement.

--- a/ravenframework/CustomModes/MPISimulationMode.py
+++ b/ravenframework/CustomModes/MPISimulationMode.py
@@ -47,6 +47,7 @@ class MPISimulationMode(Simulation.SimulationMode):
     self.__memNeeded = None #If not none, use this for mem=
     self.__place = "free" #use this for place=
     self.__mpiparams = [] #Paramaters to give to mpi
+    self.__createPrecommand = True #If true, do create precommand.
     self.printTag = 'MPI SIMULATION MODE'
 
   def modifyInfo(self, runInfoDict):
@@ -112,7 +113,10 @@ class MPISimulationMode(Simulation.SimulationMode):
       mpiParams = ""
     # Create the mpiexec pre command
     # Note, with defaults the precommand is "mpiexec -f nodeFile -n numMPI"
-    newRunInfo['precommand'] = runInfoDict["MPIExec"]+" "+mpiParams+nodeCommand+" -n "+str(numMPI)+" "+runInfoDict['precommand']
+    if self.__createPrecommand:
+      newRunInfo['precommand'] = runInfoDict["MPIExec"]+" "+mpiParams+nodeCommand+" -n "+str(numMPI)+" "+runInfoDict['precommand']
+    else:
+      newRunInfo['precommand'] = runInfoDict['precommand']
     if runInfoDict['NumThreads'] > 1:
       newRunInfo['threadParameter'] = runInfoDict['threadParameter']
       #add number of threads to the post command.
@@ -210,5 +214,7 @@ class MPISimulationMode(Simulation.SimulationMode):
         self.__runQsub = True
       elif child.tag.lower() == "mpiparam":
         self.__mpiparams.append(child.text.strip())
+      elif child.tag.lower() == "noprecommand":
+        self.__createPrecommand = False
       else:
         self.raiseADebug("We should do something with child "+str(child))

--- a/tests/cluster_tests/.gitignore
+++ b/tests/cluster_tests/.gitignore
@@ -8,6 +8,8 @@ FirstMFRun/
 FirstMLRun/
 FirstMForcedRun/
 FirstMQL/
+FirstMPre/FirstMPreRun/
+FirstMPre/samples.xml
 DatabaseStorage/
 *.log
 InternalParallel/InternalParallelExtModel/test*Set_dump.xml

--- a/tests/cluster_tests/FirstMPre/simple_gp_test.i
+++ b/tests/cluster_tests/FirstMPre/simple_gp_test.i
@@ -1,0 +1,5 @@
+[outputParams]
+  names = "pipe_Area pipe_Hw pipe_Tw time"
+  start = "2.0 3.0 5.0 0.0"
+  increment = "0.5 0.1 -0.5 1.0"
+[]

--- a/tests/cluster_tests/test_mpiqsub_noprecommand.xml
+++ b/tests/cluster_tests/test_mpiqsub_noprecommand.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" ?>
+<Simulation verbosity='debug'>
+  <TestInfo>
+    <name>cluster_tests/test_mpiqsub_noprecommand</name>
+    <author>cogljj</author>
+    <created>2024-05-02</created>
+    <classesTested>MPISimulationMode</classesTested>
+    <description>
+      This tests running with mpi and a qsub with noprecommand
+    </description>
+  </TestInfo>
+
+  <RunInfo>
+    <WorkingDir>FirstMPre</WorkingDir>
+    <Sequence>FirstMPreRun</Sequence>
+    <batchSize>8</batchSize>
+    <NumThreads>1</NumThreads>
+    <NumMPI>1</NumMPI>
+    <expectedTime>0:10:00</expectedTime>
+    <clusterParameters>-W block=true</clusterParameters>
+    <JobName>test_mpinopre</JobName>
+    <mode>
+      mpi
+      <runQSUB/>
+      <MPIParam>--bind-to none</MPIParam>
+      <noPrecommand/>
+    </mode>
+   </RunInfo>
+
+  <Files>
+    <Input name="simple_gp_test.i" type="">simple_gp_test.i</Input>
+  </Files>
+
+  <Models>
+    <Code name="MyRAVEN" subType="GenericCode">
+      <executable>mpiexec -np 1 -machinefile  %BASE_WORKING_DIR%/node_%INDEX% python %FRAMEWORK_DIR%/../tests/cluster_tests/compute_test.py </executable>
+      <clargs arg="-i" extension=".i" type="input"/>
+    </Code>
+  </Models>
+
+  <Distributions>
+    <Normal name="Gauss1">
+      <mean>1</mean>
+      <sigma>0.001</sigma>
+      <lowerBound>0</lowerBound>
+      <upperBound>2</upperBound>
+    </Normal>
+    <Normal name="auxBackUpTimeDist">
+      <mean>1</mean>
+      <sigma>0.001</sigma>
+      <lowerBound>0</lowerBound>
+      <upperBound>2</upperBound>
+    </Normal>
+    <Normal name="Gauss2">
+      <mean>1</mean>
+      <sigma>0.4</sigma>
+      <lowerBound>0</lowerBound>
+      <upperBound>2</upperBound>
+    </Normal>
+    <Triangular name="CladFailureDist">
+      <apex>1</apex>
+      <min>-0.1</min>
+      <max>3</max>
+      <!--
+        <lowerBound>0</lowerBound>
+         This is not yet supported
+        <upperBound>2</upperBound>
+        <adjustement>up</adjustement>
+      -->
+    </Triangular>
+  </Distributions>
+
+  <Samplers>
+    <MonteCarlo name="RAVENmc6">
+      <samplerInit>
+        <limit>16</limit>
+      </samplerInit>
+    </MonteCarlo>
+  </Samplers>
+
+  <Steps>
+    <MultiRun name="FirstMPreRun">
+      <Input class="Files" type="">simple_gp_test.i</Input>
+      <Model class="Models" type="Code">MyRAVEN</Model>
+      <Sampler class="Samplers" type="MonteCarlo">RAVENmc6</Sampler>
+      <Output class="DataObjects" type="PointSet">stories</Output>
+      <Output class="OutStreams" type="Print">samples</Output>
+    </MultiRun>
+  </Steps>
+
+  <DataObjects>
+    <PointSet name="stories">
+      <Input>iterations</Input>
+      <Output>delta</Output>
+    </PointSet>
+  </DataObjects>
+
+  <OutStreams>
+    <Print name='samples'>
+      <type>csv</type>
+      <source>stories</source>
+      <what>input,output</what>
+    </Print>
+  </OutStreams>
+
+</Simulation>

--- a/tests/cluster_tests/tests
+++ b/tests/cluster_tests/tests
@@ -71,6 +71,14 @@
    type = RavenFramework
    max_time = 3600
  [../]
+ [./test_mpi_noprecommand]
+   input='test_mpiqsub_noprecommand.xml cluster_runinfo_legacy.xml'
+   run_types = 'qsub'
+   output = 'FirstMPre/FirstMPreRun/1/out~simple_gp_test.csv FirstMPre/FirstMPreRun/6/out~simple_gp_test.csv'
+   output_wait_time = 60
+   type = RavenFramework
+   max_time = 3600
+ [../]
  [./test_mpi_fake]
    input=test_mpi.xml
    skip = 'cluster only test'


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2310

##### What are the significant changes in functionality due to this change request?
Adds the ability to disable the precommand generation of MPI's CustomMode.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

