### PR TITLE
Filepath handling changes to deal with backslashes in regex

### DIFF
--- a/rook/main.py
+++ b/rook/main.py
@@ -363,7 +363,7 @@ if __name__ == "__main__":
                                                                               env_var_value))
       os.environ[env_var_name] = env_var_value
 
-  test_re = re.compile(args.test_re_raw)
+  test_re = re.compile((repr(args.test_re_raw)).strip("'"))
 
   this_dir = os.path.abspath(os.path.dirname(__file__))
   up_one_dir = os.path.dirname(this_dir)
@@ -446,7 +446,7 @@ if __name__ == "__main__":
       if not param_handler.check_for_all_known(node.attrib):
         print("Unknown Parameters in:", node.tag, test_file)
       rel_test_dir = test_dir#[len(base_test_dir)+1:]
-      test_name = rel_test_dir+os.sep+node.tag
+      test_name = os.path.normpath(os.path.join(rel_test_dir, node.tag))
       if "prereq" in node.attrib:
         prereq = node.attrib['prereq']
         prereq_name = rel_test_dir+os.sep+prereq

--- a/rook/main.py
+++ b/rook/main.py
@@ -364,8 +364,6 @@ if __name__ == "__main__":
       os.environ[env_var_name] = env_var_value
 
   test_re = re.compile(re.escape(args.test_re_raw))
-  import pdb
-  pdb.set_trace()
 
   this_dir = os.path.abspath(os.path.dirname(__file__))
   up_one_dir = os.path.dirname(this_dir)

--- a/rook/main.py
+++ b/rook/main.py
@@ -363,7 +363,7 @@ if __name__ == "__main__":
                                                                               env_var_value))
       os.environ[env_var_name] = env_var_value
 
-  test_re = re.compile(re.escape(args.test_re_raw))
+  test_re = re.compile((args.test_re_raw).replace('\\', '\\\\'))
 
   this_dir = os.path.abspath(os.path.dirname(__file__))
   up_one_dir = os.path.dirname(this_dir)

--- a/rook/main.py
+++ b/rook/main.py
@@ -363,7 +363,9 @@ if __name__ == "__main__":
                                                                               env_var_value))
       os.environ[env_var_name] = env_var_value
 
-  test_re = re.compile((repr(args.test_re_raw)).strip("'"))
+  test_re = re.compile(re.escape(args.test_re_raw))
+  import pdb
+  pdb.set_trace()
 
   this_dir = os.path.abspath(os.path.dirname(__file__))
   up_one_dir = os.path.dirname(this_dir)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2437 

##### What are the significant changes in functionality due to this change request?
This request generalizes the handling of the regex string in rook to ensure that it is not changed from the literal input from the user. It also ensures that the test names use normalized paths for the operating system, simplifying the usage of the `--re` argument in `run_tests` for Windows users.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

