### PR TITLE
Optimization Path Plot Fix for long strings in ylabel

### DIFF
--- a/ravenframework/OutStreams/PlotInterfaces/OptPath.py
+++ b/ravenframework/OutStreams/PlotInterfaces/OptPath.py
@@ -115,12 +115,14 @@ class OptPath(PlotInterface):
         self.addPoint(ax, r, value, accepted)
         if v == len(self.vars) - 1:
           ax.set_xlabel('Optimizer Iteration')
-        ax.set_ylabel(var)
+        ax.set_title(var)
+    fig.tight_layout()
     # common legend
     fig.subplots_adjust(right=0.80)
     lns = []
     for cond in self.markerMap.keys():
       lns.append(Line2D([0], [0], color=self.markerMap[cond][0], marker=self.markerMap[cond][1]))
+
     fig.legend(lns, list(self.markerMap.keys()),
                loc='center right',
                borderaxespad=0.1,

--- a/ravenframework/OutStreams/PlotInterfaces/OptPath.py
+++ b/ravenframework/OutStreams/PlotInterfaces/OptPath.py
@@ -115,7 +115,7 @@ class OptPath(PlotInterface):
         self.addPoint(ax, r, value, accepted)
         if v == len(self.vars) - 1:
           ax.set_xlabel('Optimizer Iteration')
-        ax.set_title(var)
+        ax.set_ylabel('\n'.join(var.split('_')))
     fig.tight_layout()
     # common legend
     fig.subplots_adjust(right=0.80)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2329 

##### What are the significant changes in functionality due to this change request?
When creating an optimization path plot, var names in the y-label are split by underscores (if they have any) and create a new line for each string. From the linked issue which shows an example of the HERON optimization settings regression test, here is the difference with the new changes in RAVEN:
![1-opt_path](https://github.com/idaholab/raven/assets/109242402/13bb6738-d6cf-46fc-8fb7-a9b3b868f9bf)


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

