### PR TITLE
update libs

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -60,7 +60,7 @@ Note all install methods after "main" take
     <lxml/>
     <psutil/>
     <pip/>
-    <pyDOE3/>
+    <pyDOE3 source="pip"/>
     <importlib_metadata/>
     <pyside2 optional='True'/>
     <nomkl os='linux' skip_check='True'/>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -91,6 +91,7 @@ Note all install methods after "main" take
     <serpentTools optional='True' source="pip"/>
     <pydmd source="pip"/>
     <ezyrb source="pip"/>
+    <torch source="pip">2.1.2</torch>
   </main>
   <alternate name="pip">
     <hdf5>remove</hdf5>

--- a/dependencies.xml
+++ b/dependencies.xml
@@ -90,8 +90,6 @@ Note all install methods after "main" take
     <mamba source="mamba" skip_check='True'/>
     <serpentTools optional='True' source="pip"/>
     <pydmd source="pip"/>
-    <ezyrb source="pip"/>
-    <torch source="pip">2.1.2</torch>
   </main>
   <alternate name="pip">
     <hdf5>remove</hdf5>

--- a/ravenframework/SupervisedLearning/DMD/DMDBase.py
+++ b/ravenframework/SupervisedLearning/DMD/DMDBase.py
@@ -236,7 +236,7 @@ class DMDBase(SupervisedLearning):
       @ Out, None
     """
     from pydmd import ParametricDMD
-    from ezyrb import POD, RBF, GPR
+    from ...contrib.ezyrb import POD, RBF, GPR
 
     assert(self._dmdBase is not None)
     self.dmdParams = dmdParams

--- a/ravenframework/contrib/ezyrb/__init__.py
+++ b/ravenframework/contrib/ezyrb/__init__.py
@@ -1,0 +1,11 @@
+""" EZyRB modules """
+
+__all__ = [
+    'GPR',
+    'POD',
+    'RBF'
+]
+
+from .pod import POD
+from .gpr import GPR
+from .rbf import RBF

--- a/ravenframework/contrib/ezyrb/approximation.py
+++ b/ravenframework/contrib/ezyrb/approximation.py
@@ -1,0 +1,42 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2016-2018 by EZyRB contributors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Adapted from https://github.com/mathLab/EZyRB
+
+"""Module for the Approximation abstract class"""
+
+from abc import ABC, abstractmethod
+
+
+class Approximation(ABC):
+    """
+    The abstract `Approximation` class.
+
+    All the classes that implement the input-output mapping should be inherited
+    from this class.
+    """
+    @abstractmethod
+    def fit(self, points, values):
+        """Abstract `fit`"""
+
+    @abstractmethod
+    def predict(self, new_point):
+        """Abstract `predict`"""

--- a/ravenframework/contrib/ezyrb/gpr.py
+++ b/ravenframework/contrib/ezyrb/gpr.py
@@ -1,0 +1,137 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2016-2018 by EZyRB contributors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Adapted from https://github.com/mathLab/EZyRB
+
+"""
+Module wrapper exploiting `GPy` for Gaussian Process Regression
+"""
+import numpy as np
+from scipy.optimize import minimize
+from sklearn.gaussian_process import GaussianProcessRegressor
+
+from .approximation import Approximation
+
+
+class GPR(Approximation):
+    """
+    Multidimensional regression using Gaussian process.
+
+    :cvar numpy.ndarray X_sample: the array containing the input points,
+        arranged by row.
+    :cvar numpy.ndarray Y_sample: the array containing the output values,
+        arranged by row.
+    :cvar sklearn.gaussian_process.GaussianProcessRegressor model: the
+        regression model.
+    :cvar sklearn.gaussian_process.kernels.Kernel kern: kernel object from
+        sklearn.
+    :cvar bool normalizer: whether to normilize `values` or not.  Defaults to
+        True.
+    :cvar int optimization_restart: number of restarts for the optimization.
+        Defaults to 20.
+
+    :Example:
+
+        >>> import ezyrb
+        >>> import numpy as np
+        >>> x = np.random.uniform(-1, 1, size=(4, 2))
+        >>> y = (np.sin(x[:, 0]) + np.cos(x[:, 1]**3)).reshape(-1, 1)
+        >>> gpr = ezyrb.GPR()
+        >>> gpr.fit(x, y)
+        >>> y_pred = gpr.predict(x)
+        >>> print(np.allclose(y, y_pred))
+
+    """
+    def __init__(self, kern=None, normalizer=True, optimization_restart=20):
+
+        self.X_sample = None
+        self.Y_sample = None
+        self.kern = kern
+        self.normalizer = normalizer  # TODO: avoid normalizer inside GPR class
+        self.optimization_restart = optimization_restart
+        self.model = None
+
+    def fit(self, points, values):
+        """
+        Construct the regression given `points` and `values`.
+
+        :param array_like points: the coordinates of the points.
+        :param array_like values: the values in the points.
+        """
+        self.X_sample = np.array(points)
+        self.Y_sample = np.array(values)
+        if self.X_sample.ndim == 1:
+            self.X_sample = self.X_sample.reshape(-1, 1)
+        if self.Y_sample.ndim == 1:
+            self.Y_sample = self.Y_sample.reshape(-1, 1)
+
+        self.model = GaussianProcessRegressor(
+            kernel=self.kern, n_restarts_optimizer=self.optimization_restart,
+            normalize_y=self.normalizer)
+        self.model.fit(self.X_sample, self.Y_sample)
+
+    def predict(self, new_points, return_variance=False):
+        """
+        Predict the mean and the variance of Gaussian distribution at given
+        `new_points`.
+
+        :param array_like new_points: the coordinates of the given points.
+        :param bool return_variance: flag to return also the variance.
+            Default is False.
+        :return: the mean and the variance
+        :rtype: (numpy.ndarray, numpy.ndarray)
+        """
+        new_points = np.atleast_2d(new_points)
+        return self.model.predict(new_points, return_std=return_variance)
+
+    def optimal_mu(self, bounds, optimization_restart=10):
+        """
+        Proposes the next sampling point by looking at the point where the
+        Gaussian covariance is maximized. A gradient method (with multi
+        starting points) is adopted for the optimization.
+
+        :param numpy.ndarray bounds: the boundaries in the gradient
+            optimization. The shape must be (*input_dim*, 2), where *input_dim*
+            is the dimension of the input points.
+        :param int optimization_restart: the number of restart in the gradient
+            optimization. Default is 10.
+        """
+        dim = self.X_sample.shape[1]
+        min_val = 1
+        min_x = None
+
+        def min_obj(X):
+            return -1 * np.linalg.norm(self.predict(X.reshape(1, -1), True)[1])
+
+        initial_starts = np.random.uniform(bounds[:, 0],
+                                           bounds[:, 1],
+                                           size=(optimization_restart, dim))
+
+        # Find the best optimum by starting from n_restart different random
+        # points.
+        for x0 in initial_starts:
+            res = minimize(min_obj, x0, bounds=bounds, method='L-BFGS-B')
+
+            if res.fun < min_val:
+                min_val = res.fun
+                min_x = res.x
+
+        return min_x.reshape(1, -1)

--- a/ravenframework/contrib/ezyrb/pod.py
+++ b/ravenframework/contrib/ezyrb/pod.py
@@ -33,45 +33,45 @@ from .reduction import Reduction
 
 
 class POD(Reduction):
+    """
+    Perform the Proper Orthogonal Decomposition.
+
+    :param method: the implementation to use for the computation of the POD
+        modes. Default is 'svd'.
+    :type method: {'svd', 'randomized_svd', 'correlation_matrix'}
+    :param rank: the rank for the truncation; If 0, the method computes
+        the optimal rank and uses it for truncation; if positive interger,
+        the method uses the argument for the truncation; if float between 0
+        and 1, the rank is the number of the biggest singular values that
+        are needed to reach the 'energy' specified by `svd_rank`; if -1,
+        the method does not compute truncation. Default is 0. The `rank`
+        parameter is available using all the available methods.
+    :type rank: int or float
+    :param int subspace_iteration: the number of subspace iteration in the
+        randomized svd. It is available only using the 'randomized_svd'
+        method. Default value is 1.
+    :param int omega_rank: the number of columns of the Omega random
+        matrix. If set to 0, the number of columns is equal to twice the
+        `rank` (if it has explicitly passed as integer) or twice the number
+        of input snapshots. Default value is 0. It is available only using
+        the 'randomized_svd' method.
+    :param bool save_memory: reduce the usage of the memory, despite an
+        higher number of operations. It is available only using the
+        'correlation_matrix' method. Default value is False.
+
+
+    :Example:
+        >>> pod = POD().fit(snapshots)
+        >>> reduced_snapshots = pod.reduce(snapshots)
+        >>> # Other possible constructors are ...
+        >>> pod = POD('svd')
+        >>> pod = POD('svd', rank=20)
+        >>> pod = POD('randomized_svd', rank=-1)
+        >>> pod = POD('randomized_svd', rank=0, subspace_iteration=3,
+                        omega_rank=10)
+        >>> pod = POD('correlation_matrix', rank=10, save_memory=False)
+    """
     def __init__(self, method='svd', **kwargs):
-        """
-        Perform the Proper Orthogonal Decomposition.
-
-        :param method: the implementation to use for the computation of the POD
-            modes. Default is 'svd'.
-        :type method: {'svd', 'randomized_svd', 'correlation_matrix'}
-        :param rank: the rank for the truncation; If 0, the method computes
-            the optimal rank and uses it for truncation; if positive interger,
-            the method uses the argument for the truncation; if float between 0
-            and 1, the rank is the number of the biggest singular values that
-            are needed to reach the 'energy' specified by `svd_rank`; if -1,
-            the method does not compute truncation. Default is 0. The `rank`
-            parameter is available using all the available methods.
-        :type rank: int or float
-        :param int subspace_iteration: the number of subspace iteration in the
-            randomized svd. It is available only using the 'randomized_svd'
-            method. Default value is 1.
-        :param int omega_rank: the number of columns of the Omega random
-            matrix. If set to 0, the number of columns is equal to twice the
-            `rank` (if it has explicitly passed as integer) or twice the number
-            of input snapshots. Default value is 0. It is available only using
-            the 'randomized_svd' method.
-        :param bool save_memory: reduce the usage of the memory, despite an
-            higher number of operations. It is available only using the
-            'correlation_matrix' method. Default value is False.
-
-
-        :Example:
-            >>> pod = POD().fit(snapshots)
-            >>> reduced_snapshots = pod.reduce(snapshots)
-            >>> # Other possible constructors are ...
-            >>> pod = POD('svd')
-            >>> pod = POD('svd', rank=20)
-            >>> pod = POD('randomized_svd', rank=-1)
-            >>> pod = POD('randomized_svd', rank=0, subspace_iteration=3,
-                          omega_rank=10)
-            >>> pod = POD('correlation_matrix', rank=10, save_memory=False)
-        """
         available_methods = {
             'svd': (self._svd, {
                 'rank': -1

--- a/ravenframework/contrib/ezyrb/pod.py
+++ b/ravenframework/contrib/ezyrb/pod.py
@@ -1,0 +1,291 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2016-2018 by EZyRB contributors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Adapted from https://github.com/mathLab/EZyRB
+
+"""
+Module for Proper Orthogonal Decomposition (POD).
+Three different methods can be employed: Truncated Singular Value
+Decomposition, Truncated Randomized Singular Value Decomposition, Truncated
+Singular Value Decomposition via correlation matrix.
+"""
+import numpy as np
+
+from .reduction import Reduction
+
+
+class POD(Reduction):
+    def __init__(self, method='svd', **kwargs):
+        """
+        Perform the Proper Orthogonal Decomposition.
+
+        :param method: the implementation to use for the computation of the POD
+            modes. Default is 'svd'.
+        :type method: {'svd', 'randomized_svd', 'correlation_matrix'}
+        :param rank: the rank for the truncation; If 0, the method computes
+            the optimal rank and uses it for truncation; if positive interger,
+            the method uses the argument for the truncation; if float between 0
+            and 1, the rank is the number of the biggest singular values that
+            are needed to reach the 'energy' specified by `svd_rank`; if -1,
+            the method does not compute truncation. Default is 0. The `rank`
+            parameter is available using all the available methods.
+        :type rank: int or float
+        :param int subspace_iteration: the number of subspace iteration in the
+            randomized svd. It is available only using the 'randomized_svd'
+            method. Default value is 1.
+        :param int omega_rank: the number of columns of the Omega random
+            matrix. If set to 0, the number of columns is equal to twice the
+            `rank` (if it has explicitly passed as integer) or twice the number
+            of input snapshots. Default value is 0. It is available only using
+            the 'randomized_svd' method.
+        :param bool save_memory: reduce the usage of the memory, despite an
+            higher number of operations. It is available only using the
+            'correlation_matrix' method. Default value is False.
+
+
+        :Example:
+            >>> pod = POD().fit(snapshots)
+            >>> reduced_snapshots = pod.reduce(snapshots)
+            >>> # Other possible constructors are ...
+            >>> pod = POD('svd')
+            >>> pod = POD('svd', rank=20)
+            >>> pod = POD('randomized_svd', rank=-1)
+            >>> pod = POD('randomized_svd', rank=0, subspace_iteration=3,
+                          omega_rank=10)
+            >>> pod = POD('correlation_matrix', rank=10, save_memory=False)
+        """
+        available_methods = {
+            'svd': (self._svd, {
+                'rank': -1
+            }),
+            'randomized_svd': (self._rsvd, {
+                'rank': -1,
+                'subspace_iteration': 1,
+                'omega_rank': 0
+            }),
+            'correlation_matrix': (self._corrm, {
+                'rank': -1,
+                'save_memory': False
+            }),
+        }
+
+        self._modes = None
+        self._singular_values = None
+
+        method = available_methods.get(method)
+        if method is None:
+            raise RuntimeError(
+                f"Invalid method for POD. Please chose one among {', '.join(available_methods)}"
+            )
+
+        self.__method, args = method
+        args.update(kwargs)
+
+        for hyperparam, value in args.items():
+            setattr(self, hyperparam, value)
+
+    @property
+    def modes(self):
+        """
+        The POD modes.
+
+        :type: numpy.ndarray
+        """
+        return self._modes
+
+    @property
+    def singular_values(self):
+        """
+        The singular values
+
+        :type: numpy.ndarray
+        """
+        return self._singular_values
+
+    def fit(self, X):
+        """
+        Create the reduced space for the given snapshots `X` using the
+        specified method
+
+        :param numpy.ndarray X: the input snapshots matrix (stored by column)
+        """
+        self._modes, self._singular_values = self.__method(X)
+        return self
+
+    def transform(self, X):
+        """
+        Reduces the given snapshots.
+
+        :param numpy.ndarray X: the input snapshots matrix (stored by column).
+        """
+        return self.modes.T.conj().dot(X)
+
+    def inverse_transform(self, X):
+        """
+        Projects a reduced to full order solution.
+
+        :type: numpy.ndarray
+        """
+        return self.modes.dot(X)
+
+    def reduce(self, X):
+        """
+        Reduces the given snapshots.
+
+        :param numpy.ndarray X: the input snapshots matrix (stored by column).
+
+        .. note::
+
+            Same as `transform`. Kept for backward compatibility.
+        """
+        return self.transform(X)
+
+    def expand(self, X):
+        """
+        Projects a reduced to full order solution.
+
+        :type: numpy.ndarray
+
+        .. note::
+
+            Same as `inverse_transform`. Kept for backward compatibility.
+        """
+        return self.inverse_transform(X)
+
+    def _truncation(self, X, s):
+        """
+        Return the number of modes to select according to the `rank` parameter.
+        See POD.__init__ for further info.
+
+        :param numpy.ndarray X: the matrix to decompose.
+        :param numpy.ndarray s: the singular values of X.
+
+        :return: the number of modes
+        :rtype: int
+        """
+        def omega(x):
+            return 0.56 * x**3 - 0.95 * x**2 + 1.82 * x + 1.43
+
+        if self.rank == 0:
+            beta = np.divide(*sorted(X.shape))
+            tau = np.median(s) * omega(beta)
+            rank = np.sum(s > tau)
+        elif self.rank > 0 and self.rank < 1:
+            cumulative_energy = np.cumsum(s**2 / (s**2).sum())
+            rank = np.searchsorted(cumulative_energy, self.rank) + 1
+        elif self.rank >= 1 and isinstance(self.rank, int):
+            rank = self.rank
+        else:
+            rank = X.shape[1]
+
+        return rank
+
+    def _svd(self, X):
+        """
+        Truncated Singular Value Decomposition.
+
+        :param numpy.ndarray X: the matrix to decompose.
+        :return: the truncated left-singular vectors matrix, the truncated
+            singular values array, the truncated right-singular vectors matrix.
+        :rtype: numpy.ndarray, numpy.ndarray, numpy.ndarray
+
+        References:
+        Gavish, Matan, and David L. Donoho, The optimal hard threshold for
+        singular values is, IEEE Transactions on Information Theory 60.8
+        (2014): 5040-5053.
+        """
+        U, s = np.linalg.svd(X, full_matrices=False)[:2]
+
+        rank = self._truncation(X, s)
+        return U[:, :rank], s[:rank]
+
+    def _rsvd(self, X):
+        """
+        Truncated randomized Singular Value Decomposition.
+
+        :param numpy.ndarray X: the matrix to decompose.
+        :return: the truncated left-singular vectors matrix, the truncated
+            singular values array, the truncated right-singular vectors matrix.
+        :rtype: numpy.ndarray, numpy.ndarray, numpy.ndarray
+
+        References:
+        Finding structure with randomness: probabilistic algorithms for
+        constructing approximate matrix decompositions. N. Halko, P. G.
+        Martinsson, J. A. Tropp.
+        """
+        if (self.omega_rank == 0 and isinstance(self.rank, int)
+                and self.rank not in [0, -1]):
+            omega_rank = self.rank * 2
+        elif self.omega_rank == 0:
+            omega_rank = X.shape[1] * 2
+        else:
+            omega_rank = self.omega_rank
+        Omega = np.random.rand(X.shape[1], omega_rank)
+
+        Y = np.dot(X, Omega)
+        Q = np.linalg.qr(Y)[0]
+
+        if self.subspace_iteration:
+            for _ in range(self.subspace_iteration):
+                Y_ = np.dot(X.T.conj(), Q)
+                Q_ = np.linalg.qr(Y_)[0]
+                Y = np.dot(X, Q_)
+                Q = np.linalg.qr(Y)[0]
+
+        B = np.dot(Q.T.conj(), X)
+        Uy, s = np.linalg.svd(B, full_matrices=False)[:2]
+        U = Q.dot(Uy)
+
+        rank = self._truncation(X, s)
+        return U[:, :rank], s[:rank]
+
+    def _corrm(self, X):
+        """
+        Truncated POD calculated with correlation matrix.
+
+        :param numpy.ndarray X: the matrix to decompose.
+        :return: the truncated left-singular vectors matrix, the truncated
+            singular values array, the truncated right-singular vectors matrix.
+        :rtype: numpy.ndarray, numpy.ndarray, numpy.ndarray
+        """
+
+        if self.save_memory:
+            corr = np.empty(shape=(X.shape[1], X.shape[1]))
+            for i, i_snap in enumerate(X.T):
+                for j, k_snap in enumerate(X.T):
+                    corr[i, j] = np.inner(i_snap, k_snap)
+
+        else:
+            corr = X.T.dot(X)
+
+        eigs, eigv = np.linalg.eigh(corr)
+
+        ordered_idx = np.argsort(eigs)[::-1]
+        eigs = eigs[ordered_idx]
+        eigv = eigv[:, ordered_idx]
+        s = np.sqrt(eigs[eigs > 0])
+        rank = self._truncation(X, s)
+
+        # compute modes
+        eigv = eigv[:, eigs > 0]
+        U = X.dot(eigv) / s
+
+        return U[:, :rank], s[:rank]

--- a/ravenframework/contrib/ezyrb/rbf.py
+++ b/ravenframework/contrib/ezyrb/rbf.py
@@ -1,0 +1,117 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2016-2018 by EZyRB contributors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Adapted from https://github.com/mathLab/EZyRB
+
+"""Module for Radial Basis Function Interpolation."""
+
+import numpy as np
+from scipy.interpolate import RBFInterpolator
+from .approximation import Approximation
+
+
+class RBF(Approximation):
+    """
+    Multidimensional interpolator using Radial Basis Function.
+
+    :param kernel: The radial basis function; the default is ‘multiquadric’.
+    :type kernel: str or callable
+    :param float smooth: values greater than zero increase the smoothness of
+        the approximation. 0 is for interpolation (default), the function will
+        always go through the nodal points in this case.
+    :param int neighbors: if specified, the value of the interpolant at each
+        evaluation point will be computed using only the nearest data points.
+        If None (default), all the data points are used by default.
+    :param float epsilon: Shape parameter that scales the input to the RBF.
+        If kernel is ‘linear’, ‘thin_plate_spline’, ‘cubic’, or ‘quintic’, this
+        defaults to 1 and can be ignored. Otherwise, this must be specified.
+    :param int degree: Degree of the added polynomial. The default value is
+        the minimum degree for kernel or 0 if there is no minimum degree.
+
+    :cvar kernel: The radial basis function; the default is ‘multiquadric’.
+    :cvar interpolator: the RBF interpolator
+
+    :Example:
+
+         >>> import ezyrb
+         >>> import numpy as np
+         >>>
+         >>> x = np.random.uniform(-1, 1, size=(4, 2))
+         >>> y = np.array([np.sin(x[:, 0]), np.cos(x[:, 1]**3)]).T
+         >>> rbf = ezyrb.RBF()
+         >>> rbf.fit(x, y)
+         >>> y_pred = rbf.predict(x)
+         >>> print(np.allclose(y, y_pred))
+
+    """
+    def __init__(self,
+                 kernel='thin_plate_spline',
+                 smooth=0,
+                 neighbors=None,
+                 epsilon=None,
+                 degree=None):
+        self.kernel = kernel
+        self.smooth = smooth
+        self.neighbors = neighbors
+        self.degree = degree
+        self.epsilon = epsilon
+        self.interpolator = None
+        self.xi = None
+
+    def fit(self, points, values):
+        """
+        Construct the interpolator given `points` and `values`.
+
+        :param array_like points: the coordinates of the points.
+        :param array_like values: the values in the points.
+        """
+        self.xi = np.asarray(points)
+
+        if self.epsilon is None:
+            # default epsilon is the "the average distance between nodes" based
+            # on a bounding hypercube
+            N = self.xi.shape[-1]
+            ximax = np.amax(self.xi, axis=0)
+            ximin = np.amin(self.xi, axis=0)
+            edges = ximax - ximin
+            edges = edges[np.nonzero(edges)]
+            self.epsilon = np.power(np.prod(edges)/N, 1.0/edges.size)
+            if self.kernel in ['thin_plate_spline', 'cubic', 'quintic']:
+                self.epsilon = 1
+
+        self.interpolator = RBFInterpolator(
+            points,
+            values,
+            neighbors=self.neighbors,
+            smoothing=self.smooth,
+            kernel=self.kernel,
+            epsilon=self.epsilon,
+            degree=self.degree)
+
+    def predict(self, new_point):
+        """
+        Evaluate interpolator at given `new_points`.
+
+        :param array_like new_points: the coordinates of the given points.
+        :return: the interpolated values.
+        :rtype: numpy.ndarray
+        """
+        return self.interpolator(np.asarray(new_point))

--- a/ravenframework/contrib/ezyrb/reduction.py
+++ b/ravenframework/contrib/ezyrb/reduction.py
@@ -1,0 +1,46 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2016-2018 by EZyRB contributors.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+# FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Adapted from https://github.com/mathLab/EZyRB
+
+"""Module for the Reduction abstract class."""
+
+from abc import ABC, abstractmethod
+
+
+class Reduction(ABC):
+    """
+    The abstract `Approximation` class.
+
+    All the classes that implement the input-output mapping should be inherited
+    from this class.
+    """
+    @abstractmethod
+    def fit(self):
+        """Abstract `fit`"""
+
+    @abstractmethod
+    def transform(self):
+        """Abstract `transform`"""
+
+    @abstractmethod
+    def inverse_transform(self):
+        """Abstract `inverse_transform`"""

--- a/scripts/plugin_handler.py
+++ b/scripts/plugin_handler.py
@@ -44,7 +44,7 @@ except impErr:
 
 # globals
 ravenConfigName = '.ravenconfig.xml'
-requiredDirs = ['src', 'doc', 'tests']
+requiredDirs = ['src', 'doc|docs', 'tests']
 pluginTreeFile = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'plugins', 'plugin_directory.xml'))
 
 def checkValidPlugin(rawLoc):
@@ -67,13 +67,14 @@ def checkValidPlugin(rawLoc):
     # check for source, doc, tests dirs
     missing = []
     for needDir in requiredDirs:
-      fullDir = os.path.join(loc, needDir)
-      if not os.path.isdir(fullDir):
+      needDirList = needDir.split('|')
+      validDirList = [os.path.isdir(os.path.join(loc, testDir)) for testDir in needDirList]
+      if sum(validDirList) == 0:
         missing.append(needDir)
     if missing:
       okay = False
       for m in missing:
-        msgs.append('Required directory missing in {}: {}'.format(fullDir, m))
+        msgs.append('Required directory missing in {}: {}'.format(loc, m))
 
   return okay, msgs, loc
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
close #2376 

Switch 'pip' to install pyDOE3 since pyDOE3 is not available in latest ubuntu machine. 

##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

