### PR TITLE
Added support in RAVEN-runs-RAVEN for 'prepend' type <clargs> input

### DIFF
--- a/ravenframework/CodeInterfaceClasses/RAVEN/RAVENInterface.py
+++ b/ravenframework/CodeInterfaceClasses/RAVEN/RAVENInterface.py
@@ -170,9 +170,12 @@ class RAVEN(CodeInterfaceBase):
     outputfile = self.outputPrefix+inputFiles[index].getBase()
     # we set the command type to serial since the SLAVE RAVEN handles the parallel on its own
     # executable command will either be the direct raven_framework, or
-    # executable command will be: "python <path>/raven_framework.py"
+    # executable command will be: "<python> <path>/raven_framework.py"
     # in which case make sure executable ends with .py
     # Note that for raven_framework to work, it needs to be in the path.
+    if clargs["pre"] != '':
+      self.preCommand = clargs["pre"]
+    # TODO: Add support for other clargs
     if executable == 'raven_framework' or executable == '%RAVENEXECUTABLE%':
       self.preCommand = ''
     elif not executable.endswith(".py"):


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2348 

##### What are the significant changes in functionality due to this change request?
This request adds support in the `RAVENInterface` for a `<clargs type="prepend" ...>` subnode to the `<Models>.<Code>` node when running RAVEN-runs-RAVEN. Previously, the only python command that could be used for running `raven_framework.py` on the inner xml was `python`. Now users may add a `<clargs>` node to the outer RAVEN input xml to specify a custom python command with which to run the inner. See the issue linked above for an explanation of the use case for which this change is required.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

