### PR TITLE
Converting to latex that can be compiled with code in Centos8.

### DIFF
--- a/developer_tools/createSQAtracebilityMatrix.py
+++ b/developer_tools/createSQAtracebilityMatrix.py
@@ -54,15 +54,12 @@ def createLatexFile(reqDictionary,reqDocument,outputLatex):
   fileObject.write(" This section contains all of the requirements, requirements' description, and \n")
   fileObject.write(" requirement test cases. The requirement tests are automatically tested for each \n")
   fileObject.write(" CR (Change Request) by the CIS (Continuous Integration System). \n")
-  fileObject.write(" \\newcolumntype{b}{X} \n")
-  fileObject.write(" \\newcolumntype{s}{>{\\hsize=.5\\hsize}X} \n")
 
   for group, groupDict in allGroups.items():
     fileObject.write(" \\subsubsection{"+group.strip()+"} \n")
     for reqSetName,reqSet in groupDict.items():
       # create table here
-      fileObject.write("\\begin{table}\n")
-      fileObject.write("\\begin{tabularx}{\\textwidth}{|s|s|b|} \n")
+      fileObject.write("\\begin{longtable}{|p{0.2\\textwidth}|p{0.2\\textwidth}|p{0.6\\textwidth}|} \n")
       fileObject.write("\\hline \n")
       fileObject.write("\\textbf{Requirement ID} & \\textbf{Requirement Description} & \\textbf{Test(s)}  \\\ \hline \n")
       fileObject.write("\\hline \n")
@@ -79,8 +76,7 @@ def createLatexFile(reqDictionary,reqDocument,outputLatex):
         fileObject.write(" \\hspace{0pt}"+reqName.strip()+" & \\hspace{0pt}"+req['description']+" & \\hspace{0pt}"+ ' '.join(requirementTests)+" \\\ \hline \n")
         fileObject.write("\\hline \n")
       fileObject.write("\\caption*{"+reqSetName.strip()+"}\n")
-      fileObject.write("\\end{tabularx} \n")
-      fileObject.write("\\end{table} \n")
+      fileObject.write("\\end{longtable} \n")
   fileObject.write("\\end{document}")
   fileObject.close()
 

--- a/developer_tools/createSQAtracebilityMatrix.py
+++ b/developer_tools/createSQAtracebilityMatrix.py
@@ -61,6 +61,7 @@ def createLatexFile(reqDictionary,reqDocument,outputLatex):
     fileObject.write(" \\subsubsection{"+group.strip()+"} \n")
     for reqSetName,reqSet in groupDict.items():
       # create table here
+      fileObject.write("\\begin{table}\n")
       fileObject.write("\\begin{tabularx}{\\textwidth}{|s|s|b|} \n")
       fileObject.write("\\hline \n")
       fileObject.write("\\textbf{Requirement ID} & \\textbf{Requirement Description} & \\textbf{Test(s)}  \\\ \hline \n")
@@ -79,6 +80,7 @@ def createLatexFile(reqDictionary,reqDocument,outputLatex):
         fileObject.write("\\hline \n")
       fileObject.write("\\caption*{"+reqSetName.strip()+"}\n")
       fileObject.write("\\end{tabularx} \n")
+      fileObject.write("\\end{table} \n")
   fileObject.write("\\end{document}")
   fileObject.close()
 

--- a/doc/plugins_manual/raven_plugins_manual.tex
+++ b/doc/plugins_manual/raven_plugins_manual.tex
@@ -33,7 +33,6 @@
 \usepackage{ifthen}          % For simple checking in newcommand blocks
 \usepackage{textcomp}
 \usepackage{mathtools}
-\usepackage{relsize}
 \usepackage{lscape}
 \usepackage[toc,page]{appendix}
 \usepackage{RAVEN}

--- a/doc/sqa/rtr/raven_requirements_traceability_matrix.tex
+++ b/doc/sqa/rtr/raven_requirements_traceability_matrix.tex
@@ -25,6 +25,7 @@
 \usepackage[FIGBOTCAP,normal,bf,tight]{subfigure}
 \usepackage{amsmath}
 \usepackage{tabularx}
+\usepackage{longtable}
 \usepackage{amssymb}
 \usepackage[labelfont=bf]{caption}
 \usepackage{pifont}

--- a/doc/sqa/rtr/raven_requirements_traceability_matrix.tex
+++ b/doc/sqa/rtr/raven_requirements_traceability_matrix.tex
@@ -25,7 +25,6 @@
 \usepackage[FIGBOTCAP,normal,bf,tight]{subfigure}
 \usepackage{amsmath}
 \usepackage{tabularx}
-\usepackage{ltablex}
 \usepackage{amssymb}
 \usepackage[labelfont=bf]{caption}
 \usepackage{pifont}

--- a/doc/sqa/srs_rtr_combined/raven_software_requirements_specifications_and_traceability.tex
+++ b/doc/sqa/srs_rtr_combined/raven_software_requirements_specifications_and_traceability.tex
@@ -25,6 +25,7 @@
 \usepackage[FIGBOTCAP,normal,bf,tight]{subfigure}
 \usepackage{amsmath}
 \usepackage{tabularx}
+\usepackage{longtable}
 \usepackage{amssymb}
 \usepackage[labelfont=bf]{caption}
 \usepackage{pifont}

--- a/doc/sqa/srs_rtr_combined/raven_software_requirements_specifications_and_traceability.tex
+++ b/doc/sqa/srs_rtr_combined/raven_software_requirements_specifications_and_traceability.tex
@@ -25,7 +25,6 @@
 \usepackage[FIGBOTCAP,normal,bf,tight]{subfigure}
 \usepackage{amsmath}
 \usepackage{tabularx}
-\usepackage{ltablex}
 \usepackage{amssymb}
 \usepackage[labelfont=bf]{caption}
 \usepackage{pifont}

--- a/doc/tests/regression_tests_documentation.tex
+++ b/doc/tests/regression_tests_documentation.tex
@@ -33,7 +33,6 @@
 \usepackage{ifthen}          % For simple checking in newcommand blocks
 \usepackage{textcomp}
 \usepackage{mathtools}
-\usepackage{relsize}
 \usepackage{lscape}
 \usepackage[toc,page]{appendix}
 %\usepackage{RAVEN}

--- a/doc/theory_manual/adaptiveSampling.tex
+++ b/doc/theory_manual/adaptiveSampling.tex
@@ -1,3 +1,5 @@
+\newcommand{\mathlarger}[1]{#1}
+
 \section{Adaptive Sampling Strategies}
 Performing UQ and Dynamic PRA can be
 challenging from a computational point of view. The \textit{Forward}

--- a/doc/theory_manual/raven_theory_manual.tex
+++ b/doc/theory_manual/raven_theory_manual.tex
@@ -33,11 +33,9 @@
 \usepackage{ifthen}          % For simple checking in newcommand blocks
 \usepackage{textcomp}
 \usepackage{mathtools}
-\usepackage{relsize}
 \usepackage{lscape}
 \usepackage[toc,page]{appendix}
 \usepackage{RAVEN}
-\usepackage{tabls}
 \usepackage{multirow}
 \usepackage{float}
 

--- a/doc/user_guide/raven_user_guide.tex
+++ b/doc/user_guide/raven_user_guide.tex
@@ -33,7 +33,6 @@
 \usepackage{ifthen}          % For simple checking in newcommand blocks
 \usepackage{textcomp}
 \usepackage{mathtools}
-\usepackage{relsize}
 \usepackage{lscape}
 \usepackage[toc,page]{appendix}
 \usepackage{RAVEN}

--- a/plugins/ExamplePlugin/tests/test_raven_running_raven_plugin.xml
+++ b/plugins/ExamplePlugin/tests/test_raven_running_raven_plugin.xml
@@ -24,7 +24,7 @@
     <!-- This settings here are going to run 2 SLAVE RAVENs at a time, each of them using 1 processors -->
     <batchSize>1</batchSize>
     <NumMPI>1</NumMPI>
-    <mode>mpi</mode>
+    <parallelMethod>dask</parallelMethod>
   </RunInfo>
 
 <Files>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2432 


##### What are the significant changes in functionality due to this change request?
* This simplifies the LaTeX so it can be compiled with the included TeX in Centos8.
* Switches Raven Runs Raven example plugin test to dask from mpi to work better in container.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

