### PR TITLE
Arbitrary Custom Input in InputSpec

### DIFF
--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -151,6 +151,7 @@ class ParameterInput(object):
     self.parameterValues = {}
     self.subparts = []
     self.value = ""
+    self.additionalInput = []
 
   @classmethod
   def createClass(cls, name, ordered=False, contentType=None, baseNode=None,
@@ -464,10 +465,12 @@ class ParameterInput(object):
       subs = self.subs
     # read in subnodes
     subNames = set()
+    # loop over each of the nodes in the input and find matches in the defined spec
     for child in node:
       childName = child.tag
       subsSet = self._subDict.get(childName,set())
       foundSubs = 0
+      # loop over defined spec subs and see if there's a match for the input node
       for sub in subsSet:
         if sub._checkCanRead is None:
           subInstance = sub()
@@ -482,6 +485,8 @@ class ParameterInput(object):
       elif self.strictMode:
         allowed = [s.getName() for s in subs]
         handleError(f'Unrecognized input node "{childName}"! Allowed: [{", ".join(allowed)}], tried [{", ".join(subsSet)}]')
+      else:
+        self.additionalInput.append(child)
     if self.strictMode:
       nodeNames = set([child.tag for child in node])
       if nodeNames != subNames:

--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -151,7 +151,7 @@ class ParameterInput(object):
     self.parameterValues = {}
     self.subparts = []
     self.value = ""
-    self.additionalInput = []
+    self.additionalInput = [] # List of raven.utils.TreeStructure.InputNode instances
 
   @classmethod
   def createClass(cls, name, ordered=False, contentType=None, baseNode=None,

--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -148,10 +148,13 @@ class ParameterInput(object):
       create new instance.
       @ Out, None
     """
-    self.parameterValues = {}
-    self.subparts = []
-    self.value = ""
-    self.additionalInput = [] # List of raven.utils.TreeStructure.InputNode instances
+    self.parameterValues = {} # attributes of the hierarchal input, attached to nodes, but not nodes themselves
+    self.subparts = []        # pre-defined nodes that are children of this node
+    self.value = ""           # non-hierarchal value associated with this node
+    # addtionalInput is a List of raven.utils.TreeStructure.InputNode instances. Unlike subparts, these do not have
+    #   a predefined structure, and will not directly be parsed as part of the spec. Only used when
+    #   strictMode is set to False for this node.
+    self.additionalInput = []
 
   @classmethod
   def createClass(cls, name, ordered=False, contentType=None, baseNode=None,

--- a/tests/cluster_tests/AdaptiveSobol/test_adapt_sobol_parallel.xml
+++ b/tests/cluster_tests/AdaptiveSobol/test_adapt_sobol_parallel.xml
@@ -4,8 +4,7 @@
     <WorkingDir>workdir</WorkingDir>
     <Sequence>make,train,print</Sequence>
     <batchSize>3</batchSize>
-    <internalParallel>True</internalParallel>
-    <expectedTime>00:10:00</expectedTime>
+    <expectedTime>00:20:00</expectedTime>
     <JobName>test_qsub</JobName>
     <mode>
       mpi
@@ -14,8 +13,8 @@
   </RunInfo>
 
   <Steps>
-    <MultiRun name="make" pauseAtEnd="False">
-      <Input class="DataObjects" type="PointSet">dummyIN</Input>
+    <MultiRun name="make">
+      <Input class="DataObjects" type="PointSet">placeholder</Input>
       <Model class="Models" type="ExternalModel">poly</Model>
       <Sampler class="Samplers" type="AdaptiveSobol">sobol</Sampler>
       <Output class="DataObjects" type="PointSet">solns</Output>
@@ -65,7 +64,6 @@
   </Samplers>
 
   <Models>
-    <Dummy name="MyDummy" print="True" subType=""/>
     <ExternalModel ModuleToLoad="../multi" name="poly" subType="">
       <inputs>x1,x2,x3,x4</inputs>
       <outputs>ans,ans2</outputs>
@@ -80,10 +78,7 @@
   </Models>
 
   <DataObjects>
-    <PointSet name="dummyIN">
-      <Input>x1,x2,x3,x4</Input>
-      <Output>OutputPlaceHolder</Output>
-    </PointSet>
+    <PointSet name="placeholder"/>
     <PointSet name="solns">
       <Input>x1,x2,x3,x4</Input>
       <Output>ans,ans2</Output>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2331 

##### What are the significant changes in functionality due to this change request?
Setting an InputSpec node's "strict" mode to False allows it to read in any arbitrary input. It does not become part of the spec, but is attached to the non-strict node as an `additionalInput` member. This member is a list of each arbitrary node added to the non-strict node that is not defined already in the InputSpec for the non-strict node. The entries in this list are RAVEN `TreeStructure` elements.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

