### PR TITLE
Letting dependencies float.

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -38,17 +38,17 @@ Note all install methods after "main" take
 <dependencies>
   <main>
     <h5py/>
-    <numpy>1.24</numpy>
-    <scipy>1.9</scipy>
-    <scikit-learn>1.0</scikit-learn>
+    <numpy/>
+    <scipy/>
+    <scikit-learn/>
     <pandas/>
     <!-- Note most versions of xarray work, but some (such as 0.20) don't -->
-    <xarray>2023</xarray>
-    <netcdf4 source="pip">1.6</netcdf4>
-    <matplotlib>3.5</matplotlib>
-    <statsmodels>0.13</statsmodels>
+    <xarray/>
+    <netcdf4 source="pip"/>
+    <matplotlib/>
+    <statsmodels/>
     <cloudpickle/>
-    <tensorflow source="pip">2.13</tensorflow>
+    <tensorflow source="pip"/>
     <grpcio source="pip" />
     <!-- conda is really slow on windows if the version is not specified.-->
     <python skip_check='True' os='windows'>3.10</python>
@@ -66,24 +66,24 @@ Note all install methods after "main" take
     <nomkl os='linux' skip_check='True'/>
     <cmake skip_check='True' optional='True'/>
     <dask source="pip" pip_extra="[complete]"/>
-    <ray source="pip" pip_extra="[default]">2.6</ray>
+    <ray source="pip" pip_extra="[default]"/>
     <!-- redis is needed by ray, but on windows, this seems to need to be explicitly stated -->
-    <redis source="pip" os='windows'/>
-    <imageio source="pip">2.22</imageio>
+    <!-- <redis source="pip" os='windows'/> -->
+    <imageio source="pip"/>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->
     <statsforecast/>
-    <pywavelets>1.2</pywavelets>
+    <pywavelets/>
     <python-sensors source="pip"/>
-    <numdifftools source="pip">0.9</numdifftools>
+    <numdifftools source="pip"/>
     <fmpy optional='True'/>
     <xmlschema source="pip"/>
-    <pyomo optional='True'>6.4</pyomo>
+    <pyomo optional='True'/>
     <glpk skip_check='True' optional='True'/>
     <ipopt skip_check='True' optional='True'/>
     <cyipopt optional='True'/>
     <pyomo-extensions source="pyomo" skip_check='True' optional='True'/>
-    <setuptools>69</setuptools> <!-- ray 2.6 can't be installed with setuptools 70 -->
+    <!-- <setuptools>69</setuptools> --> <!-- ray 2.6 can't be installed with setuptools 70 -->
     <!-- source="mamba" are the ones installed when mamba is installed -->
     <!-- mamba version 2.0.0 causes failures on mac: critical libmamba filesystem error: in permissions: Operation not permitted-->
     <mamba source="mamba" skip_check='True' os='mac'>1.5</mamba>

--- a/ravenframework/Metrics/metrics/ScipyMetric.py
+++ b/ravenframework/Metrics/metrics/ScipyMetric.py
@@ -45,9 +45,8 @@ class ScipyMetric(MetricInterface):
   availMetrics['boolean']['dice']               = spatialDistance.dice
   availMetrics['boolean']['hamming']            = spatialDistance.hamming
   availMetrics['boolean']['jaccard']            = spatialDistance.jaccard
-  #Note in scipy 1.12 this needs to be changed to
-  #availMetrics['boolean']['kulsinski']           = spatialDistance.kulczynski1
-  availMetrics['boolean']['kulsinski']           = spatialDistance.kulsinski
+  availMetrics['boolean']['kulsinski']           = spatialDistance.kulczynski1
+  #availMetrics['boolean']['kulsinski']           = spatialDistance.kulsinski
   availMetrics['boolean']['russellrao']         = spatialDistance.russellrao
   availMetrics['boolean']['sokalmichener']      = spatialDistance.sokalmichener
   availMetrics['boolean']['sokalsneath']        = spatialDistance.sokalsneath

--- a/ravenframework/Models/PostProcessors/Validations/PPDSS.py
+++ b/ravenframework/Models/PostProcessors/Validations/PPDSS.py
@@ -19,7 +19,7 @@ Created on January XX, 2021
 #External Modules------------------------------------------------------------------------------------
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.integrate import simps
+from scipy.integrate import simpson
 import xarray as xr
 import os
 from collections import OrderedDict
@@ -360,7 +360,7 @@ class PPDSS(ValidationBase):
           else:
             featureD[cnt2][i] = 0
       #
-      featureProcessAction = simps(featureIntNew, interpGridNew)
+      featureProcessAction = simpson(featureIntNew, interpGridNew)
       featureProcessTimeNorm[cnt2] = featureProcessTime/featureProcessAction
       featureOmegaNorm[cnt2] = featureProcessAction*featureOmega
     #
@@ -406,7 +406,7 @@ class PPDSS(ValidationBase):
           else:
             targetD[cnt2][i] = 0
       #
-      targetProcessAction = simps(targetIntNew, interpGridNew)
+      targetProcessAction = simpson(targetIntNew, interpGridNew)
       targetProcessTimeNorm[cnt2] = targetProcessTime/targetProcessAction
       targetOmegaNorm[cnt2] = targetProcessAction*targetOmega
     #


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?
This lets the dependencies float (and also fixes some things that caused lots of tests to fail)

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

