### PR TITLE
Moved Unittest tester from FORCE

### DIFF
--- a/scripts/TestHarness/testers/RavenUnittest.py
+++ b/scripts/TestHarness/testers/RavenUnittest.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+from RavenPython import RavenPython
+
+try:
+  import unittest
+  unittest_found = True
+except ModuleNotFoundError or ImportError:
+  unittest_found = False
+
+class Unittest(RavenPython):
+  """
+  This class simplifies use of the unittest module for running unit tests through rook.
+  """
+
+  @staticmethod
+  def get_valid_params():
+    """
+      Return a list of valid parameters and their descriptions for this type
+      of test.
+      @ In, None
+      @ Out, params, _ValidParameters, the parameters for this class.
+    """
+    params = RavenPython.get_valid_params()
+    # 'input' param can be test case or test suite; unittest will handle either when called
+    params.add_param('unittest_args', '', "Arguments to the unittest module")
+    return params
+  
+  def __init__(self, name, params):
+    """
+      Initializer for the class. Takes a String name and a dictionary params
+      @ In, name, string, name of the test.
+      @ In, params, dictionary, parameters for the class
+      @ Out, None.
+    """
+    RavenPython.__init__(self, name, params)
+    
+  def check_runnable(self):
+    """
+      Checks if this test can be run.
+      @ In, None
+      @ Out, check_runnable, boolean, If True can run this test.
+    """
+    if not unittest_found:
+      self.set_skip('skipped (required unittest module is not found)')
+      return False
+    
+    return RavenPython.check_runnable(self)
+  
+  def get_command(self):
+    """
+      returns the command used by this tester.
+      @ In, None
+      @ Out, get_command, string, command to run.
+    """
+    # If the test command has been specified, use it
+    if (command := self._get_test_command()) is not None:
+      return ' '.join([command, '-m unittest', self.specs["unittest_args"], self.specs["input"]])
+
+    # Otherwise, if the python command has been specified, use it
+    if len(self.specs["python_command"]) == 0:
+      pythonCommand = self._get_python_command()
+    else:
+      pythonCommand = self.specs["python_command"]
+    return ' '.join([pythonCommand, '-m unittest', self.specs["unittest_args"], self.specs["input"]])


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2381 

##### What are the significant changes in functionality due to this change request?
This adds a tester to specifically deal with running tests through rook that use the unittest module. It was initially created in FORCE (see [https://github.com/idaholab/FORCE/pull/35](url)).

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

