### PR TITLE
Fixed multi-word arguments bug in run_tests

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -143,9 +143,8 @@ if [[ $DO_RAVEN == 0 ]]; then
   echo
   echo Running $P tests ...
   # get location of ExamplePlugin test dir
-  ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
+  $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub "${ARGS[@]}"
   # $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --add-non-default-run-types qsub "${ARGS[@]}"
-  $ROOK_COMMAND
   rc=$?
   ALL_PASS=$(($ALL_PASS + $rc))
   if [[ $rc != 0 ]]; then
@@ -171,11 +170,12 @@ if [[ $DO_PLUGINS == 0 ]]; then
     echo
     echo Starting tests for plugin "$P" ...
     # add RAVEN testers to plugin testers
-    ROOK_COMMAND="$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]}"
-    echo Running ROOK command: "$ROOK_COMMAND" ...
+    echo Running ROOK command: "$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]} ..."
     {
       # try
-      $ROOK_COMMAND
+      # this is copy/paste from line 173
+      # saving this command in a string variable causes problems when there are multi-word args using quotes (--arg="con tent") in ARGS
+      $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub "${ARGS[@]}"
       rc=$?
     } || {
       # catch

--- a/run_tests
+++ b/run_tests
@@ -143,7 +143,8 @@ if [[ $DO_RAVEN == 0 ]]; then
   echo
   echo Running $P tests ...
   # get location of ExamplePlugin test dir
-  $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub "${ARGS[@]}"
+  EXTRA="--test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub"
+  $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py $EXTRA "${ARGS[@]}"
   # $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --add-non-default-run-types qsub "${ARGS[@]}"
   rc=$?
   ALL_PASS=$(($ALL_PASS + $rc))
@@ -170,12 +171,13 @@ if [[ $DO_PLUGINS == 0 ]]; then
     echo
     echo Starting tests for plugin "$P" ...
     # add RAVEN testers to plugin testers
-    echo Running ROOK command: "$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub ${ARGS[@]} ..."
+    EXTRA="--test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub"
+    echo Running ROOK command: "$PYTHON_COMMAND $SCRIPT_DIR/rook/main.py $EXTRA ${ARGS[@]} ..."
     {
       # try
-      # this is copy/paste from line 173
-      # saving this command in a string variable causes problems when there are multi-word args using quotes (--arg="con tent") in ARGS
-      $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py --test-dir $LOCATION --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$LOCATION/../src/Testers --add-non-default-run-types qsub "${ARGS[@]}"
+      # this is copy/paste from line 175
+      # saving this entire command in a string variable causes problems when there are multi-word args using quotes (--arg="con tent") in ARGS
+      $PYTHON_COMMAND $SCRIPT_DIR/rook/main.py $EXTRA "${ARGS[@]}"
       rc=$?
     } || {
       # catch


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2338 

##### What are the significant changes in functionality due to this change request?
This change allows `run_tests` to forward command line arguments that contain spaces to rook successfully. Instead of saving the entire command for rook in a string variable, then calling the string variable as a command, this update calls the command directly. In the Plugins section, this requires that the command be repeated (copy/pasted), since in the previous version of `run_tests` the string of the rook command was printed before being called. Functionality should not change for typical `run_tests` usage with this update.

Admittedly, this solution introduces code with suboptimal style. Nevertheless, of all options, this is likely the stylistically best solution that effectively solves the problem. Various alternative solutions were attempted that would not require modifying `run_tests`, including placing the multi-word argument to `run_tests` in single quotes instead of double quotes (e.g. `./run_tests --arg-for-rook='content to be passed to rook'`), escaping double quote characters in the argument to `run_tests` (e.g. `./run_tests --arg-for-rook=\"content to be passed to rook\"`), and escaping space characters in the argument to `run_tests` (e.g. `./run_tests --arg-for-rook="content\ to\ be\ passed\ to\ rook"`). None were effective. 

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

