### PR TITLE
Remove unneccesary print statement

### DIFF
--- a/ravenframework/PluginManager.py
+++ b/ravenframework/PluginManager.py
@@ -38,7 +38,7 @@ class PluginError(RuntimeError):
   pass
 
 ## Method definitions
-def loadPlugins(path, catalogue):
+def loadPlugins(path, catalogue, debug=False):
   """
     Loads plugins and their entities into factory storage.
     @ In, path, str, location of plugins folder
@@ -53,14 +53,15 @@ def loadPlugins(path, catalogue):
       raise PluginError('Installation is corrupted for plugin "{}". Check raven/plugins/plugin_directory.xml and try reinstalling using raven/scripts/intall_plugin')
     if name is None:
       name = os.path.basename(location)
-    print('Loading plugin "{}" at {}'.format(name, location))
+    if debug:
+      print('Loading plugin "{}" at {}'.format(name, location))
     module = loadPluginModule(name, location)
     loadEntities(name, module)
 
 #Stores the name of the plugin, and the (spec, plugin, loaded)
 _delayedPlugins = {}
 
-def loadPluginModule(name, location):
+def loadPluginModule(name, location, debug=False):
   """
     Loads the plugin as a package
     @ In, name, str, name of plugin package
@@ -79,7 +80,8 @@ def loadPluginModule(name, location):
   # load the module
   #Save plugin so spec.loader.exec_module(plugin) can be called later
   _delayedPlugins[name] = (spec, plugin, False)
-  print(' ... successfully imported "{}" ...'.format(name))
+  if debug:
+    print(' ... successfully imported "{}" ...'.format(name))
   return plugin
 
 def finishLoadPlugin(name):


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

#1806

##### What are the significant changes in functionality due to this change request?

There are some unnecessary print statements in `PluginManager.py` that get print when loading certain modules. We shouldn't have side effects like this since RAVEN is being used as an API in the plugins. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

