### PR TITLE
Fix various bitterroot and parallel issues

### DIFF
--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -182,8 +182,7 @@ class JobHandler(BaseType):
     """
     state = copy.copy(self.__dict__)
     state.pop('_JobHandler__queueLock')
-    #XXX we probably need to record how this was init, and store that
-    # such as the scheduler file
+    #This will be reinitialized from a schedulerFile.
     if self._parallelLib == ParallelLibEnum.dask and '_server' in state:
       state.pop('_server')
     return state
@@ -196,6 +195,11 @@ class JobHandler(BaseType):
     """
     self.__dict__.update(d)
     self.__queueLock = threading.RLock()
+    if '_server' not in self.__dict__:
+      if self._parallelLib == ParallelLibEnum.dask and self.daskSchedulerFile is not None:
+        self._server = dask.distributed.Client(scheduler_file=self.daskSchedulerFile)
+      else:
+        self._server = None
 
   def createCloneJobHandler(self):
     """

--- a/run_tests
+++ b/run_tests
@@ -52,16 +52,16 @@ done
 echo 'Loading libraries ...'
 if [[ $SKIP_LOAD_ENV == 1 ]];
 then
-    echo Using currently active python environment, with command $(which python)
-    PYTHON_COMMAND=$(which python)
+    echo Using currently active python environment, with command $(command -v python)
+    PYTHON_COMMAND=$(command -v python)
 elif  [[ "$INSTALLATION_MANAGER" == "CONDA" ]];
 then
     source $SCRIPT_DIR/scripts/establish_conda_env.sh --load
-    echo Loaded conda environment, with command $(which python)
+    echo Loaded conda environment, with command $(command -v python)
 elif [[ "$INSTALLATION_MANAGER" == "PIP" ]];
 then
     source $SCRIPT_DIR/scripts/establish_conda_env.sh --load --installation-manager PIP
-    echo Loaded pip environment, with command $(which python)
+    echo Loaded pip environment, with command $(command -v python)
 else
     echo No installation: $INSTALLATION_MANAGER
     if [ -z $PYTHON_COMMAND ];

--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -84,7 +84,7 @@ function guess_conda_defs ()
 {
 	if [ -z ${CONDA_DEFS} ];
 	then
-      CONDA_DEFS=$(which conda | tail -1)
+      CONDA_DEFS=$(command -v conda | tail -1)
       if [[ "$CONDA_DEFS" != "" ]]; then
         # we found it
         LOCATION_CONDASH="etc/profile.d/conda.sh"
@@ -480,7 +480,7 @@ if [[ "$INSTALL_MANAGER" == "CONDA" ]];
     #The next lines are useful sometimes, but excessivly verbose.
     #if [[ $ECE_VERBOSE == 0 ]]; then
     #  echo ... conda:
-    #  which conda || echo no conda
+    #  command -v conda || echo no conda
     #  conda info || echo conda info failed
     #fi
   else

--- a/tests/cluster_tests/RavenRunsRaven/tests
+++ b/tests/cluster_tests/RavenRunsRaven/tests
@@ -46,5 +46,6 @@
    output_wait_time = 60
    type = RavenFramework
    max_time = 3600
+   skip = 'usually fails'
  [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2420


##### What are the significant changes in functionality due to this change request?
* Restarts dask server when JobHandler is unpickled
* Switch from which to POSIX standard command -v
* Skips test that fails on bitterroot

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

