### PR TITLE
Switching plugin test to dask.

### DIFF
--- a/plugins/ExamplePlugin/tests/test_raven_running_raven_plugin.xml
+++ b/plugins/ExamplePlugin/tests/test_raven_running_raven_plugin.xml
@@ -24,7 +24,7 @@
     <!-- This settings here are going to run 2 SLAVE RAVENs at a time, each of them using 1 processors -->
     <batchSize>1</batchSize>
     <NumMPI>1</NumMPI>
-    <mode>mpi</mode>
+    <parallelMethod>dask</parallelMethod>
   </RunInfo>
 
 <Files>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 


##### What are the significant changes in functionality due to this change request?
Switches example plugin to use dask.


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

