### PR TITLE
Workaround Windows issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "plugins/LOGOS"]
 	path = plugins/LOGOS
 	url = https://github.com/idaholab/LOGOS.git
-[submodule "plugins/SRAW"]
-	path = plugins/SRAW
-	url = git@hpcgitlab.hpc.inl.gov:RAVEN_PLUGINS/SRAW.git
 [submodule "plugins/FARM"]
 	path = plugins/FARM
 	url = https://github.com/Argonne-National-Laboratory/FARM.git

--- a/rook/main.py
+++ b/rook/main.py
@@ -68,6 +68,8 @@ class NoColors:
 parser = argparse.ArgumentParser(description="Test Runner")
 parser.add_argument('-j', '--jobs', dest='number_jobs', type=int, default=1,
                     help='Specifies number of tests to run simultaneously (default: 1)')
+parser.add_argument('--longest-jobs',dest='longest_jobs', type=int, default=0,
+                    help='Only for compatibility')
 parser.add_argument('--re', dest='test_re_raw', default='.*',
                     help='Only tests with this regular expression inside will be run')
 parser.add_argument('-l', dest='load_average', type=float, default=-1.0,

--- a/tests/framework/InternalParallelTests/tests
+++ b/tests/framework/InternalParallelTests/tests
@@ -13,6 +13,7 @@
   type = 'RavenFramework'
   input = 'test_internal_parallel_extModelRay.xml'
   UnorderedCsv = 'InternalParallelExtModelRay/testPointSet_dump.csv'
+  skip_if_OS = windows
  [../]
  [./PostProcessor]
   type = 'RavenFramework'

--- a/tests/framework/ROM/TimeSeries/MultiResolutionTSA/tests
+++ b/tests/framework/ROM/TimeSeries/MultiResolutionTSA/tests
@@ -19,6 +19,7 @@
   [./multiYearDWT]
     type = 'RavenFramework'
     input = 'multiYearDWT.xml'
+    skip_if_OS = windows
     [./csv]
       type = OrderedCSV
       output = 'MultiYearDWT/samples.csv'


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2399 

##### What are the significant changes in functionality due to this change request?
This works around two windows issues.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

