### PR TITLE
Zero threshold applied correctly for relative error check in UnorderedCSVDiffer

### DIFF
--- a/scripts/TestHarness/testers/UnorderedCSVDiffer.py
+++ b/scripts/TestHarness/testers/UnorderedCSVDiffer.py
@@ -239,8 +239,8 @@ class UnorderedCSVDiffer:
       ## align columns
       testCsv = testCsv[goldCsv.columns.tolist()]
       ## set marginal values to zero, fix infinites
-      testCsv = self.prep_data_frame(testCsv, self._zero_threshold)
-      goldCsv = self.prep_data_frame(goldCsv, self._zero_threshold)
+      testCsv = self.prep_data_frame(testCsv)
+      goldCsv = self.prep_data_frame(goldCsv)
       ## check for matching rows
       for idx in goldCsv.index:
         find = goldCsv.iloc[idx].rename(None)
@@ -256,17 +256,14 @@ class UnorderedCSVDiffer:
       self.finalizeMessage(same, msg, testFilename)
     return self._same, self._message
 
-  def prep_data_frame(self, csv, tol):
+  def prep_data_frame(self, csv):
     """
       Does several prep actions:
         - For any columns that contain numbers, drop near-zero numbers to zero
         - replace infs and nans with symbolic values
       @ In, csv, pd.DataFrame, contents to reduce
-      @ In, tol, float, tolerance sufficently near zero
       @ Out, csv, converted dataframe
     """
-    # use absolute or relative?
-    key = {'atol':tol} if self._check_absolute_values else {'rtol':tol}
     # take care of infinites
     csv = csv.replace(np.inf, -sys.float_info.max)
     csv = csv.replace(np.nan, sys.float_info.max)
@@ -276,7 +273,7 @@ class UnorderedCSVDiffer:
       if not mathUtils.isAFloatOrInt(example):
         continue
       # flatten near-zeros
-      csv[col].values[np.isclose(csv[col].values, 0, **key)] = 0
+      csv[col].values[np.isclose(csv[col].values, 0, atol=self._zero_threshold)] = 0
     # TODO would like to sort here, but due to relative errors it doesn't do
     #  enough good.  Instead, sort in findRow.
     return csv

--- a/scripts/TestHarness/testers/UnorderedCSVDiffer.py
+++ b/scripts/TestHarness/testers/UnorderedCSVDiffer.py
@@ -54,7 +54,7 @@ class UnorderedCSVDiffer:
       @ In, relativeError, float, optional, relative error
       @ In, absoluteCheck, bool, optional, if True then check absolute
          differences in the values instead of relative differences
-      @ In, zeroThreshold, float, optional, if a number is less equal then
+      @ In, zeroThreshold, float, optional, if a number is less than or equal to
                                              abs(zeroThreshold), it will be considered 0
       @ In, ignoreSign, bool, optional, if True then the sign will be ignored during the comparison
       @ Out, None.

--- a/tests/framework/PostProcessors/BasicStatistics/tests
+++ b/tests/framework/PostProcessors/BasicStatistics/tests
@@ -176,6 +176,7 @@
     input = 'ste_grid.xml'
     UnorderedCsv = 'steGrid/basicStatPP_dump.csv'
     rel_err = 1e-6
+    zero_threshold = 1e-15
   [../]
   [./timeDepMeta]
     type = 'RavenFramework'

--- a/tests/framework/user_guide/ravenTutorial/tests
+++ b/tests/framework/user_guide/ravenTutorial/tests
@@ -6,7 +6,7 @@
     rel_err = 0.000001
     python3_only = true
   [../]
-  
+
   [./singleRunPlot]
     type = 'RavenFramework'
     input = 'singleRunPlotAndPrint.xml'
@@ -16,7 +16,7 @@
     python3_only = true
     rel_err = 0.01
   [../]
-  
+
   [./singleRunSubPlot]
     type = 'RavenFramework'
     input = 'singleRunSubPlotsAndSelectivePrint.xml'
@@ -26,7 +26,7 @@
     python3_only = true
     rel_err = 0.01
   [../]
-  
+
   [./MonteCarlo]
     type = 'RavenFramework'
     input = 'MonteCarlo.xml'
@@ -36,7 +36,7 @@
     python3_only = true
     rel_err = 0.01
   [../]
-  
+
   [./RomTrain]
     type = 'RavenFramework'
     input = 'RomTrain.xml'
@@ -44,7 +44,7 @@
     rel_err = 0.000001
     python3_only = true
   [../]
-  
+
   [./RomLoad]
     type = 'RavenFramework'
     input = 'RomLoad.xml'
@@ -54,11 +54,12 @@
     python3_only = true
     rel_err = 0.005
   [../]
-  
+
   [./PostProcess]
     type = 'RavenFramework'
     input = 'PostProcess.xml'
     UnorderedCsv = 'stat/statisticalAnalysis_basicStatPP_dump.csv stat/statisticalAnalysis_basicStatPP_time_dump_0.csv'
+    zero_threshold = 1e-12
     python3_only = true
   [../]
 []

--- a/tests/reg_self_tests/test_unordered_csv.py
+++ b/tests/reg_self_tests/test_unordered_csv.py
@@ -53,7 +53,7 @@ def test_a_file(fname):
     @ In, fname, string, filename string
     @ Out, test_a_file, (same, message), (bool, str) result of test.
   """
-  differ = UCSV([fname], [f'gold/{fname}'], zeroThreshold=5e-14)
+  differ = UCSV([fname], [f'gold/{fname}'], zeroThreshold=1e-8)
   differ.diff()
   return differ._same, differ._message
 


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2423 

##### What are the significant changes in functionality due to this change request?
Fixes usage of `zero_tolerance` parameter in UnorderedCSVDiffer

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

