### PR TITLE
added descriptions to all distribution input specs

### DIFF
--- a/ravenframework/Distributions.py
+++ b/ravenframework/Distributions.py
@@ -106,8 +106,20 @@ class Distribution(BaseEntity, InputDataUser):
         specifying input of cls.
     """
     inputSpecification = super().getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory('upperBound', contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory('lowerBound', contentType=InputTypes.FloatType))
+    inputSpecification.addSub(
+      InputData.parameterInputFactory(
+        'upperBound',
+        descr=r"""the maximum value allowable by this distribution. For distributions that do not traditionally
+          include an upper bound, including this node will truncate (and rebalance the probability) of the distribution,
+          with this value as the maximum value.""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(
+      InputData.parameterInputFactory(
+        'lowerBound',
+        descr=r"""the minimum value allowable by this distribution. For distributions that do not traditionally
+          include a lower bound, including this node will truncate (and rebalance the probability) of the distribution,
+          with this value as the minimum value.""",
+        contentType=InputTypes.FloatType))
     return inputSpecification
 
   def __init__(self):
@@ -514,6 +526,22 @@ class Uniform(BoostDistribution):
     Uniform univariate distribution
   """
 
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, cls, the class for which we are retrieving the specification
+      @ Out, inputSpecification, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    inputSpecification = super(Uniform, cls).getInputSpecification()
+    inputSpecification.description = r"""Classical uniform distribution. The probability density function for the uniform
+      distribution is given by $f(x)=\frac{1}{b-a}$ for $a \le x \le b$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.uniform.html} for more details.
+      """
+    return inputSpecification
+
   def __init__(self, lowerBound=None, upperBound=None):
     """
       Constructor
@@ -636,8 +664,18 @@ class Normal(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Normal, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("mean", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("sigma", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""Classical Gaussian normal distribution. The probability density function for the normal
+      distribution is given by $f(x)=\frac{1}{\sqrt{2\pi\sigma^2}}e^{-\frac{(x-\mu)^2}{2\sigma^2}}$ for $-\infty\leq x \leq \infty$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.norm.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("mean",
+        descr=r"""the distribution mean or expected value. For a standard normal distribution,
+          this is zero. """,
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("sigma",
+        descr=r"""the standard deviation (stdv) of this distribution. For a standard normal distribution,
+          this is one. The variance of this distribution is the square of this value, $\sigma^2$.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -786,9 +824,24 @@ class Gamma(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Gamma, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("low", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("alpha", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("beta", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""Classical gamma distribution. The probability density function for the gamma
+      distribution is given by $f(x,\alpha)=\frac{\beta^{\alpha}x^{\alpha-1}e^{-\beta x}}{\Gamma(\alpha)}$
+      for $x\geq 0,\alpha>0$, and where $\Gamma(\alpha)$ refers to the gamma function.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gamma.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("low",
+        descr=r"""the lower domain value of this distribution. Setting this to a nonzero value will shift the
+          distribution to the left or right. \default{0.0} """,
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("alpha",
+        descr=r"""first shape parameter.
+          See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gamma.html} for more details.  """,
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("beta",
+        descr=r"""rate parameter, also inverse scale parameter.
+          See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gamma.html} for more details. \default{1.0}
+          """,
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -942,11 +995,34 @@ class Beta(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Beta, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("low", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("alpha", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("beta", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("high", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("peakFactor", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""Classical beta distribution. The probability density function for the beta
+      distribution is given by $f(x;\alpha,\beta)=\frac{1}{B(\alpha,\beta)}x^{\alpha-1}(1-x)^{\beta-1}$
+      for $\alpha>0, \beta>0$ and $0 \leq x \leq 1$
+      and $B(\alpha,\beta)=\frac{\Gamma(\alpha)\Gamma(\beta)}{\Gamma(\alpha+\beta)}$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.beta.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("low",
+        descr=r"""the lower domain value of this distribution. Setting this to a nonzero value will shift the
+          distribution to the left or right. \default{0.0} """,
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("high",
+        descr=r"""the upper domain value of this distribution. Setting this to a nonzero value will shift the right side
+          of the distribution to the left or right. \default{0.0} """,
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("alpha",
+        descr=r"""first shape parameter. If specified, \xmlNode{beta} must also be provided, and
+          \xmlNode{peakFactor} cannot be specified.
+          See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.beta.html} for more details. """,
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("beta",
+        descr=r"""second shape parameter. If specified, \xmlNode{alpha} must also be provided, and
+          \xmlNode{peakFactor} cannot be specified.
+          See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.beta.html} for more details. """,
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("peakFactor",
+        descr=r"""alternate shape parameter. If specified, neither \xmlNode{alpha} nor \xmlNode{beta} may be specified.
+          """,
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -1119,9 +1195,20 @@ class Triangular(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Triangular, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("apex", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("min", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("max", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical triangular distribution. The probability density function for the
+      triangular distribution is given by
+      $f(x)=\frac{2(x-a)}{(b-a)(c-a))}$ for $a \le x < c$, and $\frac{2(b-x)}{(b-a)(b-c)}$ for $c< x \le b$, and 0 otherwise.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.triang.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("min",
+        descr=r"""lower domain boundary of this distribution, referred to as $a$ in euqation form.""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("max",
+        descr=r"""upper domain boundary of this distribution, referred to as $b$ in euqation form.""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("apex",
+        descr=r"""location of the peak of the distribution, referred to as $c$ in equation form.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -1237,7 +1324,14 @@ class Poisson(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Poisson, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("mu", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical Poisson discrete distribution. The probability mass function for the
+      Poisson distribution is given by
+      $f(k)=\frac{\mu^k e^{-\mu}}{k!}$ where $k$ is the number of occurances and $\mu$ is the mean.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.poisson.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("mu",
+        descr=r"""mean rate of events/time""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -1331,8 +1425,18 @@ class Binomial(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Binomial, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("n", contentType=InputTypes.IntegerType))
-    inputSpecification.addSub(InputData.parameterInputFactory("p", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical binomial discrete distribution. The probability mass function for the
+      binomial distribution is given by
+      $f(k;n,p)=\binom{n}{k}p^k (1-p)^{n-k}$ where $k$ is the number of occurances, $p$ is the probabilty of occurance,
+      and $n$ is the number of experiments.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binom.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("n",
+        descr=r"""number of experiments or trials.""",
+        contentType=InputTypes.IntegerType))
+    inputSpecification.addSub(InputData.parameterInputFactory("p",
+        descr=r"""probability of occurance, often probability of a success.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -1433,7 +1537,14 @@ class Bernoulli(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Bernoulli, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("p", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical Bournoulli discrete distribution. The probability mass function for the
+      Bernoulli distribution is given by
+      $f(k;p)=p$ if $k=1$ and $f(k;p)=1-p$ if $k=0$, where $k$ is the possible outcomes and $p$ is the probabilty of occurance.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Bernoulli.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("p",
+        descr=r"""probability of occurrance, or success.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -1526,7 +1637,14 @@ class Geometric(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Geometric, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("p", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical geometric discrete distribution. The probability mass function for the
+      geometric distribution is given by
+      $f(k;p)=(1-p)^{k}p$, where $k$ is the possible outcomes and $p$ is the probabilty of occurance.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.geom.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("p",
+        descr=r"""probability of occurrance, or success.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -1617,19 +1735,29 @@ class Categorical(Distribution):
         specifying input of cls.
     """
     inputSpecification = InputData.parameterInputFactory(cls.__name__, ordered=True, baseNode=None)
-
-    StatePartInput = InputData.parameterInputFactory("state", contentType=InputTypes.FloatType)
-    StatePartInput.addParam("outcome", InputTypes.FloatOrStringType, True)
+    inputSpecification.description = r"""classical categorical discrete distribution, sometimes also referred to
+      as a multinomial distribution. The categorical distribution
+      describes the result of a random variable that can have $K$ possible outcome states, with each outcome potentially
+      having a distinct probability. These states can be numbers as well as strings.
+      """
+    StatePartInput = InputData.parameterInputFactory("state",
+        descr=r"""probability of this state's outcome""",
+        contentType=InputTypes.FloatType)
+    StatePartInput.addParam("outcome",
+        InputTypes.FloatOrStringType,
+        True,
+        descr=r"""value of this state's outcome""")
     inputSpecification.addSub(StatePartInput, InputData.Quantity.one_to_infinity)
     inputSpecification.addSub(InputData.parameterInputFactory("rtol",
-                                                              contentType=InputTypes.FloatType,
-                                                              descr=r"""Relative tolerance used to identify close state in case of"""
-                                                              r""" float/int states. Not used for string states!""", default=1e-6))
-
+        contentType=InputTypes.FloatType,
+        descr=r"""Relative tolerance used to identify close states in case of
+          float/int states. Not used for string states!""",
+        default=1e-6))
 
     ## Because we do not inherit from the base class, we need to manually
     ## add the name back in.
-    inputSpecification.addParam("name", InputTypes.StringType, True)
+    inputSpecification.addParam("name", InputTypes.StringType, True,
+        descr=r"""User-defined name to designate this entity in the RAVEN input file.""")
 
     return inputSpecification
 
@@ -2040,14 +2168,29 @@ class MarkovCategorical(Categorical):
         specifying input of cls.
     """
     inputSpecification = InputData.parameterInputFactory(cls.__name__, ordered=True, baseNode=None)
+    inputSpecification.description = r"""Markov categorical discrete distribution. Describes a random variable
+      that can have $K$ possible outcomes, based on the steady state probilities provided by a Markov model.
+      """
 
-    StatePartInput = InputData.parameterInputFactory("state", contentType=InputTypes.StringType)
-    StatePartInput.addParam("outcome", InputTypes.FloatType, True)
-    StatePartInput.addParam("index", InputTypes.IntegerType, True)
-    TransitionInput = InputData.parameterInputFactory("transition", contentType=InputTypes.StringType)
+    StatePartInput = InputData.parameterInputFactory("state",
+        descr=r"""probability of occurrance, or outcome 1.""",
+        contentType=InputTypes.StringType)
+    StatePartInput.addParam("outcome",
+        InputTypes.FloatType,
+        True,
+        descr=r"""value of this outcome""")
+    StatePartInput.addParam("index",
+        InputTypes.IntegerType,
+        True,
+        descr=r"""indexes steady state probabilities corresponding to the transition matrix""")
+    TransitionInput = InputData.parameterInputFactory("transition",
+        descr=r"""transition matrix of the desired Markov model""",
+        contentType=InputTypes.StringType)
     inputSpecification.addSub(StatePartInput, InputData.Quantity.one_to_infinity)
     inputSpecification.addSub(TransitionInput, InputData.Quantity.zero_to_one)
-    inputSpecification.addSub(InputData.parameterInputFactory("workingDir", contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("workingDir",
+        descr=r"""filesystem referential path""",
+        contentType=InputTypes.StringType))
     ## Because we do not inherit from the base class, we need to manually
     ## add the name back in.
     inputSpecification.addParam("name", InputTypes.StringType, True)
@@ -2174,8 +2317,17 @@ class Logistic(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Logistic, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("location", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("scale", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical logistic distribution. The probability density function for the
+      logistic distribution is given by
+      $f(x)=\frac{1}{1+e^{-\frac{x-\lambda}{\sigma}}}$ for $-\infty \leq x < \infty$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.logistic.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("location",
+        descr=r"""location parameter, referred to as $\lambda$ in equation form.""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("scale",
+        descr=r"""scale parameter, referred to as $\sigma$ in equation form.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -2284,8 +2436,17 @@ class Laplace(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Laplace, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("location", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("scale", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical Laplace distribution. The probability density function for the
+      Laplace distribution is given by
+      $f(x)=\frac{1}{2b}e^{-\frac{\left| x-\mu\right| }{b}}$ for $-\infty \leq x \leq \infty$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.laplace.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("location",
+        descr=r"""location parameter, referred to as $\mu$ in equation form.""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("scale",
+        descr=r"""scale parameter, referred to as $b$ in equation form.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -2387,8 +2548,17 @@ class Exponential(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Exponential, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("low", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("lambda", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""classical exponential distribution. The probability density function for the
+      exponential distribution is given by
+      $f(x)=\lambda e^{-\lambda x}$ for $0 \leq x \leq \infty$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.expon.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("low",
+        descr=r"""lower domain boundary for this distribution""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("lambda",
+        descr=r"""rate parameter for this distribution, shown as $\lambda$ in equation form""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -2525,9 +2695,20 @@ class LogNormal(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(LogNormal, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("mean", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("sigma", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("low", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""log-normal distribution. The probability density function for the
+      log-normal distribution is given by
+      $f(x)=\frac{1}{x\sigma\sqrt{2\pi}}e^{-\frac{(\ln{x}-\mu)^2}{2\sigma^2}}$ for $0 \leq x \leq \infty$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("mean",
+        descr=r"""mean of log of the distribution""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("sigma",
+        descr=r"""standard deviation of the log of the distribution""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("low",
+        descr=r"""distribution lower domain boundary""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -2642,9 +2823,20 @@ class Weibull(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Weibull, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("low", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("k", contentType=InputTypes.FloatType))
-    inputSpecification.addSub(InputData.parameterInputFactory("lambda", contentType=InputTypes.FloatType))
+    inputSpecification.description = r"""Weibull distribution. The probability density function for the
+      Weibull distribution is given by
+      $f(x)=\frac{k}{\lambda}\left(\frac{x}{\lambda}\right)^{k-1} e^{-(x/\lambda)^k}$ for $0 \leq x \leq \infty$.
+      See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.weibull_min.html} for more details.
+      """
+    inputSpecification.addSub(InputData.parameterInputFactory("low",
+        descr=r"""distribution lower domain boundary""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("k",
+        descr=r"""shape parameter""",
+        contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("lambda",
+        descr=r"""scale parameter""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -2759,11 +2951,24 @@ class Custom1D(Distribution):
         specifying input of cls.
     """
     inputSpecification = super(Custom1D, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("workingDir", contentType=InputTypes.StringType))
-    inputSpecification.addSub(InputData.parameterInputFactory("functionType", contentType=InputTypes.StringType))
-    inputSpecification.addSub(InputData.parameterInputFactory("dataFilename", contentType=InputTypes.StringType))
-    inputSpecification.addSub(InputData.parameterInputFactory("functionID", contentType=InputTypes.StringType))
-    inputSpecification.addSub(InputData.parameterInputFactory("variableID", contentType=InputTypes.StringType))
+    inputSpecification.description = r"""Custom user-defined distribution. This allows empirically-defined
+        functions that are not currently defined in RAVEN to be used for probability weighting and sampling.
+        The distribution is defined through empirical distribution in a CSV file."""
+    inputSpecification.addSub(InputData.parameterInputFactory("workingDir",
+        descr=r"""relative working directory that contains the input file""",
+        contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("functionType",
+        descr=r"""type of initialization values specifid in the input file (pdf or cdf)""",
+        contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("dataFilename",
+        descr=r"""name of file to be used to initialize the distribution""",
+        contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("functionID",
+        descr=r"""ID of the function associated to the variableID in the input file""",
+        contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("variableID",
+        descr=r"""ID of the variable in the input file""",
+        contentType=InputTypes.StringType))
 
     return inputSpecification
 
@@ -2942,9 +3147,16 @@ class LogUniform(Distribution):
         specifying input of cls.
     """
     inputSpecification = super(LogUniform, cls).getInputSpecification()
+    inputSpecification.description = r"""Log-Uniform distribution. This distribution is associated
+        to a variable $x'$ such that $x = e^{x'}$. Sometimes known as the Reciprocal distribution. The
+        probability density function of this distribution is
+        $f(x)=\frac{1}{x(\ln{b}-\ln{a})}$ for $a \le x \le b$."""
 
     BaseInputType = InputTypes.makeEnumType("base", "baseType", ["natural","decimal"])
-    inputSpecification.addSub(InputData.parameterInputFactory("base"      , BaseInputType))
+    inputSpecification.addSub(InputData.parameterInputFactory("base",
+        BaseInputType,
+        descr=r"""exponent base for scaling the underlying uniform distribution, either "decimal" (base 10) or
+        "natural" base ($e$)."""))
 
     return inputSpecification
 
@@ -3059,7 +3271,9 @@ class NDimensionalDistributions(Distribution):
         specifying input of cls.
     """
     inputSpecification = super(NDimensionalDistributions, cls).getInputSpecification()
-    inputSpecification.addSub(InputData.parameterInputFactory("workingDir", contentType=InputTypes.StringType))
+    inputSpecification.addSub(InputData.parameterInputFactory("workingDir",
+        descr=r"""relative working directory that contains data files""",
+        contentType=InputTypes.StringType))
 
     return inputSpecification
 
@@ -3183,13 +3397,22 @@ class NDInverseWeight(NDimensionalDistributions):
         specifying input of cls.
     """
     inputSpecification = super(NDInverseWeight, cls).getInputSpecification()
-
-
-    DataFilenameParameterInput = InputData.parameterInputFactory("dataFilename", contentType=InputTypes.StringType)
-    DataFilenameParameterInput.addParam("type", InputTypes.StringType, True)
+    inputSpecification.description = r"""Custom user-defined N-diminsional distribution. This allows empirically-defined
+        custom distributions that are not currently defined in RAVEN to be used for probability weighting and sampling.
+        The combined distribution is defined through empirical distribution in a CSV file."""
+    DataFilenameParameterInput = InputData.parameterInputFactory("dataFilename",
+        descr=r"""name of file to be used to initialize the distribution""",
+        contentType=InputTypes.StringType)
+    DataFilenameParameterInput.addParam("type",
+        InputTypes.StringType,
+        True,
+        descr=r"""type of initialization values specifid in the input file (PDF or CDF)""")
     inputSpecification.addSub(DataFilenameParameterInput)
 
-    inputSpecification.addSub(InputData.parameterInputFactory("p", contentType=InputTypes.FloatType))
+    inputSpecification.addSub(InputData.parameterInputFactory("p",
+        descr=r"""power parameter. Greater values of p assign greater influence to values closest to
+          interpolation points.""",
+        contentType=InputTypes.FloatType))
 
     return inputSpecification
 
@@ -3385,9 +3608,17 @@ class NDCartesianSpline(NDimensionalDistributions):
         specifying input of cls.
     """
     inputSpecification = super(NDCartesianSpline, cls).getInputSpecification()
+    inputSpecification.description = r"""describes a N-dimensional distribution given a set of points regularly
+        distributed on a Cartesian grid. These points sample the PDF of the original distribution. Distributed
+        values (PDF or CDF) are calculated using the ND Spline interpolation scheme."""
 
-    DataFilenameParameterInput = InputData.parameterInputFactory("dataFilename", contentType=InputTypes.StringType)
-    DataFilenameParameterInput.addParam("type", InputTypes.StringType, True)
+    DataFilenameParameterInput = InputData.parameterInputFactory("dataFilename",
+        descr=r"""name of file to be used to initialize the distribution""",
+        contentType=InputTypes.StringType)
+    DataFilenameParameterInput.addParam("type",
+        InputTypes.StringType,
+        True,
+        descr=r"""type of initialization values specifid in the input file (PDF or CDF)""")
     inputSpecification.addSub(DataFilenameParameterInput)
 
     return inputSpecification
@@ -3555,14 +3786,33 @@ class MultivariateNormal(NDimensionalDistributions):
       @ Out, inputSpecification, InputData.ParameterInput, class to use for input data.
     """
     inputSpecification = super(MultivariateNormal, cls).getInputSpecification()
+    inputSpecification.description = r"""describes a N-dimensional multivariate Gaussian normal distribution.
+        This generalizes the univariate nurmal distribution to higher dimensions. The multivariate normal
+        distribution is defined by an N-dimensional random vector $\widehat{x}$ and is defined by a multidimensional
+        mean $\widehat{\mu}$ and standard deviation $\Sigma$. The probability density function for this distribution is
+        $f(\widehat{x})=\frac{1}{\sqrt{(2\pi)^k}\left|\Sigma\right| } e^{-\frac{1}{2}(\widehat{x}-\widehat{\mu})^T \Sigma^{-1}(\widehat{x}-\widehat{\mu})}$."""
 
-    MuListParameterInput = InputData.parameterInputFactory("mu", contentType=InputTypes.StringType)
+    MuListParameterInput = InputData.parameterInputFactory("mu",
+        descr=r"""list of mean values for each dimension of the distribution""",
+        contentType=InputTypes.StringType)
 
-    CovarianceListParameterInput = InputData.parameterInputFactory("covariance", contentType=InputTypes.StringType)
-    CovarianceListParameterInput.addParam("type", InputTypes.StringType, False)
+    CovarianceListParameterInput = InputData.parameterInputFactory("covariance",
+        descr=r"""list of covariance values in the covariance matrix. These are specified based on the \xmlAttr{type} parameter""",
+        contentType=InputTypes.StringType)
+    CovarianceListParameterInput.addParam("type",
+        InputTypes.StringType,
+        False,
+        descr=r"""type of covariance. \xmlString{abs} indicates a normal covariance matrix, while \xmlString{rel}
+        indicates a relative covarience matrics.
+        For \xmlNode{transformation}, \xmlString{pca} can be combined with both types, and
+        \xmlString{spline} only accepts \xmlString{abs}\default{abs}""")
 
-    TransformationParameterInput = InputData.parameterInputFactory("transformation")
-    RankParameterInput = InputData.parameterInputFactory("rank", contentType=InputTypes.IntegerType)
+    TransformationParameterInput = InputData.parameterInputFactory("transformation",
+        descr=r"""enables input parameter transformation using principle component analysis (PCA). If enabled,
+        PCA is used on the input covariance matrix with truncation to the specified rank.""")
+    RankParameterInput = InputData.parameterInputFactory("rank",
+        descr=r"""desired dimensionality reduction for covariance matrix""",
+        contentType=InputTypes.IntegerType)
     TransformationParameterInput.addSub(RankParameterInput)
 
     inputSpecification.addSub(MuListParameterInput)
@@ -3570,7 +3820,9 @@ class MultivariateNormal(NDimensionalDistributions):
     inputSpecification.addSub(TransformationParameterInput)
 
     MultivariateMethodType = InputTypes.makeEnumType("multivariateMethod","multivariateMethodType",["pca","spline"])
-    inputSpecification.addParam("method", MultivariateMethodType, True)
+    inputSpecification.addParam("method",
+        MultivariateMethodType,
+        True)
 
     return inputSpecification
 

--- a/ravenframework/Distributions.py
+++ b/ravenframework/Distributions.py
@@ -1201,10 +1201,10 @@ class Triangular(BoostDistribution):
       See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.triang.html} for more details.
       """
     inputSpecification.addSub(InputData.parameterInputFactory("min",
-        descr=r"""lower domain boundary of this distribution, referred to as $a$ in euqation form.""",
+        descr=r"""lower domain boundary of this distribution, referred to as $a$ in equation form.""",
         contentType=InputTypes.FloatType))
     inputSpecification.addSub(InputData.parameterInputFactory("max",
-        descr=r"""upper domain boundary of this distribution, referred to as $b$ in euqation form.""",
+        descr=r"""upper domain boundary of this distribution, referred to as $b$ in equation form.""",
         contentType=InputTypes.FloatType))
     inputSpecification.addSub(InputData.parameterInputFactory("apex",
         descr=r"""location of the peak of the distribution, referred to as $c$ in equation form.""",
@@ -1537,7 +1537,7 @@ class Bernoulli(BoostDistribution):
         specifying input of cls.
     """
     inputSpecification = super(Bernoulli, cls).getInputSpecification()
-    inputSpecification.description = r"""classical Bournoulli discrete distribution. The probability mass function for the
+    inputSpecification.description = r"""classical Bernoulli discrete distribution. The probability mass function for the
       Bernoulli distribution is given by
       $f(k;p)=p$ if $k=1$ and $f(k;p)=1-p$ if $k=0$, where $k$ is the possible outcomes and $p$ is the probabilty of occurance.
       See \url{https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Bernoulli.html} for more details.
@@ -3397,7 +3397,7 @@ class NDInverseWeight(NDimensionalDistributions):
         specifying input of cls.
     """
     inputSpecification = super(NDInverseWeight, cls).getInputSpecification()
-    inputSpecification.description = r"""Custom user-defined N-diminsional distribution. This allows empirically-defined
+    inputSpecification.description = r"""Custom user-defined N-dimensional distribution. This allows empirically-defined
         custom distributions that are not currently defined in RAVEN to be used for probability weighting and sampling.
         The combined distribution is defined through empirical distribution in a CSV file."""
     DataFilenameParameterInput = InputData.parameterInputFactory("dataFilename",
@@ -3787,7 +3787,7 @@ class MultivariateNormal(NDimensionalDistributions):
     """
     inputSpecification = super(MultivariateNormal, cls).getInputSpecification()
     inputSpecification.description = r"""describes a N-dimensional multivariate Gaussian normal distribution.
-        This generalizes the univariate nurmal distribution to higher dimensions. The multivariate normal
+        This generalizes the univariate normal distribution to higher dimensions. The multivariate normal
         distribution is defined by an N-dimensional random vector $\widehat{x}$ and is defined by a multidimensional
         mean $\widehat{\mu}$ and standard deviation $\Sigma$. The probability density function for this distribution is
         $f(\widehat{x})=\frac{1}{\sqrt{(2\pi)^k}\left|\Sigma\right| } e^{-\frac{1}{2}(\widehat{x}-\widehat{\mu})^T \Sigma^{-1}(\widehat{x}-\widehat{\mu})}$."""


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
idaholab/HERON#372

##### What are the significant changes in functionality due to this change request?
Adds the input spec descriptions to all the `Distribution` objects in RAVEN, for use in dynamic manual compiling, particularly in HERON.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

