### PR TITLE
Trailing Whitespace cleanup

### DIFF
--- a/doc/user_manual/generated/generateOptimizerDoc.py
+++ b/doc/user_manual/generated/generateOptimizerDoc.py
@@ -28,7 +28,7 @@ except Exception as e:
   raise e
 sys.path.pop()
 
-from ravenframework.utils.InputData import wrapText
+from ravenframework.utils.InputData import wrapText, removeTrailingWhitespace
 
 def insertSolnExport(tex, obj):
   """
@@ -277,6 +277,6 @@ for name in Optimizers.factory.knownTypes():
 
 fName = os.path.abspath(os.path.join(os.path.dirname(__file__), 'optimizer.tex'))
 with open(fName, 'w', encoding='utf-8') as f:
-  f.writelines(msg)
+  f.writelines(removeTrailingWhitespace(msg))
 
 print(f'\nSuccessfully wrote "{fName}"')

--- a/doc/user_manual/generated/generateRomDoc.py
+++ b/doc/user_manual/generated/generateRomDoc.py
@@ -29,7 +29,7 @@ except Exception as e:
   raise e
 sys.path.pop()
 
-from ravenframework.utils.InputData import wrapText
+from ravenframework.utils.InputData import wrapText, removeTrailingWhitespace
 
 # examples
 ndSpline = r"""
@@ -1493,10 +1493,10 @@ for name in orderedValidRom:
 
 fName = os.path.abspath(os.path.join(os.path.dirname(__file__), 'internalRom.tex'))
 with open(fName, 'w', encoding='utf-8') as f:
-  f.writelines(internalRom)
+  f.writelines(removeTrailingWhitespace(internalRom))
 print(f'\nSuccessfully wrote "{fName}"')
 
 fName = os.path.abspath(os.path.join(os.path.dirname(__file__), 'sklRom.tex'))
 with open(fName, 'w', encoding='utf-8') as f:
-  f.writelines(sklROM)
+  f.writelines(removeTrailingWhitespace(sklROM))
 print(f'\nSuccessfully wrote "{fName}"')

--- a/doc/user_manual/generated/optimizer.tex
+++ b/doc/user_manual/generated/optimizer.tex
@@ -28,20 +28,20 @@
              \item \texttt{stepSize}: the size of step taken in the normalized input space to arrive at each optimal point
              \item \texttt{conv\_\{CONV\}}: status of each given convergence criteria
              \item \texttt{CG\_task}: for ConjugateGradient, current task of line search. FD suggests continuing the search, and CONV indicates the line search converged and will pivot.
-           
+
          \end{itemize}
 
   The \xmlNode{GradientDescent} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
   \end{itemize}
 
   The \xmlNode{GradientDescent} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{objective}: \xmlDesc{string}, 
+    \item \xmlNode{objective}: \xmlDesc{string},
       Name of the response variable (or ``objective function'') that should be optimized
       (minimized or maximized).
 
@@ -49,10 +49,10 @@
       defines the input space variables to be sampled through various means.
       The \xmlNode{variable} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{name}: \xmlDesc{string, optional},
             user-defined name of this Sampler. \nb As for the other objects,               this is
             the name that can be used to refer to this specific entity from other input blocks
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the number of samples and shape of samples               to be taken.  For
             example, \xmlAttr{shape}=``2,3'' will provide a 2 by 3               matrix of values,
             while \xmlAttr{shape}=``10'' will produce a vector of 10 values.               Omitting
@@ -63,7 +63,7 @@
 
       The \xmlNode{variable} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{distribution}: \xmlDesc{string}, 
+        \item \xmlNode{distribution}: \xmlDesc{string},
           name of the distribution that is associated to this variable.               Its name needs
           to be contained in the \xmlNode{Distributions} block explained               in Section
           \ref{sec:distributions}. In addition, if NDDistribution is used,               the
@@ -71,32 +71,33 @@
           if the \xmlNode{function} node is supplied.}
           The \xmlNode{distribution} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{dim}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{dim}: \xmlDesc{integer, optional},
                 for an NDDistribution, indicates the dimension within the NDDistribution that
                 corresponds               to this variable.
           \end{itemize}
 
-        \item \xmlNode{grid}: \xmlDesc{string}, 
+        \item \xmlNode{grid}: \xmlDesc{string},
           -- no description yet --
           The \xmlNode{grid} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{type}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{construction}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{construction}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{steps}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{steps}: \xmlDesc{integer, optional},
                 -- no description yet --
           \end{itemize}
 
-        \item \xmlNode{function}: \xmlDesc{string}, 
+        \item \xmlNode{function}: \xmlDesc{string},
           name of the function that               defines the calculation of this variable from
           other distributed variables.  Its name               needs to be contained in the
           \xmlNode{Functions} block explained in Section               \ref{sec:functions}. This
-          function must implement a method named ``evaluate''.               \nb{Each
-          \xmlNode{variable} must contain only one \xmlNode{Function} or
-          \xmlNode{Distribution}, but not both.}
+          function module must contain and implement a method either with the same name of the
+          function or a method named  ``evaluate''.               \nb{Each \xmlNode{variable} must
+          contain only one \xmlNode{Function} or               \xmlNode{Distribution}, but not
+          both.}
 
-        \item \xmlNode{initial}: \xmlDesc{comma-separated floats}, 
+        \item \xmlNode{initial}: \xmlDesc{comma-separated floats},
           indicates the initial values where independent trajectories for this optimization
           effort should begin. The number of entries should be the same for all variables, unless
           a variable is initialized with a sampler (see \xmlNode{samplerInit} below). Note these
@@ -106,16 +107,16 @@
           beginning at the locations (1, 5), (2, 6),               (3, 7), and (4, 8).
       \end{itemize}
 
-    \item \xmlNode{TargetEvaluation}: \xmlDesc{string}, 
+    \item \xmlNode{TargetEvaluation}: \xmlDesc{string},
       name of the DataObject where the sampled outputs of the Model will be collected.
       This DataObject is the means by which the sampling entity obtains the results of requested
       samples, and so should require all the input and output variables needed for adaptive
       sampling.
       The \xmlNode{TargetEvaluation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
@@ -124,21 +125,21 @@
 
       The \xmlNode{samplerInit} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{limit}: \xmlDesc{integer}, 
+        \item \xmlNode{limit}: \xmlDesc{integer},
           limits the number of Model evaluations that may be performed as part of this optimization.
           For example, a limit of 100 means at most 100 total Model evaluations may be performed.
 
-        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]}, 
+        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]},
           delineates when the \xmlNode{SolutionExport} DataObject should be written to. In case
           of \xmlString{final}, only the final optimal solution for each trajectory will be written.
           In case of \xmlString{every}, the \xmlNode{SolutionExport} will be updated with each
           iteration               of the Optimizer.
 
-        \item \xmlNode{initialSeed}: \xmlDesc{integer}, 
+        \item \xmlNode{initialSeed}: \xmlDesc{integer},
           seed for random number generation. Note that by default RAVEN uses an internal seed,
           so this seed must be changed to observe changed behavior. \default{RAVEN-determined}
 
-        \item \xmlNode{type}: \xmlDesc{[min, max]}, 
+        \item \xmlNode{type}: \xmlDesc{[min, max]},
           the type of optimization to perform. \xmlString{min} will search for the lowest
           \xmlNode{objective} value, while \xmlString{max} will search for the highest value.
       \end{itemize}
@@ -166,7 +167,7 @@
 
           The \xmlNode{FiniteDifference} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{gradDistanceScalar}: \xmlDesc{float}, 
+            \item \xmlNode{gradDistanceScalar}: \xmlDesc{float},
               a scalar for the distance away from an optimal point candidate in the optimization
               search at which points should be evaluated to estimate the local gradient. This scalar
               is a         multiplier for the step size used to reach this optimal point candidate
@@ -191,7 +192,7 @@
 
           The \xmlNode{CentralDifference} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{gradDistanceScalar}: \xmlDesc{float}, 
+            \item \xmlNode{gradDistanceScalar}: \xmlDesc{float},
               a scalar for the distance away from an optimal point candidate in the optimization
               search at which points should be evaluated to estimate the local gradient. This scalar
               is a         multiplier for the step size used to reach this optimal point candidate
@@ -217,7 +218,7 @@
 
           The \xmlNode{SPSA} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{gradDistanceScalar}: \xmlDesc{float}, 
+            \item \xmlNode{gradDistanceScalar}: \xmlDesc{float},
               a scalar for the distance away from an optimal point candidate in the optimization
               search at which points should be evaluated to estimate the local gradient. This scalar
               is a         multiplier for the step size used to reach this optimal point candidate
@@ -248,7 +249,7 @@
 
           The \xmlNode{GradientHistory} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{initialStepScale}: \xmlDesc{float}, 
+            \item \xmlNode{initialStepScale}: \xmlDesc{float},
               specifies the scale of the initial step in the optimization, in percent of the
               size of the problem. The size of the problem is defined as the hyperdiagonal of the
               input space, composed of the input variables. A value of 1 indicates the first step
@@ -259,13 +260,13 @@
               problem. This scaling factor should always               be less than $1/\sqrt{N}$,
               where $N$ is the number of optimization variables. \default{0.05}
 
-            \item \xmlNode{growthFactor}: \xmlDesc{float}, 
+            \item \xmlNode{growthFactor}: \xmlDesc{float},
               specifies the rate at which the step size should grow if the gradient continues in
               same direction through multiple iterative steps. For example, a growth factor of 2
               means               that if the gradient is identical twice, the step size is doubled.
               \default{1.25}
 
-            \item \xmlNode{shrinkFactor}: \xmlDesc{float}, 
+            \item \xmlNode{shrinkFactor}: \xmlDesc{float},
               specifies the rate at which the step size should shrink if the gradient changes
               direction through multiple iterative steps. For example, a shrink factor of 2 means
               that if the gradient completely flips direction, the step size is halved. Note that
@@ -274,13 +275,13 @@
               optimization path appears to be converging               early, increasing the shrink
               factor might improve the search. \default{1.15}
 
-            \item \xmlNode{window}: \xmlDesc{integer}, 
+            \item \xmlNode{window}: \xmlDesc{integer},
               the number of previous gradient evaluations to include when determining a new step
               direction. Modifying this allows past gradient evaluations to influence future steps,
               with a decaying influence. Setting this to 1 means only the local gradient evaluation
               will be used. \default{1}.
 
-            \item \xmlNode{decay}: \xmlDesc{float}, 
+            \item \xmlNode{decay}: \xmlDesc{float},
               if including more than one gradient history terms when determining a new step
               direction,               specifies the rate of decay for previous terms to influence
               the current direction. The               decay factor has the form $e^(-\lambda t)$,
@@ -294,7 +295,7 @@
 
           The \xmlNode{ConjugateGradient} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{initialStepScale}: \xmlDesc{float}, 
+            \item \xmlNode{initialStepScale}: \xmlDesc{float},
               specifies the scale of the initial step in the optimization, in percent of the
               size of the problem. The size of the problem is defined as the hyperdiagonal of the
               input space, composed of the input variables. A value of 1 indicates the first step
@@ -332,43 +333,43 @@
 
       The \xmlNode{convergence} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{gradient}: \xmlDesc{float}, 
+        \item \xmlNode{gradient}: \xmlDesc{float},
           provides the desired value for the local estimated of the gradient
           for convergence. \default{1e-6, if no criteria specified}
 
-        \item \xmlNode{objective}: \xmlDesc{float}, 
+        \item \xmlNode{objective}: \xmlDesc{float},
           provides the maximum relative change in the objective function for convergence.
 
-        \item \xmlNode{stepSize}: \xmlDesc{float}, 
+        \item \xmlNode{stepSize}: \xmlDesc{float},
           provides the maximum size in relative step size for convergence.
 
-        \item \xmlNode{terminateFollowers}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+        \item \xmlNode{terminateFollowers}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
           indicates whether a trajectory should be terminated when it begins following the path
           of another trajectory.
           The \xmlNode{terminateFollowers} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{proximity}: \xmlDesc{float, optional}, 
+              \item \xmlAttr{proximity}: \xmlDesc{float, optional},
                 provides the normalized distance at which a trajectory's head should be proximal to
                 another trajectory's path before terminating the following trajectory.
           \end{itemize}
 
-        \item \xmlNode{persistence}: \xmlDesc{integer}, 
+        \item \xmlNode{persistence}: \xmlDesc{integer},
           provides the number of consecutive times convergence should be reached before a trajectory
           is considered fully converged. This helps in preventing early false convergence.
 
-        \item \xmlNode{constraintExplorationLimit}: \xmlDesc{integer}, 
+        \item \xmlNode{constraintExplorationLimit}: \xmlDesc{integer},
           provides the number of consecutive times a functional constraint boundary can be explored
           for an acceptable sampling point before aborting search. Only apples if using a
           \xmlNode{Constraint}. \default{500}
       \end{itemize}
 
-    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats}, 
+    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats},
       allows variables that do not change value to be part of the input space.
       The \xmlNode{constant} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, required}, 
+          \item \xmlAttr{name}: \xmlDesc{string, required},
             variable name for this constant, which will be provided to the Model.
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the shape of samples of the constant value.               For example,
             \xmlAttr{shape}=``2,3'' will shape the values into a 2 by 3               matrix, while
             \xmlAttr{shape}=``10'' will shape into a vector of 10 values.               Unlike the
@@ -376,17 +377,17 @@
             of required values is equal to the product of the \xmlAttr{shape} values, e.g. 6 entries
             for shape ``2,3'').               \nb A model interface must be prepared to handle non-
             scalar inputs to use this option.
-          \item \xmlAttr{source}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{source}: \xmlDesc{string, optional},
             the name of the DataObject containing the value to be used for this constant.
             Requires \xmlNode{ConstantSource} node with a \xmlNode{DataObject} identified for this
             Sampler/Optimizer.
-          \item \xmlAttr{index}: \xmlDesc{integer, optional}, 
+          \item \xmlAttr{index}: \xmlDesc{integer, optional},
             the index of the realization in the \xmlNode{ConstantSource} \xmlNode{DataObject}
             containing the value for this constant. Requires \xmlNode{ConstantSource} node with
             a \xmlNode{DataObject} identified for this Sampler/Optimizer.
       \end{itemize}
 
-    \item \xmlNode{ConstantSource}: \xmlDesc{string}, 
+    \item \xmlNode{ConstantSource}: \xmlDesc{string},
       identifies a \xmlNode{DataObject} to provide \xmlNode{constant} values to the input
       space of this entity while sampling. As an alternative to providing predefined values
       for constants, the \xmlNode{ConstantSource} provides a dynamic means of always providing
@@ -394,14 +395,14 @@
       calculation.
       The \xmlNode{ConstantSource} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{Constraint}: \xmlDesc{string}, 
+    \item \xmlNode{Constraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains explicit constraints for the sampling of
       the input space of the Model. From a practical point of view, this XML node must contain
       the name of a function defined in the \xmlNode{Functions} block (see
@@ -411,13 +412,13 @@
       user.
       The \xmlNode{Constraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string}, 
+    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains implicit constraints of the Model. From a practical
       point of view, this XML node must contain the name of a function defined in the
       \xmlNode{Functions}               block (see Section~\ref{sec:functions}). This external
@@ -425,13 +426,13 @@
       for outputs satisfying the implicit constraints and False otherwise.
       The \xmlNode{ImplicitConstraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ROM}: \xmlDesc{string}, 
+    \item \xmlNode{ROM}: \xmlDesc{string},
       Name of a Model that optimizers may want to use during optimization. For example, the
       Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
       in                                           detail with in the \xmlNode{Models} as in other
@@ -439,13 +440,13 @@
       the model definition's name.
       The \xmlNode{ROM} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Sampler}: \xmlDesc{string}, 
+    \item \xmlNode{Sampler}: \xmlDesc{string},
       name of a Sampler that can be used to initialize the starting points for the trajectories
       of some of the variables. From a practical point of view, this XML node must contain the
       name of a Sampler defined in the \xmlNode{Samplers} block (see
@@ -455,13 +456,13 @@
       variables, the \xmlNode{initial} XML node is required only for the remaining 3 variables.
       The \xmlNode{Sampler} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Restart}: \xmlDesc{string}, 
+    \item \xmlNode{Restart}: \xmlDesc{string},
       name of a DataObject. Used to leverage existing data when sampling a model. For
       example, if a Model has               already been sampled, but some samples were not
       collected, the successful samples can               be stored and used instead of rerunning
@@ -470,14 +471,14 @@
       being sampled.
       The \xmlNode{Restart} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{restartTolerance}: \xmlDesc{float}, 
+    \item \xmlNode{restartTolerance}: \xmlDesc{float},
       specifies how strictly a matching point from a \xmlNode{Restart} DataObject must match
       the desired sample point in order to be used. If a potential restart point is within a
       relative Euclidean distance (as specified by the value in this node) of a desired sample
@@ -490,7 +491,7 @@
       by the Model.
       The \xmlNode{variablesTransformation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{distribution}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{distribution}: \xmlDesc{string, optional},
             the name for the distribution defined in the XML node \xmlNode{Distributions}.
             This attribute indicates the values of \xmlNode{manifestVariables} are drawn from
             \xmlAttr{distribution}.
@@ -498,21 +499,21 @@
 
       The \xmlNode{variablesTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings},
           user-defined latent variables that are used for the variables transformation.
           All the variables listed under this node should be also mentioned in \xmlNode{variable}.
 
-        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings},
           user-defined manifest variables that can be used by the \xmlNode{Model}.
 
-        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings},
           user-defined manifest variables indices paired with \xmlNode{manifestVariables}.
           These indices indicate the position of manifest variables associated with multivariate
           normal               distribution defined in the XML node \xmlNode{Distributions}.
           The indices should be postive integer. If not provided, the code will use the positions
           of manifest variables listed in \xmlNode{manifestVariables} as the indices.
 
-        \item \xmlNode{method}: \xmlDesc{string}, 
+        \item \xmlNode{method}: \xmlDesc{string},
           the method that is used for the variables transformation. The currently available method
           is \xmlString{pca}.
       \end{itemize}
@@ -578,20 +579,20 @@ Gradient Descent Example:
              \item \texttt{delta\_\{VAR\}}: step size associated to each variable
              \item \texttt{Temp}: temperature at current state
              \item \texttt{fraction}: current fraction of the max iteration limit
-           
+
          \end{itemize}
 
   The \xmlNode{SimulatedAnnealing} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
   \end{itemize}
 
   The \xmlNode{SimulatedAnnealing} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{objective}: \xmlDesc{string}, 
+    \item \xmlNode{objective}: \xmlDesc{string},
       Name of the response variable (or ``objective function'') that should be optimized
       (minimized or maximized).
 
@@ -599,10 +600,10 @@ Gradient Descent Example:
       defines the input space variables to be sampled through various means.
       The \xmlNode{variable} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{name}: \xmlDesc{string, optional},
             user-defined name of this Sampler. \nb As for the other objects,               this is
             the name that can be used to refer to this specific entity from other input blocks
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the number of samples and shape of samples               to be taken.  For
             example, \xmlAttr{shape}=``2,3'' will provide a 2 by 3               matrix of values,
             while \xmlAttr{shape}=``10'' will produce a vector of 10 values.               Omitting
@@ -613,7 +614,7 @@ Gradient Descent Example:
 
       The \xmlNode{variable} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{distribution}: \xmlDesc{string}, 
+        \item \xmlNode{distribution}: \xmlDesc{string},
           name of the distribution that is associated to this variable.               Its name needs
           to be contained in the \xmlNode{Distributions} block explained               in Section
           \ref{sec:distributions}. In addition, if NDDistribution is used,               the
@@ -621,32 +622,33 @@ Gradient Descent Example:
           if the \xmlNode{function} node is supplied.}
           The \xmlNode{distribution} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{dim}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{dim}: \xmlDesc{integer, optional},
                 for an NDDistribution, indicates the dimension within the NDDistribution that
                 corresponds               to this variable.
           \end{itemize}
 
-        \item \xmlNode{grid}: \xmlDesc{string}, 
+        \item \xmlNode{grid}: \xmlDesc{string},
           -- no description yet --
           The \xmlNode{grid} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{type}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{construction}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{construction}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{steps}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{steps}: \xmlDesc{integer, optional},
                 -- no description yet --
           \end{itemize}
 
-        \item \xmlNode{function}: \xmlDesc{string}, 
+        \item \xmlNode{function}: \xmlDesc{string},
           name of the function that               defines the calculation of this variable from
           other distributed variables.  Its name               needs to be contained in the
           \xmlNode{Functions} block explained in Section               \ref{sec:functions}. This
-          function must implement a method named ``evaluate''.               \nb{Each
-          \xmlNode{variable} must contain only one \xmlNode{Function} or
-          \xmlNode{Distribution}, but not both.}
+          function module must contain and implement a method either with the same name of the
+          function or a method named  ``evaluate''.               \nb{Each \xmlNode{variable} must
+          contain only one \xmlNode{Function} or               \xmlNode{Distribution}, but not
+          both.}
 
-        \item \xmlNode{initial}: \xmlDesc{comma-separated floats}, 
+        \item \xmlNode{initial}: \xmlDesc{comma-separated floats},
           indicates the initial values where independent trajectories for this optimization
           effort should begin. The number of entries should be the same for all variables, unless
           a variable is initialized with a sampler (see \xmlNode{samplerInit} below). Note these
@@ -656,16 +658,16 @@ Gradient Descent Example:
           beginning at the locations (1, 5), (2, 6),               (3, 7), and (4, 8).
       \end{itemize}
 
-    \item \xmlNode{TargetEvaluation}: \xmlDesc{string}, 
+    \item \xmlNode{TargetEvaluation}: \xmlDesc{string},
       name of the DataObject where the sampled outputs of the Model will be collected.
       This DataObject is the means by which the sampling entity obtains the results of requested
       samples, and so should require all the input and output variables needed for adaptive
       sampling.
       The \xmlNode{TargetEvaluation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
@@ -674,21 +676,21 @@ Gradient Descent Example:
 
       The \xmlNode{samplerInit} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{limit}: \xmlDesc{integer}, 
+        \item \xmlNode{limit}: \xmlDesc{integer},
           limits the number of Model evaluations that may be performed as part of this optimization.
           For example, a limit of 100 means at most 100 total Model evaluations may be performed.
 
-        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]}, 
+        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]},
           delineates when the \xmlNode{SolutionExport} DataObject should be written to. In case
           of \xmlString{final}, only the final optimal solution for each trajectory will be written.
           In case of \xmlString{every}, the \xmlNode{SolutionExport} will be updated with each
           iteration               of the Optimizer.
 
-        \item \xmlNode{initialSeed}: \xmlDesc{integer}, 
+        \item \xmlNode{initialSeed}: \xmlDesc{integer},
           seed for random number generation. Note that by default RAVEN uses an internal seed,
           so this seed must be changed to observe changed behavior. \default{RAVEN-determined}
 
-        \item \xmlNode{type}: \xmlDesc{[min, max]}, 
+        \item \xmlNode{type}: \xmlDesc{[min, max]},
           the type of optimization to perform. \xmlString{min} will search for the lowest
           \xmlNode{objective} value, while \xmlString{max} will search for the highest value.
       \end{itemize}
@@ -700,17 +702,17 @@ Gradient Descent Example:
 
       The \xmlNode{convergence} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{objective}: \xmlDesc{float}, 
+        \item \xmlNode{objective}: \xmlDesc{float},
           provides the desired value for the convergence criterion of the objective function
           ($\epsilon^{obj}$), i.e., convergence is reached when: $$ |newObjevtive - oldObjective|
           \le \epsilon^{obj}$$.                        \default{1e-6}, if no criteria specified
 
-        \item \xmlNode{temperature}: \xmlDesc{float}, 
+        \item \xmlNode{temperature}: \xmlDesc{float},
           provides the desired value for the convergence creiteron of the system temperature,
           ($\epsilon^{temp}$), i.e., convergence is reached when: $$T \le \epsilon^{temp}$$.
           \default{1e-10}, if no criteria specified
 
-        \item \xmlNode{persistence}: \xmlDesc{integer}, 
+        \item \xmlNode{persistence}: \xmlDesc{integer},
           provides the number of consecutive times convergence should be reached before a trajectory
           is considered fully converged. This helps in preventing early false convergence.
       \end{itemize}
@@ -732,55 +734,57 @@ Gradient Descent Example:
 
       The \xmlNode{coolingSchedule} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{exponential}: \xmlDesc{string}, 
+        \item \xmlNode{exponential}: \xmlDesc{string},
           exponential cooling schedule
 
           The \xmlNode{exponential} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{alpha}: \xmlDesc{float}, 
+            \item \xmlNode{alpha}: \xmlDesc{float},
               slowing down constant, should be between 0,1 and preferable very close to 1.
               \default{0.94}
           \end{itemize}
 
-        \item \xmlNode{veryfast}: \xmlDesc{string}, 
+        \item \xmlNode{veryfast}: \xmlDesc{string},
           veryfast cooling schedule
 
           The \xmlNode{veryfast} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{c}: \xmlDesc{float}, 
+            \item \xmlNode{c}: \xmlDesc{float},
               decay constant, \default{1.0}
           \end{itemize}
 
-        \item \xmlNode{cauchy}: \xmlDesc{string}, 
+        \item \xmlNode{cauchy}: \xmlDesc{string},
           cauchy cooling schedule
 
           The \xmlNode{cauchy} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{d}: \xmlDesc{float}, 
+            \item \xmlNode{d}: \xmlDesc{float},
               bias, \default{1.0}
-             \item \xmlNode{learningRate}: \xmlDesc{float}, 
-              learning rate: Scale constant for adjusting guesses, \default{0.9}
+
+            \item \xmlNode{learningRate}: \xmlDesc{float},
+              learning rate, Scale constant for adjusting guesses. \default{0.9}
           \end{itemize}
 
-        \item \xmlNode{boltzmann}: \xmlDesc{string}, 
+        \item \xmlNode{boltzmann}: \xmlDesc{string},
           boltzmann cooling schedule
 
           The \xmlNode{boltzmann} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{d}: \xmlDesc{float}, 
+            \item \xmlNode{d}: \xmlDesc{float},
               bias, \default{1.0}
-              \item \xmlNode{learningRate}: \xmlDesc{float}, 
-              learning rate: Scale constant for adjusting guesses, \default{0.9}
+
+            \item \xmlNode{learningRate}: \xmlDesc{float},
+              learning rate, Scale constant for adjusting guesses. \default{0.9}
           \end{itemize}
       \end{itemize}
 
-    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats}, 
+    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats},
       allows variables that do not change value to be part of the input space.
       The \xmlNode{constant} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, required}, 
+          \item \xmlAttr{name}: \xmlDesc{string, required},
             variable name for this constant, which will be provided to the Model.
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the shape of samples of the constant value.               For example,
             \xmlAttr{shape}=``2,3'' will shape the values into a 2 by 3               matrix, while
             \xmlAttr{shape}=``10'' will shape into a vector of 10 values.               Unlike the
@@ -788,17 +792,17 @@ Gradient Descent Example:
             of required values is equal to the product of the \xmlAttr{shape} values, e.g. 6 entries
             for shape ``2,3'').               \nb A model interface must be prepared to handle non-
             scalar inputs to use this option.
-          \item \xmlAttr{source}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{source}: \xmlDesc{string, optional},
             the name of the DataObject containing the value to be used for this constant.
             Requires \xmlNode{ConstantSource} node with a \xmlNode{DataObject} identified for this
             Sampler/Optimizer.
-          \item \xmlAttr{index}: \xmlDesc{integer, optional}, 
+          \item \xmlAttr{index}: \xmlDesc{integer, optional},
             the index of the realization in the \xmlNode{ConstantSource} \xmlNode{DataObject}
             containing the value for this constant. Requires \xmlNode{ConstantSource} node with
             a \xmlNode{DataObject} identified for this Sampler/Optimizer.
       \end{itemize}
 
-    \item \xmlNode{ConstantSource}: \xmlDesc{string}, 
+    \item \xmlNode{ConstantSource}: \xmlDesc{string},
       identifies a \xmlNode{DataObject} to provide \xmlNode{constant} values to the input
       space of this entity while sampling. As an alternative to providing predefined values
       for constants, the \xmlNode{ConstantSource} provides a dynamic means of always providing
@@ -806,14 +810,14 @@ Gradient Descent Example:
       calculation.
       The \xmlNode{ConstantSource} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{Constraint}: \xmlDesc{string}, 
+    \item \xmlNode{Constraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains explicit constraints for the sampling of
       the input space of the Model. From a practical point of view, this XML node must contain
       the name of a function defined in the \xmlNode{Functions} block (see
@@ -823,13 +827,13 @@ Gradient Descent Example:
       user.
       The \xmlNode{Constraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string}, 
+    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains implicit constraints of the Model. From a practical
       point of view, this XML node must contain the name of a function defined in the
       \xmlNode{Functions}               block (see Section~\ref{sec:functions}). This external
@@ -837,13 +841,13 @@ Gradient Descent Example:
       for outputs satisfying the implicit constraints and False otherwise.
       The \xmlNode{ImplicitConstraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ROM}: \xmlDesc{string}, 
+    \item \xmlNode{ROM}: \xmlDesc{string},
       Name of a Model that optimizers may want to use during optimization. For example, the
       Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
       in                                           detail with in the \xmlNode{Models} as in other
@@ -851,13 +855,13 @@ Gradient Descent Example:
       the model definition's name.
       The \xmlNode{ROM} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Sampler}: \xmlDesc{string}, 
+    \item \xmlNode{Sampler}: \xmlDesc{string},
       name of a Sampler that can be used to initialize the starting points for the trajectories
       of some of the variables. From a practical point of view, this XML node must contain the
       name of a Sampler defined in the \xmlNode{Samplers} block (see
@@ -867,13 +871,13 @@ Gradient Descent Example:
       variables, the \xmlNode{initial} XML node is required only for the remaining 3 variables.
       The \xmlNode{Sampler} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Restart}: \xmlDesc{string}, 
+    \item \xmlNode{Restart}: \xmlDesc{string},
       name of a DataObject. Used to leverage existing data when sampling a model. For
       example, if a Model has               already been sampled, but some samples were not
       collected, the successful samples can               be stored and used instead of rerunning
@@ -882,14 +886,14 @@ Gradient Descent Example:
       being sampled.
       The \xmlNode{Restart} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{restartTolerance}: \xmlDesc{float}, 
+    \item \xmlNode{restartTolerance}: \xmlDesc{float},
       specifies how strictly a matching point from a \xmlNode{Restart} DataObject must match
       the desired sample point in order to be used. If a potential restart point is within a
       relative Euclidean distance (as specified by the value in this node) of a desired sample
@@ -902,7 +906,7 @@ Gradient Descent Example:
       by the Model.
       The \xmlNode{variablesTransformation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{distribution}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{distribution}: \xmlDesc{string, optional},
             the name for the distribution defined in the XML node \xmlNode{Distributions}.
             This attribute indicates the values of \xmlNode{manifestVariables} are drawn from
             \xmlAttr{distribution}.
@@ -910,21 +914,21 @@ Gradient Descent Example:
 
       The \xmlNode{variablesTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings},
           user-defined latent variables that are used for the variables transformation.
           All the variables listed under this node should be also mentioned in \xmlNode{variable}.
 
-        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings},
           user-defined manifest variables that can be used by the \xmlNode{Model}.
 
-        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings},
           user-defined manifest variables indices paired with \xmlNode{manifestVariables}.
           These indices indicate the position of manifest variables associated with multivariate
           normal               distribution defined in the XML node \xmlNode{Distributions}.
           The indices should be postive integer. If not provided, the code will use the positions
           of manifest variables listed in \xmlNode{manifestVariables} as the indices.
 
-        \item \xmlNode{method}: \xmlDesc{string}, 
+        \item \xmlNode{method}: \xmlDesc{string},
           the method that is used for the variables transformation. The currently available method
           is \xmlString{pca}.
       \end{itemize}
@@ -996,20 +1000,20 @@ Simulated Annealing Example:
              \item \texttt{AHD}: Hausdorff Distance between populations
              \item \texttt{HDSM}: Hausdorff Distance Similarity Measure between populations
              \item \texttt{ConstraintEvaluation\_\{CONSTRAINT\}}: Constraint function evaluation (negative if violating and positive otherwise)
-           
+
          \end{itemize}
 
   The \xmlNode{GeneticAlgorithm} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
   \end{itemize}
 
   The \xmlNode{GeneticAlgorithm} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{objective}: \xmlDesc{string}, 
+    \item \xmlNode{objective}: \xmlDesc{string},
       Name of the response variable (or ``objective function'') that should be optimized
       (minimized or maximized).
 
@@ -1017,10 +1021,10 @@ Simulated Annealing Example:
       defines the input space variables to be sampled through various means.
       The \xmlNode{variable} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{name}: \xmlDesc{string, optional},
             user-defined name of this Sampler. \nb As for the other objects,               this is
             the name that can be used to refer to this specific entity from other input blocks
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the number of samples and shape of samples               to be taken.  For
             example, \xmlAttr{shape}=``2,3'' will provide a 2 by 3               matrix of values,
             while \xmlAttr{shape}=``10'' will produce a vector of 10 values.               Omitting
@@ -1031,7 +1035,7 @@ Simulated Annealing Example:
 
       The \xmlNode{variable} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{distribution}: \xmlDesc{string}, 
+        \item \xmlNode{distribution}: \xmlDesc{string},
           name of the distribution that is associated to this variable.               Its name needs
           to be contained in the \xmlNode{Distributions} block explained               in Section
           \ref{sec:distributions}. In addition, if NDDistribution is used,               the
@@ -1039,32 +1043,33 @@ Simulated Annealing Example:
           if the \xmlNode{function} node is supplied.}
           The \xmlNode{distribution} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{dim}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{dim}: \xmlDesc{integer, optional},
                 for an NDDistribution, indicates the dimension within the NDDistribution that
                 corresponds               to this variable.
           \end{itemize}
 
-        \item \xmlNode{grid}: \xmlDesc{string}, 
+        \item \xmlNode{grid}: \xmlDesc{string},
           -- no description yet --
           The \xmlNode{grid} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{type}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{construction}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{construction}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{steps}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{steps}: \xmlDesc{integer, optional},
                 -- no description yet --
           \end{itemize}
 
-        \item \xmlNode{function}: \xmlDesc{string}, 
+        \item \xmlNode{function}: \xmlDesc{string},
           name of the function that               defines the calculation of this variable from
           other distributed variables.  Its name               needs to be contained in the
           \xmlNode{Functions} block explained in Section               \ref{sec:functions}. This
-          function must implement a method named ``evaluate''.               \nb{Each
-          \xmlNode{variable} must contain only one \xmlNode{Function} or
-          \xmlNode{Distribution}, but not both.}
+          function module must contain and implement a method either with the same name of the
+          function or a method named  ``evaluate''.               \nb{Each \xmlNode{variable} must
+          contain only one \xmlNode{Function} or               \xmlNode{Distribution}, but not
+          both.}
 
-        \item \xmlNode{initial}: \xmlDesc{comma-separated floats}, 
+        \item \xmlNode{initial}: \xmlDesc{comma-separated floats},
           indicates the initial values where independent trajectories for this optimization
           effort should begin. The number of entries should be the same for all variables, unless
           a variable is initialized with a sampler (see \xmlNode{samplerInit} below). Note these
@@ -1074,16 +1079,16 @@ Simulated Annealing Example:
           beginning at the locations (1, 5), (2, 6),               (3, 7), and (4, 8).
       \end{itemize}
 
-    \item \xmlNode{TargetEvaluation}: \xmlDesc{string}, 
+    \item \xmlNode{TargetEvaluation}: \xmlDesc{string},
       name of the DataObject where the sampled outputs of the Model will be collected.
       This DataObject is the means by which the sampling entity obtains the results of requested
       samples, and so should require all the input and output variables needed for adaptive
       sampling.
       The \xmlNode{TargetEvaluation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
@@ -1092,21 +1097,21 @@ Simulated Annealing Example:
 
       The \xmlNode{samplerInit} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{limit}: \xmlDesc{integer}, 
+        \item \xmlNode{limit}: \xmlDesc{integer},
           limits the number of Model evaluations that may be performed as part of this optimization.
           For example, a limit of 100 means at most 100 total Model evaluations may be performed.
 
-        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]}, 
+        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]},
           delineates when the \xmlNode{SolutionExport} DataObject should be written to. In case
           of \xmlString{final}, only the final optimal solution for each trajectory will be written.
           In case of \xmlString{every}, the \xmlNode{SolutionExport} will be updated with each
           iteration               of the Optimizer.
 
-        \item \xmlNode{initialSeed}: \xmlDesc{integer}, 
+        \item \xmlNode{initialSeed}: \xmlDesc{integer},
           seed for random number generation. Note that by default RAVEN uses an internal seed,
           so this seed must be changed to observe changed behavior. \default{RAVEN-determined}
 
-        \item \xmlNode{type}: \xmlDesc{[min, max]}, 
+        \item \xmlNode{type}: \xmlDesc{[min, max]},
           the type of optimization to perform. \xmlString{min} will search for the lowest
           \xmlNode{objective} value, while \xmlString{max} will search for the highest value.
       \end{itemize}
@@ -1141,10 +1146,10 @@ Simulated Annealing Example:
 
       The \xmlNode{GAparams} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{populationSize}: \xmlDesc{integer}, 
+        \item \xmlNode{populationSize}: \xmlDesc{integer},
           The number of chromosomes in each population.
 
-        \item \xmlNode{parentSelection}: \xmlDesc{string}, 
+        \item \xmlNode{parentSelection}: \xmlDesc{string},
           A node containing the criterion based on which the parents are selected. This can be a
           fitness proportional selection such as:                   a.
           \textbf{\textit{rouletteWheel}},                   b.
@@ -1162,53 +1167,53 @@ Simulated Annealing Example:
 
           The \xmlNode{reproduction} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{crossover}: \xmlDesc{string}, 
+            \item \xmlNode{crossover}: \xmlDesc{string},
               a subnode containing the implemented crossover mechanisms.                   This
               includes: a.    onePointCrossover,                                  b.
               twoPointsCrossover,                                  c.    uniformCrossover.
               The \xmlNode{crossover} node recognizes the following parameters:
                 \begin{itemize}
-                  \item \xmlAttr{type}: \xmlDesc{string, required}, 
+                  \item \xmlAttr{type}: \xmlDesc{string, required},
                     type of crossover operation to be used (e.g., OnePoint, MultiPoint, or Uniform)
               \end{itemize}
 
               The \xmlNode{crossover} node recognizes the following subnodes:
               \begin{itemize}
-                \item \xmlNode{points}: \xmlDesc{comma-separated integers}, 
+                \item \xmlNode{points}: \xmlDesc{comma-separated integers},
                   point/gene(s) at which crossover will occur.
 
-                \item \xmlNode{crossoverProb}: \xmlDesc{float}, 
+                \item \xmlNode{crossoverProb}: \xmlDesc{float},
                   The probability governing the crossover step, i.e., the probability that if
                   exceeded crossover will occur.
               \end{itemize}
 
-            \item \xmlNode{mutation}: \xmlDesc{string}, 
+            \item \xmlNode{mutation}: \xmlDesc{string},
               a subnode containing the implemented mutation mechanisms.                   This
               includes: a.    bitFlipMutation,                                  b.    swapMutation,
               c.    scrambleMutation,                                  d.    inversionMutation, or
               e.    randomMutator.
               The \xmlNode{mutation} node recognizes the following parameters:
                 \begin{itemize}
-                  \item \xmlAttr{type}: \xmlDesc{string, required}, 
+                  \item \xmlAttr{type}: \xmlDesc{string, required},
                     type of mutation operation to be used (e.g., bit, swap, or scramble)
               \end{itemize}
 
               The \xmlNode{mutation} node recognizes the following subnodes:
               \begin{itemize}
-                \item \xmlNode{locs}: \xmlDesc{comma-separated integers}, 
+                \item \xmlNode{locs}: \xmlDesc{comma-separated integers},
                   locations at which mutation will occur.
 
-                \item \xmlNode{mutationProb}: \xmlDesc{float}, 
+                \item \xmlNode{mutationProb}: \xmlDesc{float},
                   The probability governing the mutation step, i.e., the probability that if
                   exceeded mutation will occur.
               \end{itemize}
           \end{itemize}
 
-        \item \xmlNode{survivorSelection}: \xmlDesc{string}, 
+        \item \xmlNode{survivorSelection}: \xmlDesc{string},
           a subnode containing the implemented survivor selection mechanisms.                   This
           includes: a.    ageBased, or                                  b.    fitnessBased.
 
-        \item \xmlNode{fitness}: \xmlDesc{string}, 
+        \item \xmlNode{fitness}: \xmlDesc{string},
           a subnode containing the implemented fitness functions.                   This includes:
           \begin{itemize}                                 \item    invLinear:
           \[fitness = -a \times obj - b \times \sum\\_{j=1}^{nConstraint} max(0,-penalty\\_j) \].
@@ -1221,16 +1226,16 @@ Simulated Annealing Example:
           \end{itemize}.
           The \xmlNode{fitness} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{type}: \xmlDesc{string, required}, 
+              \item \xmlAttr{type}: \xmlDesc{string, required},
                 [invLin, logistic, feasibleFirst]
           \end{itemize}
 
           The \xmlNode{fitness} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{a}: \xmlDesc{float}, 
+            \item \xmlNode{a}: \xmlDesc{float},
               a: coefficient of objective function.
 
-            \item \xmlNode{b}: \xmlDesc{float}, 
+            \item \xmlNode{b}: \xmlDesc{float},
               b: coefficient of constraint penalty.
           \end{itemize}
       \end{itemize}
@@ -1242,20 +1247,20 @@ Simulated Annealing Example:
 
       The \xmlNode{convergence} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{objective}: \xmlDesc{float}, 
+        \item \xmlNode{objective}: \xmlDesc{float},
           provides the desired value for the convergence criterion of the objective function
           ($\epsilon^{obj}$). In essence this is solving the inverse problem of finding the design
           variable                         at a given objective value, i.e., convergence is reached
           when: $$ Objective = \epsilon^{obj}$$.                        \default{1e-6}, if no
           criteria specified
 
-        \item \xmlNode{AHDp}: \xmlDesc{float}, 
+        \item \xmlNode{AHDp}: \xmlDesc{float},
           provides the desired value for the Average Hausdorff Distance between populations
 
-        \item \xmlNode{AHD}: \xmlDesc{float}, 
+        \item \xmlNode{AHD}: \xmlDesc{float},
           provides the desired value for the Hausdorff Distance between populations
 
-        \item \xmlNode{HDSM}: \xmlDesc{float}, 
+        \item \xmlNode{HDSM}: \xmlDesc{float},
           provides the desired value for the Hausdorff Distance Similarity Measure between
           populations.                                     This convergence criterion is based on a
           normalized                                     similarity metric that can be summurized as
@@ -1263,18 +1268,18 @@ Simulated Annealing Example:
           domain of to population/iterations). The metric is normalized between 0 and 1,
           which implies that values closer to 1.0 represents a tighter convergence criterion.
 
-        \item \xmlNode{persistence}: \xmlDesc{integer}, 
+        \item \xmlNode{persistence}: \xmlDesc{integer},
           provides the number of consecutive times convergence should be reached before a trajectory
           is considered fully converged. This helps in preventing early false convergence.
       \end{itemize}
 
-    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats}, 
+    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats},
       allows variables that do not change value to be part of the input space.
       The \xmlNode{constant} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, required}, 
+          \item \xmlAttr{name}: \xmlDesc{string, required},
             variable name for this constant, which will be provided to the Model.
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the shape of samples of the constant value.               For example,
             \xmlAttr{shape}=``2,3'' will shape the values into a 2 by 3               matrix, while
             \xmlAttr{shape}=``10'' will shape into a vector of 10 values.               Unlike the
@@ -1282,17 +1287,17 @@ Simulated Annealing Example:
             of required values is equal to the product of the \xmlAttr{shape} values, e.g. 6 entries
             for shape ``2,3'').               \nb A model interface must be prepared to handle non-
             scalar inputs to use this option.
-          \item \xmlAttr{source}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{source}: \xmlDesc{string, optional},
             the name of the DataObject containing the value to be used for this constant.
             Requires \xmlNode{ConstantSource} node with a \xmlNode{DataObject} identified for this
             Sampler/Optimizer.
-          \item \xmlAttr{index}: \xmlDesc{integer, optional}, 
+          \item \xmlAttr{index}: \xmlDesc{integer, optional},
             the index of the realization in the \xmlNode{ConstantSource} \xmlNode{DataObject}
             containing the value for this constant. Requires \xmlNode{ConstantSource} node with
             a \xmlNode{DataObject} identified for this Sampler/Optimizer.
       \end{itemize}
 
-    \item \xmlNode{ConstantSource}: \xmlDesc{string}, 
+    \item \xmlNode{ConstantSource}: \xmlDesc{string},
       identifies a \xmlNode{DataObject} to provide \xmlNode{constant} values to the input
       space of this entity while sampling. As an alternative to providing predefined values
       for constants, the \xmlNode{ConstantSource} provides a dynamic means of always providing
@@ -1300,14 +1305,14 @@ Simulated Annealing Example:
       calculation.
       The \xmlNode{ConstantSource} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{Constraint}: \xmlDesc{string}, 
+    \item \xmlNode{Constraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains explicit constraints for the sampling of
       the input space of the Model. From a practical point of view, this XML node must contain
       the name of a function defined in the \xmlNode{Functions} block (see
@@ -1317,13 +1322,13 @@ Simulated Annealing Example:
       user.
       The \xmlNode{Constraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string}, 
+    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains implicit constraints of the Model. From a practical
       point of view, this XML node must contain the name of a function defined in the
       \xmlNode{Functions}               block (see Section~\ref{sec:functions}). This external
@@ -1331,13 +1336,13 @@ Simulated Annealing Example:
       for outputs satisfying the implicit constraints and False otherwise.
       The \xmlNode{ImplicitConstraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ROM}: \xmlDesc{string}, 
+    \item \xmlNode{ROM}: \xmlDesc{string},
       Name of a Model that optimizers may want to use during optimization. For example, the
       Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
       in                                           detail with in the \xmlNode{Models} as in other
@@ -1345,13 +1350,13 @@ Simulated Annealing Example:
       the model definition's name.
       The \xmlNode{ROM} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Sampler}: \xmlDesc{string}, 
+    \item \xmlNode{Sampler}: \xmlDesc{string},
       name of a Sampler that can be used to initialize the starting points for the trajectories
       of some of the variables. From a practical point of view, this XML node must contain the
       name of a Sampler defined in the \xmlNode{Samplers} block (see
@@ -1361,13 +1366,13 @@ Simulated Annealing Example:
       variables, the \xmlNode{initial} XML node is required only for the remaining 3 variables.
       The \xmlNode{Sampler} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Restart}: \xmlDesc{string}, 
+    \item \xmlNode{Restart}: \xmlDesc{string},
       name of a DataObject. Used to leverage existing data when sampling a model. For
       example, if a Model has               already been sampled, but some samples were not
       collected, the successful samples can               be stored and used instead of rerunning
@@ -1376,14 +1381,14 @@ Simulated Annealing Example:
       being sampled.
       The \xmlNode{Restart} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{restartTolerance}: \xmlDesc{float}, 
+    \item \xmlNode{restartTolerance}: \xmlDesc{float},
       specifies how strictly a matching point from a \xmlNode{Restart} DataObject must match
       the desired sample point in order to be used. If a potential restart point is within a
       relative Euclidean distance (as specified by the value in this node) of a desired sample
@@ -1396,7 +1401,7 @@ Simulated Annealing Example:
       by the Model.
       The \xmlNode{variablesTransformation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{distribution}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{distribution}: \xmlDesc{string, optional},
             the name for the distribution defined in the XML node \xmlNode{Distributions}.
             This attribute indicates the values of \xmlNode{manifestVariables} are drawn from
             \xmlAttr{distribution}.
@@ -1404,21 +1409,21 @@ Simulated Annealing Example:
 
       The \xmlNode{variablesTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings},
           user-defined latent variables that are used for the variables transformation.
           All the variables listed under this node should be also mentioned in \xmlNode{variable}.
 
-        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings},
           user-defined manifest variables that can be used by the \xmlNode{Model}.
 
-        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings},
           user-defined manifest variables indices paired with \xmlNode{manifestVariables}.
           These indices indicate the position of manifest variables associated with multivariate
           normal               distribution defined in the XML node \xmlNode{Distributions}.
           The indices should be postive integer. If not provided, the code will use the positions
           of manifest variables listed in \xmlNode{manifestVariables} as the indices.
 
-        \item \xmlNode{method}: \xmlDesc{string}, 
+        \item \xmlNode{method}: \xmlDesc{string},
           the method that is used for the variables transformation. The currently available method
           is \xmlString{pca}.
       \end{itemize}
@@ -1522,20 +1527,20 @@ Genetic Algorithm Example:
              \item \texttt{radiusFromLast}: radius of current point from previous point
              \item \texttt{solutionValue}: Expected value of objective var at recommended solution point
              \item \texttt{solutionDeviation}: Standard deviation of recommended solution
-           
+
          \end{itemize}
 
   The \xmlNode{BayesianOptimizer} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
   \end{itemize}
 
   The \xmlNode{BayesianOptimizer} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{objective}: \xmlDesc{string}, 
+    \item \xmlNode{objective}: \xmlDesc{string},
       Name of the response variable (or ``objective function'') that should be optimized
       (minimized or maximized).
 
@@ -1543,10 +1548,10 @@ Genetic Algorithm Example:
       defines the input space variables to be sampled through various means.
       The \xmlNode{variable} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{name}: \xmlDesc{string, optional},
             user-defined name of this Sampler. \nb As for the other objects,               this is
             the name that can be used to refer to this specific entity from other input blocks
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the number of samples and shape of samples               to be taken.  For
             example, \xmlAttr{shape}=``2,3'' will provide a 2 by 3               matrix of values,
             while \xmlAttr{shape}=``10'' will produce a vector of 10 values.               Omitting
@@ -1557,7 +1562,7 @@ Genetic Algorithm Example:
 
       The \xmlNode{variable} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{distribution}: \xmlDesc{string}, 
+        \item \xmlNode{distribution}: \xmlDesc{string},
           name of the distribution that is associated to this variable.               Its name needs
           to be contained in the \xmlNode{Distributions} block explained               in Section
           \ref{sec:distributions}. In addition, if NDDistribution is used,               the
@@ -1565,32 +1570,33 @@ Genetic Algorithm Example:
           if the \xmlNode{function} node is supplied.}
           The \xmlNode{distribution} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{dim}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{dim}: \xmlDesc{integer, optional},
                 for an NDDistribution, indicates the dimension within the NDDistribution that
                 corresponds               to this variable.
           \end{itemize}
 
-        \item \xmlNode{grid}: \xmlDesc{string}, 
+        \item \xmlNode{grid}: \xmlDesc{string},
           -- no description yet --
           The \xmlNode{grid} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{type}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{construction}: \xmlDesc{string, optional}, 
+              \item \xmlAttr{construction}: \xmlDesc{string, optional},
                 -- no description yet --
-              \item \xmlAttr{steps}: \xmlDesc{integer, optional}, 
+              \item \xmlAttr{steps}: \xmlDesc{integer, optional},
                 -- no description yet --
           \end{itemize}
 
-        \item \xmlNode{function}: \xmlDesc{string}, 
+        \item \xmlNode{function}: \xmlDesc{string},
           name of the function that               defines the calculation of this variable from
           other distributed variables.  Its name               needs to be contained in the
           \xmlNode{Functions} block explained in Section               \ref{sec:functions}. This
-          function must implement a method named ``evaluate''.               \nb{Each
-          \xmlNode{variable} must contain only one \xmlNode{Function} or
-          \xmlNode{Distribution}, but not both.}
+          function module must contain and implement a method either with the same name of the
+          function or a method named  ``evaluate''.               \nb{Each \xmlNode{variable} must
+          contain only one \xmlNode{Function} or               \xmlNode{Distribution}, but not
+          both.}
 
-        \item \xmlNode{initial}: \xmlDesc{comma-separated floats}, 
+        \item \xmlNode{initial}: \xmlDesc{comma-separated floats},
           indicates the initial values where independent trajectories for this optimization
           effort should begin. The number of entries should be the same for all variables, unless
           a variable is initialized with a sampler (see \xmlNode{samplerInit} below). Note these
@@ -1600,16 +1606,16 @@ Genetic Algorithm Example:
           beginning at the locations (1, 5), (2, 6),               (3, 7), and (4, 8).
       \end{itemize}
 
-    \item \xmlNode{TargetEvaluation}: \xmlDesc{string}, 
+    \item \xmlNode{TargetEvaluation}: \xmlDesc{string},
       name of the DataObject where the sampled outputs of the Model will be collected.
       This DataObject is the means by which the sampling entity obtains the results of requested
       samples, and so should require all the input and output variables needed for adaptive
       sampling.
       The \xmlNode{TargetEvaluation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
@@ -1618,21 +1624,21 @@ Genetic Algorithm Example:
 
       The \xmlNode{samplerInit} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{limit}: \xmlDesc{integer}, 
+        \item \xmlNode{limit}: \xmlDesc{integer},
           limits the number of Model evaluations that may be performed as part of this optimization.
           For example, a limit of 100 means at most 100 total Model evaluations may be performed.
 
-        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]}, 
+        \item \xmlNode{writeSteps}: \xmlDesc{[final, every]},
           delineates when the \xmlNode{SolutionExport} DataObject should be written to. In case
           of \xmlString{final}, only the final optimal solution for each trajectory will be written.
           In case of \xmlString{every}, the \xmlNode{SolutionExport} will be updated with each
           iteration               of the Optimizer.
 
-        \item \xmlNode{initialSeed}: \xmlDesc{integer}, 
+        \item \xmlNode{initialSeed}: \xmlDesc{integer},
           seed for random number generation. Note that by default RAVEN uses an internal seed,
           so this seed must be changed to observe changed behavior. \default{RAVEN-determined}
 
-        \item \xmlNode{type}: \xmlDesc{[min, max]}, 
+        \item \xmlNode{type}: \xmlDesc{[min, max]},
           the type of optimization to perform. \xmlString{min} will search for the lowest
           \xmlNode{objective} value, while \xmlString{max} will search for the highest value.
       \end{itemize}
@@ -1655,7 +1661,7 @@ Genetic Algorithm Example:
 
           The \xmlNode{ExpectedImprovement} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]}, 
+            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]},
               String to specify routine used for the optimization of the acquisition function.
               Acceptable options include: ('differentialEvolution', 'slsqp').
               \default{'differentialEvolution'}.
@@ -1668,7 +1674,7 @@ Genetic Algorithm Example:
               \end{itemize}
   \default{differentialEvolution}
 
-            \item \xmlNode{seedingCount}: \xmlDesc{integer}, 
+            \item \xmlNode{seedingCount}: \xmlDesc{integer},
               If the method is gradient based or typically handled with singular
               decisions (ex. slsqp approximates a quadratic program using the gradient), this number
               represents the number of trajectories for a multi-start variant (default=2N).
@@ -1690,7 +1696,7 @@ Genetic Algorithm Example:
 
           The \xmlNode{ProbabilityOfImprovement} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]}, 
+            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]},
               String to specify routine used for the optimization of the acquisition function.
               Acceptable options include: ('differentialEvolution', 'slsqp').
               \default{'differentialEvolution'}.
@@ -1703,7 +1709,7 @@ Genetic Algorithm Example:
               \end{itemize}
   \default{differentialEvolution}
 
-            \item \xmlNode{seedingCount}: \xmlDesc{integer}, 
+            \item \xmlNode{seedingCount}: \xmlDesc{integer},
               If the method is gradient based or typically handled with singular
               decisions (ex. slsqp approximates a quadratic program using the gradient), this number
               represents the number of trajectories for a multi-start variant (default=2N).
@@ -1712,18 +1718,18 @@ Genetic Algorithm Example:
               natural selection on a population),
               the number represents the population size (default=10N).
 
-            \item \xmlNode{epsilon}: \xmlDesc{float}, 
+            \item \xmlNode{epsilon}: \xmlDesc{float},
               Defines the threshold for PoI via the equation:
               $\tau = min \mu(\textbf{X}) - \epsilon$. The larger $\epsilon$ is, the
               more exploratory the algorithm and vice versa.
   \default{1.0}
 
-            \item \xmlNode{rho}: \xmlDesc{float}, 
+            \item \xmlNode{rho}: \xmlDesc{float},
               Provides a 'time-constant' for the Exploit and Explore transient settings.
               Provides the period for the oscillate transient setting.
   \default{1.0}
 
-            \item \xmlNode{transient}: \xmlDesc{[Constant, Exploit, Explore, Oscillate, DecayingOscillate]}, 
+            \item \xmlNode{transient}: \xmlDesc{[Constant, Exploit, Explore, Oscillate, DecayingOscillate]},
               Determines how the threshold $\tau$ changes as optimization progresses.
               \begin{itemize}                                                  \item Constant:
               $\epsilon$ remains the provided value.
@@ -1745,7 +1751,7 @@ Genetic Algorithm Example:
 
           The \xmlNode{LowerConfidenceBound} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]}, 
+            \item \xmlNode{optimizationMethod}: \xmlDesc{[differentialEvolution, slsqp]},
               String to specify routine used for the optimization of the acquisition function.
               Acceptable options include: ('differentialEvolution', 'slsqp').
               \default{'differentialEvolution'}.
@@ -1758,7 +1764,7 @@ Genetic Algorithm Example:
               \end{itemize}
   \default{differentialEvolution}
 
-            \item \xmlNode{seedingCount}: \xmlDesc{integer}, 
+            \item \xmlNode{seedingCount}: \xmlDesc{integer},
               If the method is gradient based or typically handled with singular
               decisions (ex. slsqp approximates a quadratic program using the gradient), this number
               represents the number of trajectories for a multi-start variant (default=2N).
@@ -1767,17 +1773,17 @@ Genetic Algorithm Example:
               natural selection on a population),
               the number represents the population size (default=10N).
 
-            \item \xmlNode{pi}: \xmlDesc{float}, 
+            \item \xmlNode{pi}: \xmlDesc{float},
               Parameter that determines the lower confidence bound. Must be
               between 0 and 1.
   \default{0.98}
 
-            \item \xmlNode{rho}: \xmlDesc{float}, 
+            \item \xmlNode{rho}: \xmlDesc{float},
               Provides a 'time-constant' for the Exploit and Explore transient settings.
               Provides the period for the oscillate transient settings.
   \default{1.0}
 
-            \item \xmlNode{transient}: \xmlDesc{[Constant, Exploit, Explore, Oscillate, DecayingOscillate]}, 
+            \item \xmlNode{transient}: \xmlDesc{[Constant, Exploit, Explore, Oscillate, DecayingOscillate]},
               Determines how the threshold $\tau$ changes as optimization progresses.
               \begin{itemize}                                                  \item Constant:
               $\epsilon$ remains the provided value.
@@ -1796,10 +1802,10 @@ Genetic Algorithm Example:
 
       The \xmlNode{ModelSelection} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{Duration}: \xmlDesc{integer}, 
+        \item \xmlNode{Duration}: \xmlDesc{integer},
           Number of iterations between each reselection of the model. Default is 1
 
-        \item \xmlNode{Method}: \xmlDesc{[External, Internal, Average]}, 
+        \item \xmlNode{Method}: \xmlDesc{[External, Internal, Average]},
           Determines methodology for selecting the model. This methodology is applied
           after every duration length.
           \begin{itemize}                                                        \item External,
@@ -1817,26 +1823,26 @@ Genetic Algorithm Example:
 
       The \xmlNode{convergence} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{acquisition}: \xmlDesc{float}, 
+        \item \xmlNode{acquisition}: \xmlDesc{float},
           Provides convergence criteria in terms of the value of the acquisition
           function at a given iteration. If the value falls below a provided threshhold,
           the optimizer is considered converged; however, it is recommended to pair this
           criteria with persistance. Default is 1e-8
 
-        \item \xmlNode{persistence}: \xmlDesc{integer}, 
+        \item \xmlNode{persistence}: \xmlDesc{integer},
           provides the number of consecutive times convergence should
           be reached before a trajectory is considered fully converged.
           This helps in preventing early false convergence. Default is 5 (BO specific)
   \default{5}
       \end{itemize}
 
-    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats}, 
+    \item \xmlNode{constant}: \xmlDesc{comma-separated strings, integers, and floats},
       allows variables that do not change value to be part of the input space.
       The \xmlNode{constant} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{name}: \xmlDesc{string, required}, 
+          \item \xmlAttr{name}: \xmlDesc{string, required},
             variable name for this constant, which will be provided to the Model.
-          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional}, 
+          \item \xmlAttr{shape}: \xmlDesc{comma-separated integers, optional},
             determines the shape of samples of the constant value.               For example,
             \xmlAttr{shape}=``2,3'' will shape the values into a 2 by 3               matrix, while
             \xmlAttr{shape}=``10'' will shape into a vector of 10 values.               Unlike the
@@ -1844,17 +1850,17 @@ Genetic Algorithm Example:
             of required values is equal to the product of the \xmlAttr{shape} values, e.g. 6 entries
             for shape ``2,3'').               \nb A model interface must be prepared to handle non-
             scalar inputs to use this option.
-          \item \xmlAttr{source}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{source}: \xmlDesc{string, optional},
             the name of the DataObject containing the value to be used for this constant.
             Requires \xmlNode{ConstantSource} node with a \xmlNode{DataObject} identified for this
             Sampler/Optimizer.
-          \item \xmlAttr{index}: \xmlDesc{integer, optional}, 
+          \item \xmlAttr{index}: \xmlDesc{integer, optional},
             the index of the realization in the \xmlNode{ConstantSource} \xmlNode{DataObject}
             containing the value for this constant. Requires \xmlNode{ConstantSource} node with
             a \xmlNode{DataObject} identified for this Sampler/Optimizer.
       \end{itemize}
 
-    \item \xmlNode{ConstantSource}: \xmlDesc{string}, 
+    \item \xmlNode{ConstantSource}: \xmlDesc{string},
       identifies a \xmlNode{DataObject} to provide \xmlNode{constant} values to the input
       space of this entity while sampling. As an alternative to providing predefined values
       for constants, the \xmlNode{ConstantSource} provides a dynamic means of always providing
@@ -1862,14 +1868,14 @@ Genetic Algorithm Example:
       calculation.
       The \xmlNode{ConstantSource} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{Constraint}: \xmlDesc{string}, 
+    \item \xmlNode{Constraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains explicit constraints for the sampling of
       the input space of the Model. From a practical point of view, this XML node must contain
       the name of a function defined in the \xmlNode{Functions} block (see
@@ -1879,13 +1885,13 @@ Genetic Algorithm Example:
       user.
       The \xmlNode{Constraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string}, 
+    \item \xmlNode{ImplicitConstraint}: \xmlDesc{string},
       name of \xmlNode{Function} which contains implicit constraints of the Model. From a practical
       point of view, this XML node must contain the name of a function defined in the
       \xmlNode{Functions}               block (see Section~\ref{sec:functions}). This external
@@ -1893,13 +1899,13 @@ Genetic Algorithm Example:
       for outputs satisfying the implicit constraints and False otherwise.
       The \xmlNode{ImplicitConstraint} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this source. Options include \xmlString{Functions}.
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this source. Options include \xmlNode{External}.
       \end{itemize}
 
-    \item \xmlNode{ROM}: \xmlDesc{string}, 
+    \item \xmlNode{ROM}: \xmlDesc{string},
       Name of a Model that optimizers may want to use during optimization. For example, the
       Bayesian Optimizer requires a ROM to select points during optimization. The model is defined
       in                                           detail with in the \xmlNode{Models} as in other
@@ -1907,13 +1913,13 @@ Genetic Algorithm Example:
       the model definition's name.
       The \xmlNode{ROM} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Sampler}: \xmlDesc{string}, 
+    \item \xmlNode{Sampler}: \xmlDesc{string},
       name of a Sampler that can be used to initialize the starting points for the trajectories
       of some of the variables. From a practical point of view, this XML node must contain the
       name of a Sampler defined in the \xmlNode{Samplers} block (see
@@ -1923,13 +1929,13 @@ Genetic Algorithm Example:
       variables, the \xmlNode{initial} XML node is required only for the remaining 3 variables.
       The \xmlNode{Sampler} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{Restart}: \xmlDesc{string}, 
+    \item \xmlNode{Restart}: \xmlDesc{string},
       name of a DataObject. Used to leverage existing data when sampling a model. For
       example, if a Model has               already been sampled, but some samples were not
       collected, the successful samples can               be stored and used instead of rerunning
@@ -1938,14 +1944,14 @@ Genetic Algorithm Example:
       being sampled.
       The \xmlNode{Restart} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             The RAVEN class for this source. Options include \xmlString{DataObject}.
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             The RAVEN type for this source. Options include any valid \xmlNode{DataObject} type,
             such as HistorySet or PointSet.
       \end{itemize}
 
-    \item \xmlNode{restartTolerance}: \xmlDesc{float}, 
+    \item \xmlNode{restartTolerance}: \xmlDesc{float},
       specifies how strictly a matching point from a \xmlNode{Restart} DataObject must match
       the desired sample point in order to be used. If a potential restart point is within a
       relative Euclidean distance (as specified by the value in this node) of a desired sample
@@ -1958,7 +1964,7 @@ Genetic Algorithm Example:
       by the Model.
       The \xmlNode{variablesTransformation} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{distribution}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{distribution}: \xmlDesc{string, optional},
             the name for the distribution defined in the XML node \xmlNode{Distributions}.
             This attribute indicates the values of \xmlNode{manifestVariables} are drawn from
             \xmlAttr{distribution}.
@@ -1966,21 +1972,21 @@ Genetic Algorithm Example:
 
       The \xmlNode{variablesTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{latentVariables}: \xmlDesc{comma-separated strings},
           user-defined latent variables that are used for the variables transformation.
           All the variables listed under this node should be also mentioned in \xmlNode{variable}.
 
-        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariables}: \xmlDesc{comma-separated strings},
           user-defined manifest variables that can be used by the \xmlNode{Model}.
 
-        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{manifestVariablesIndex}: \xmlDesc{comma-separated strings},
           user-defined manifest variables indices paired with \xmlNode{manifestVariables}.
           These indices indicate the position of manifest variables associated with multivariate
           normal               distribution defined in the XML node \xmlNode{Distributions}.
           The indices should be postive integer. If not provided, the code will use the positions
           of manifest variables listed in \xmlNode{manifestVariables} as the indices.
 
-        \item \xmlNode{method}: \xmlDesc{string}, 
+        \item \xmlNode{method}: \xmlDesc{string},
           the method that is used for the variables transformation. The currently available method
           is \xmlString{pca}.
       \end{itemize}

--- a/doc/user_manual/generated/sklRom.tex
+++ b/doc/user_manual/generated/sklRom.tex
@@ -10,27 +10,27 @@
 
   The \xmlNode{LinearDiscriminantAnalysisClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LinearDiscriminantAnalysisClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -69,60 +69,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -135,24 +135,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -172,7 +172,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -183,40 +183,40 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{solver}: \xmlDesc{string}, 
+    \item \xmlNode{solver}: \xmlDesc{string},
       Solver to use, possible values:
       \begin{itemize}                                                    \item svd: Singular value
       decomposition (default). Does not compute the covariance matrix,
@@ -227,7 +227,7 @@
       \end{itemize}
   \default{svd}
 
-    \item \xmlNode{Shrinkage}: \xmlDesc{float or string}, 
+    \item \xmlNode{Shrinkage}: \xmlDesc{float or string},
       Shrinkage parameter, possible values: 1) None: no shrinkage (default),
       2) `auto': automatic shrinkage using the Ledoit-Wolf lemma,
       3) float between 0 an d1: fixed shrinkage parameter.
@@ -235,29 +235,29 @@
       only with `lsqr' and `eigen' solvers.
   \default{None}
 
-    \item \xmlNode{priors}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{priors}: \xmlDesc{comma-separated floats},
       The class prior probabilities. By default, the class proportions are inferred from the
       training data.
   \default{None}
 
-    \item \xmlNode{n\_components}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_components}: \xmlDesc{integer},
       Number of components (<= min(n\_classes - 1, n\_features)) for dimensionality reduction.
       If None, will be set to min(n\_classes - 1, n\_features). This parameter only affects the
       transform                                                  method.
   \default{None}
 
-    \item \xmlNode{store\_covariance}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{store\_covariance}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       If True, explicitely compute the weighted within-class covariance matrix when solver
       is `svd'. The matrix is always computed and stored for the other solvers.
   \default{False}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Absolute threshold for a singular value of X to be considered significant, used to estimate
       the rank of X.                                                  Dimensions whose singular
       values are non-significant are discarded. Only used if solver is `svd'.
   \default{0.0001}
 
-    \item \xmlNode{covariance\_estimator}: \xmlDesc{integer}, 
+    \item \xmlNode{covariance\_estimator}: \xmlDesc{integer},
       covariance estimator (not supported)
   \default{None}
   \end{itemize}
@@ -271,27 +271,27 @@
 
   The \xmlNode{QuadraticDiscriminantAnalysisClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{QuadraticDiscriminantAnalysisClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -330,60 +330,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -396,24 +396,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -433,7 +433,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -444,57 +444,57 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{priors}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{priors}: \xmlDesc{comma-separated floats},
       The class prior probabilities. By default, the class
       proportions are inferred from the training data.
   \default{None}
 
-    \item \xmlNode{reg\_param}: \xmlDesc{float}, 
+    \item \xmlNode{reg\_param}: \xmlDesc{float},
       Regularizes the per-class covariance estimates by transforming
       S2 as S2 = (1 - reg\_param) * S2 + reg\_param * np.eye(n\_features),
       where S2 corresponds to the                                                  scaling\_
       attribute of a given class.
   \default{0.0}
 
-    \item \xmlNode{store\_covariance}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{store\_covariance}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       If True, the class covariance matrices are explicitely
       computed and stored in the self.covariance\_ attribute.
   \default{False}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Absolute threshold for a singular value to be considered
       significant, used to estimate the rank of Xk where Xk is the centered
       matrix of samples in class k. This parameter does not affect
@@ -515,27 +515,27 @@
 
   The \xmlNode{ARDRegression} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{ARDRegression} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -574,60 +574,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -640,24 +640,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -677,7 +677,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -688,90 +688,90 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{n\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter}: \xmlDesc{integer},
       Maximum number of iterations.
   \default{300}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.001}
 
-    \item \xmlNode{alpha\_1}: \xmlDesc{float}, 
+    \item \xmlNode{alpha\_1}: \xmlDesc{float},
       Hyper-parameter : shape parameter for the Gamma
       distribution prior over the alpha parameter.
   \default{1e-06}
 
-    \item \xmlNode{alpha\_2}: \xmlDesc{float}, 
+    \item \xmlNode{alpha\_2}: \xmlDesc{float},
       Hyper-parameter : inverse scale parameter (rate parameter)
       for the Gamma distribution prior over the alpha parameter.
   \default{1e-06}
 
-    \item \xmlNode{lambda\_1}: \xmlDesc{float}, 
+    \item \xmlNode{lambda\_1}: \xmlDesc{float},
       Hyper-parameter : shape parameter for the Gamma distribution
       prior over the lambda parameter.
   \default{1e-06}
 
-    \item \xmlNode{lambda\_2}: \xmlDesc{float}, 
+    \item \xmlNode{lambda\_2}: \xmlDesc{float},
       Hyper-parameter : inverse scale parameter (rate parameter) for
       the Gamma distribution prior over the lambda parameter.
   \default{1e-06}
 
-    \item \xmlNode{compute\_score}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{compute\_score}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       If True, compute the objective function at each step of the
       model.
   \default{False}
 
-    \item \xmlNode{threshold\_lambda}: \xmlDesc{float}, 
+    \item \xmlNode{threshold\_lambda}: \xmlDesc{float},
       threshold for removing (pruning) weights with
       shigh precision from the computation..
   \default{10000}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to calculate the intercept for this model. Specifies if a constant (a.k.a. bias or
       intercept)                                                   should be added to the decision
       function.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{True}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Verbose mode when fitting the model.
   \default{False}
   \end{itemize}
@@ -789,27 +789,27 @@
 
   The \xmlNode{BayesianRidge} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{BayesianRidge} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -848,60 +848,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -914,24 +914,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -951,7 +951,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -962,94 +962,94 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{n\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter}: \xmlDesc{integer},
       Maximum number of iterations.
   \default{300}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.001}
 
-    \item \xmlNode{alpha\_1}: \xmlDesc{float}, 
+    \item \xmlNode{alpha\_1}: \xmlDesc{float},
       Hyper-parameter : shape parameter for the Gamma
       distribution prior over the alpha parameter.
   \default{1e-06}
 
-    \item \xmlNode{alpha\_2}: \xmlDesc{float}, 
+    \item \xmlNode{alpha\_2}: \xmlDesc{float},
       Hyper-parameter : inverse scale parameter (rate parameter)
       for the Gamma distribution prior over the alpha parameter.
   \default{1e-06}
 
-    \item \xmlNode{lambda\_1}: \xmlDesc{float}, 
+    \item \xmlNode{lambda\_1}: \xmlDesc{float},
       Hyper-parameter : shape parameter for the Gamma distribution
       prior over the lambda parameter.
   \default{1e-06}
 
-    \item \xmlNode{lambda\_2}: \xmlDesc{float}, 
+    \item \xmlNode{lambda\_2}: \xmlDesc{float},
       Hyper-parameter : inverse scale parameter (rate parameter) for
       the Gamma distribution prior over the lambda parameter.
   \default{1e-06}
 
-    \item \xmlNode{alpha\_init}: \xmlDesc{float}, 
+    \item \xmlNode{alpha\_init}: \xmlDesc{float},
       Initial value for alpha (precision of the noise).
       If not set, alpha\_init is $1/Var(y)$.
   \default{None}
 
-    \item \xmlNode{lambda\_init}: \xmlDesc{float}, 
+    \item \xmlNode{lambda\_init}: \xmlDesc{float},
       Initial value for lambda (precision of the weights).
   \default{1.0}
 
-    \item \xmlNode{compute\_score}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{compute\_score}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       If True, compute the objective function at each step of the
       model.
   \default{False}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to calculate the intercept for this model. Specifies if a constant (a.k.a. bias or
       intercept)                                                   should be added to the decision
       function.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Verbose mode when fitting the model.
   \default{False}
   \end{itemize}
@@ -1064,27 +1064,27 @@
 
   The \xmlNode{ElasticNet} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{ElasticNet} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -1123,60 +1123,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -1189,24 +1189,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -1226,7 +1226,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -1237,51 +1237,51 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       specifies a constant                                                  that multiplies the
       penalty terms.                                                  $alpha = 0$ is equivalent to
       an ordinary least square, solved by the
       \textbf{LinearRegression} object.
   \default{1.0}
 
-    \item \xmlNode{l1\_ratio}: \xmlDesc{float}, 
+    \item \xmlNode{l1\_ratio}: \xmlDesc{float},
       specifies the                                                  ElasticNet mixing parameter,
       with $0 <= l1\_ratio <= 1$.                                                  For $l1\_ratio =
       0$ the penalty is an L2 penalty.                                                  For
@@ -1289,37 +1289,37 @@
       l1\_ratio < 1$, the penalty is a combination of L1 and L2.
   \default{0.5}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{precompute}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{precompute}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{False}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, forces the coefficients to be positive.
   \default{True}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This (setting to `random'')
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
@@ -1335,27 +1335,27 @@
 
   The \xmlNode{ElasticNetCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{ElasticNetCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -1394,60 +1394,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -1460,24 +1460,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -1497,7 +1497,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -1508,49 +1508,49 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       Length of the path. $eps=1e-3$ means that
       $alpha\_min / alpha\_max = 1e-3$.
   \default{0.001}
 
-    \item \xmlNode{l1\_ratio}: \xmlDesc{float}, 
+    \item \xmlNode{l1\_ratio}: \xmlDesc{float},
       specifies the                                                  float between 0 and 1 passed to
       ElasticNet (scaling between l1 and l2 penalties).
       For $l1\_ratio = 0$ the penalty is an L2 penalty. For $l1\_ratio = 1$ it is
@@ -1562,42 +1562,42 @@
       as in $[.1, .5, .7, .9, .95, .99, 1]$.
   \default{0.5}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{auto}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds.
   \default{None}
 
-    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, forces the coefficients to be positive.
   \default{True}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This (setting to `random'')
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{n\_alphas}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_alphas}: \xmlDesc{integer},
       Number of alphas along the regularization path,
       used for each l1\_ratio.
   \default{100}
@@ -1614,27 +1614,27 @@
 
   The \xmlNode{Lars} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{Lars} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -1673,60 +1673,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -1739,24 +1739,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -1776,7 +1776,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -1787,71 +1787,71 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       The machine-precision regularization in the computation of the Cholesky
       diagonal factors. Increase this for very ill-conditioned systems. Unlike the tol
       parameter in some iterative optimization-based algorithms, this parameter does not
       control the tolerance of the optimization.
   \default{2.220446049250313e-16}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{auto}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{True}
 
-    \item \xmlNode{n\_nonzero\_coefs}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_nonzero\_coefs}: \xmlDesc{integer},
       Target number of non-zero coefficients.
   \default{500}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Sets the verbosity amount.
   \default{False}
 
-    \item \xmlNode{fit\_path}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_path}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       If True the full path is stored in the coef\_path\_ attribute.
       If you compute the solution for a large problem or many targets,
       setting fit\_path to False will lead to a speedup, especially with a
@@ -1871,27 +1871,27 @@
 
   The \xmlNode{LarsCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LarsCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -1930,60 +1930,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -1996,24 +1996,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -2033,7 +2033,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -2044,77 +2044,77 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       The machine-precision regularization in the computation of the Cholesky
       diagonal factors. Increase this for very ill-conditioned systems. Unlike the tol
       parameter in some iterative optimization-based algorithms, this parameter does not
       control the tolerance of the optimization.
   \default{2.220446049250313e-16}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{auto}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{True}
 
-    \item \xmlNode{max\_n\_alphas}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_n\_alphas}: \xmlDesc{integer},
       The maximum number of points on the path used to compute the
       residuals in the cross-validation.
   \default{1000}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Sets the verbosity amount.
   \default{False}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Maximum number of iterations to perform.
   \default{500}
   \end{itemize}
@@ -2130,27 +2130,27 @@
 
   The \xmlNode{Lasso} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{Lasso} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -2189,60 +2189,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -2255,24 +2255,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -2292,7 +2292,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -2303,83 +2303,83 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Constant that multiplies the L1 term. Defaults to 1.0.
       $alpha = 0$ is equivalent to an ordinary least square, solved by
       the LinearRegression object. For numerical reasons, using $alpha = 0$
       with the Lasso object is not advised.
   \default{1.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       The tolerance for the optimization: if the updates are smaller
       than tol, the optimization code checks the dual gap for optimality and
       continues until it is smaller than tol..
   \default{0.0001}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{precompute}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{precompute}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{False}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, forces the coefficients to be positive.
   \default{False}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This (setting to `random'')
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
@@ -2397,27 +2397,27 @@
 
   The \xmlNode{LassoCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LassoCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -2456,60 +2456,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -2522,24 +2522,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -2559,7 +2559,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -2570,93 +2570,93 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       Length of the path. $eps=1e-3$ means that
       $alpha\_min / alpha\_max = 1e-3$.
   \default{0.001}
 
-    \item \xmlNode{n\_alphas}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_alphas}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{100}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{auto}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, forces the coefficients to be positive.
   \default{False}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This (setting to `random'')
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{None}
 
-    \item \xmlNode{alphas}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{alphas}: \xmlDesc{comma-separated floats},
       List of alphas where to compute the models. If None alphas
       are set automatically.
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Amount of verbosity.
   \default{False}
   \end{itemize}
@@ -2671,27 +2671,27 @@
 
   The \xmlNode{LassoLars} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LassoLars} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -2730,60 +2730,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -2796,24 +2796,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -2833,7 +2833,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -2844,78 +2844,78 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Constant that multiplies the L1 term. Defaults to 1.0.
       $alpha = 0$ is equivalent to an ordinary least square, solved by
       the LinearRegression object. For numerical reasons, using $alpha = 0$
       with the Lasso object is not advised.
   \default{1.0}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{auto}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{500}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       The machine-precision regularization in the computation of the Cholesky
       diagonal factors. Increase this for very ill-conditioned systems. Unlike the tol
       parameter in some iterative optimization-based algorithms, this parameter does not
       control the tolerance of the optimization.
   \default{2.220446049250313e-16}
 
-    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, forces the coefficients to be positive.
   \default{False}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Amount of verbosity.
   \default{False}
   \end{itemize}
@@ -2931,27 +2931,27 @@
 
   The \xmlNode{LassoLarsCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LassoLarsCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -2990,60 +2990,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -3056,24 +3056,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -3093,7 +3093,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -3104,81 +3104,81 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{500}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{True}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{auto}
 
-    \item \xmlNode{max\_n\_alphas}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_n\_alphas}: \xmlDesc{integer},
       The maximum number of points on the path used to compute the residuals in
       the cross-validation
   \default{1000}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       The machine-precision regularization in the computation of the Cholesky
       diagonal factors. Increase this for very ill-conditioned systems. Unlike the tol
       parameter in some iterative optimization-based algorithms, this parameter does not
       control the tolerance of the optimization.
   \default{2.220446049250313e-16}
 
-    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, forces the coefficients to be positive.
   \default{False}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Amount of verbosity.
   \default{False}
   \end{itemize}
@@ -3196,27 +3196,27 @@
 
   The \xmlNode{LassoLarsIC} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LassoLarsIC} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -3255,60 +3255,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -3321,24 +3321,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -3358,7 +3358,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -3369,75 +3369,75 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{criterion}: \xmlDesc{[bic, aic]}, 
+    \item \xmlNode{criterion}: \xmlDesc{[bic, aic]},
       The type of criterion to use.
   \default{aic}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{500}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram matrix to speed up calculations.
       For sparse input this option is always True to preserve sparsity.
   \default{auto}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       The machine-precision regularization in the computation of the Cholesky
       diagonal factors. Increase this for very ill-conditioned systems. Unlike the tol
       parameter in some iterative optimization-based algorithms, this parameter does not
       control the tolerance of the optimization.
   \default{2.220446049250313e-16}
 
-    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{positive}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, forces the coefficients to be positive.
   \default{False}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Amount of verbosity.
   \default{False}
   \end{itemize}
@@ -3452,27 +3452,27 @@
 
   The \xmlNode{LinearRegression} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LinearRegression} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -3511,60 +3511,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -3577,24 +3577,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -3614,7 +3614,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -3625,45 +3625,45 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
@@ -3688,27 +3688,27 @@
 
   The \xmlNode{LogisticRegression} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LogisticRegression} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -3747,60 +3747,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -3813,24 +3813,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -3850,7 +3850,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -3861,65 +3861,65 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{penalty}: \xmlDesc{[l1, l2, elasticnet, none]}, 
+    \item \xmlNode{penalty}: \xmlDesc{[l1, l2, elasticnet, none]},
       Used to specify the norm used in the penalization. The newton-cg, sag and lbfgs solvers
       support only l2 penalties. elasticnet is only supported by the saga solver. If none (
       not supported by the liblinear solver), no regularization is applied.
   \default{l2}
 
-    \item \xmlNode{dual}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{dual}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Select the algorithm to either solve the dual or primal optimization problem.
       Prefer dual=False when $n\_samples > n\_features$.
   \default{True}
 
-    \item \xmlNode{C}: \xmlDesc{float}, 
+    \item \xmlNode{C}: \xmlDesc{float},
       Regularization parameter. The strength of the regularization is inversely
       proportional to C.Must be strictly positive.
   \default{1.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to calculate the intercept for this model. Specifies if a constant (a.k.a. bias or
       intercept) should be added to the decision function.
   \default{True}
 
-    \item \xmlNode{intercept\_scaling}: \xmlDesc{float}, 
+    \item \xmlNode{intercept\_scaling}: \xmlDesc{float},
       When fit\_intercept is True, instance vector x becomes $[x, intercept\_scaling]$,
       i.e. a “synthetic” feature with constant value equals to intercept\_scaling is appended
       to the instance vector. The intercept becomes $intercept\_scaling * synthetic\_feature\_weight$
@@ -3929,7 +3929,7 @@
       increased.
   \default{1.0}
 
-    \item \xmlNode{solver}: \xmlDesc{[newton-cg, lbfgs, liblinear, sag, saga]}, 
+    \item \xmlNode{solver}: \xmlDesc{[newton-cg, lbfgs, liblinear, sag, saga]},
       Algorithm to use in the optimization problem.
       \begin{itemize}                                                    \item For small datasets,
       ``liblinear'' is a good choice, whereas ``sag'' and ``saga'' are faster for large ones.
@@ -3943,11 +3943,11 @@
       \end{itemize}
   \default{lbfgs}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Hard limit on iterations within solver.``-1'' for no limit
   \default{100}
 
-    \item \xmlNode{multi\_class}: \xmlDesc{[auto, ovr, multinomial]}, 
+    \item \xmlNode{multi\_class}: \xmlDesc{[auto, ovr, multinomial]},
       If the option chosen is ``ovr'', then a binary problem is fit for each label. For
       ``multinomial''                                                  the loss minimised is the
       multinomial loss fit across the entire probability distribution, even when the
@@ -3956,20 +3956,20 @@
       solver=``liblinear'', and otherwise selects ``multinomial''.
   \default{auto}
 
-    \item \xmlNode{l1\_ratio}: \xmlDesc{float}, 
+    \item \xmlNode{l1\_ratio}: \xmlDesc{float},
       The Elastic-Net mixing parameter, with $0 <= l1\_ratio <= 1$. Only used if
       penalty=``elasticnet''.                                                  Setting $l1\_ratio=0$
       is equivalent to using penalty=``l2'', while setting $l1\_ratio=1$ is equivalent to using
       $penalty=``l1''$. For $0 < l1\_ratio <1$, the penalty is a combination of L1 and L2.
   \default{0.5}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
   \default{None}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used when solver == ‘sag’, ‘saga’ or ‘liblinear’ to shuffle the data.
   \default{None}
   \end{itemize}
@@ -3986,27 +3986,27 @@
 
   The \xmlNode{MultiTaskElasticNet} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{MultiTaskElasticNet} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -4045,60 +4045,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -4111,24 +4111,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -4148,7 +4148,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -4159,51 +4159,51 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       specifies a constant                                                  that multiplies the
       penalty terms.                                                  $alpha = 0$ is equivalent to
       an ordinary least square, solved by the
       \textbf{LinearRegression} object.
   \default{1.0}
 
-    \item \xmlNode{l1\_ratio}: \xmlDesc{float}, 
+    \item \xmlNode{l1\_ratio}: \xmlDesc{float},
       specifies the                                                  ElasticNet mixing parameter,
       with $0 <= l1\_ratio <= 1$.                                                  For $l1\_ratio =
       0$ the penalty is an L2 penalty.                                                  For
@@ -4211,28 +4211,28 @@
       l1\_ratio < 1$, the penalty is a combination of L1 and L2.
   \default{0.5}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This (setting to `random'')
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
@@ -4251,27 +4251,27 @@
 
   The \xmlNode{MultiTaskElasticNetCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{MultiTaskElasticNetCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -4310,60 +4310,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -4376,24 +4376,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -4413,7 +4413,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -4424,52 +4424,52 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       Length of the path. $eps=1e-3$ means that $alpha\_min / alpha\_max = 1e-3$.
   \default{0.001}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{n\_alpha}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_alpha}: \xmlDesc{integer},
       Number of alphas along the regularization path.
   \default{100}
 
-    \item \xmlNode{l1\_ratio}: \xmlDesc{float}, 
+    \item \xmlNode{l1\_ratio}: \xmlDesc{float},
       specifies the                                                  ElasticNet mixing parameter,
       with $0 <= l1\_ratio <= 1$.                                                  For $l1\_ratio =
       0$ the penalty is an L2 penalty.                                                  For
@@ -4477,28 +4477,28 @@
       l1\_ratio < 1$, the penalty is a combination of L1 and L2.
   \default{0.5}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This (setting to `random'')
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{5}
@@ -4515,27 +4515,27 @@
 
   The \xmlNode{MultiTaskLasso} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{MultiTaskLasso} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -4574,60 +4574,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -4640,24 +4640,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -4677,7 +4677,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -4688,74 +4688,74 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Constant that multiplies the L1 term. Defaults to 1.0.
       $alpha = 0$ is equivalent to an ordinary least square, solved by
       the LinearRegression object. For numerical reasons, using $alpha = 0$
       with the Lasso object is not advised.
   \default{1.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       The tolerance for the optimization: if the updates are smaller
       than tol, the optimization code checks the dual gap for optimality and
       continues until it is smaller than tol..
   \default{0.0001}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This setting
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
@@ -4774,27 +4774,27 @@
 
   The \xmlNode{MultiTaskLassoCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{MultiTaskLassoCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -4833,60 +4833,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -4899,24 +4899,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -4936,7 +4936,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -4947,73 +4947,73 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{eps}: \xmlDesc{float}, 
+    \item \xmlNode{eps}: \xmlDesc{float},
       Length of the path. $eps=1e-3$ means that $alpha\_min / alpha\_max = 1e-3$.
   \default{0.001}
 
-    \item \xmlNode{n\_alpha}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_alpha}: \xmlDesc{integer},
       Number of alphas along the regularization path.
   \default{100}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{False}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of iterations.
   \default{1000}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]}, 
+    \item \xmlNode{selection}: \xmlDesc{[cyclic, random]},
       If set to ``random'', a random coefficient is updated every iteration
       rather than looping over features sequentially by default. This (setting to `random'')
       often leads to significantly faster convergence especially when tol is higher than $1e-4$
   \default{cyclic}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{5}
@@ -5033,27 +5033,27 @@
 
   The \xmlNode{OrthogonalMatchingPursuit} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{OrthogonalMatchingPursuit} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -5092,60 +5092,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -5158,24 +5158,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -5195,7 +5195,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -5206,60 +5206,60 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{n\_nonzero\_coefs}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_nonzero\_coefs}: \xmlDesc{integer},
       Desired number of non-zero entries in the solution. If None (by default)
       this value is set to ten-percent of n\_features.
   \default{None}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Maximum norm of the residual.
   \default{None}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{True}
 
-    \item \xmlNode{precompute}: \xmlDesc{string}, 
+    \item \xmlNode{precompute}: \xmlDesc{string},
       Whether to use a precomputed Gram and Xy matrix to speed up calculations.
       Improves performance when n\_targets or n\_samples is very large.
   \default{auto}
@@ -5280,27 +5280,27 @@
 
   The \xmlNode{OrthogonalMatchingPursuitCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{OrthogonalMatchingPursuitCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -5339,60 +5339,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -5405,24 +5405,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -5442,7 +5442,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -5453,61 +5453,61 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True,
       the regressors X will be normalized before regression by subtracting the mean and
       dividing by the l2-norm.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Maximum numbers of iterations to perform, therefore maximum
       features to include. Ten-percent of n\_features but at least 5 if available.
   \default{None}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Amount of verbosity.
   \default{False}
   \end{itemize}
@@ -5525,27 +5525,27 @@
 
   The \xmlNode{PassiveAggressiveClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{PassiveAggressiveClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -5584,60 +5584,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -5650,24 +5650,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -5687,7 +5687,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -5698,91 +5698,91 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{C}: \xmlDesc{float}, 
+    \item \xmlNode{C}: \xmlDesc{float},
       Maximum step size (regularization).
   \default{1.0}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of passes over the training data (aka epochs).
   \default{1000}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       The stopping criterion.
   \default{0.001}
 
-    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       hether to use early stopping to terminate training when validation score is not
       improving. If set to True, it will automatically set aside a stratified fraction of training
       data as validation and terminate training when validation score is not improving by at least
       tol for n\_iter\_no\_change consecutive epochs.
   \default{False}
 
-    \item \xmlNode{validation\_fraction}: \xmlDesc{float}, 
+    \item \xmlNode{validation\_fraction}: \xmlDesc{float},
       The proportion of training data to set aside as validation set for early stopping.
       Must be between 0 and 1. Only used if early\_stopping is True.
   \default{0.1}
 
-    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer},
       Number of iterations with no improvement to wait before early stopping.
   \default{5}
 
-    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether or not the training data should be shuffled after each epoch.
   \default{True}
 
-    \item \xmlNode{loss}: \xmlDesc{[hinge,  squared\_hinge]}, 
+    \item \xmlNode{loss}: \xmlDesc{[hinge,  squared\_hinge]},
       The loss function to be used: hinge: equivalent to PA-I.
       squared\_hinge: equivalent to PA-II.
   \default{hinge}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to shuffle the training data, when shuffle is set to
       True. Pass an int for reproducible output across multiple function calls.
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{integer}, 
+    \item \xmlNode{verbose}: \xmlDesc{integer},
       The verbosity level
   \default{0}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
@@ -5797,27 +5797,27 @@
 
   The \xmlNode{PassiveAggressiveRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{PassiveAggressiveRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -5856,60 +5856,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -5922,24 +5922,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -5959,7 +5959,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -5970,101 +5970,101 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{C}: \xmlDesc{float}, 
+    \item \xmlNode{C}: \xmlDesc{float},
       Maximum step size (regularization).
   \default{1.0}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of passes over the training data (aka epochs).
   \default{1000}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       The stopping criterion.
   \default{0.001}
 
-    \item \xmlNode{epsilon}: \xmlDesc{float}, 
+    \item \xmlNode{epsilon}: \xmlDesc{float},
       If the difference between the current prediction and the
       correct label is below this threshold, the model is not updated.
   \default{0.1}
 
-    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       hether to use early stopping to terminate training when validation score is not
       improving. If set to True, it will automatically set aside a stratified fraction of training
       data as validation and terminate training when validation score is not improving by at least
       tol for n\_iter\_no\_change consecutive epochs.
   \default{False}
 
-    \item \xmlNode{validation\_fraction}: \xmlDesc{float}, 
+    \item \xmlNode{validation\_fraction}: \xmlDesc{float},
       The proportion of training data to set aside as validation set for early stopping.
       Must be between 0 and 1. Only used if early\_stopping is True.
   \default{0.1}
 
-    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer},
       Number of iterations with no improvement to wait before early stopping.
   \default{5}
 
-    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether or not the training data should be shuffled after each epoch.
   \default{True}
 
-    \item \xmlNode{loss}: \xmlDesc{[epsilon\_insensitive,  squared\_epsilon\_insensitive]}, 
+    \item \xmlNode{loss}: \xmlDesc{[epsilon\_insensitive,  squared\_epsilon\_insensitive]},
       The loss function to be used: epsilon\_insensitive: equivalent to PA-I.
       squared\_epsilon\_insensitive: equivalent to PA-II.
   \default{epsilon\_insensitive}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to shuffle the training data, when shuffle is set to
       True. Pass an int for reproducible output across multiple function calls.
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{integer}, 
+    \item \xmlNode{verbose}: \xmlDesc{integer},
       The verbosity level
   \default{0}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
 
-    \item \xmlNode{average}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{average}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, computes the averaged SGD weights and
       stores the result in the coef\_ attribute.
   \default{False}
@@ -6082,27 +6082,27 @@
 
   The \xmlNode{Perceptron} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{Perceptron} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -6141,60 +6141,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -6207,24 +6207,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -6244,7 +6244,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -6255,100 +6255,100 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{penalty}: \xmlDesc{[l2,  l1, elasticnet]}, 
+    \item \xmlNode{penalty}: \xmlDesc{[l2,  l1, elasticnet]},
       The penalty (aka regularization term) to be used.
   \default{None}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Constant that multiplies the regularization term if regularization is used.
   \default{0.0001}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of passes over the training data (aka epochs).
   \default{1000}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       The stopping criterion.
   \default{0.001}
 
-    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer},
       Number of iterations with no improvement to wait before early stopping.
   \default{5}
 
-    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether or not the training data should be shuffled after each epoch.
   \default{True}
 
-    \item \xmlNode{eta0}: \xmlDesc{float}, 
+    \item \xmlNode{eta0}: \xmlDesc{float},
       The stopping criterion.
   \default{1}
 
-    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       hether to use early stopping to terminate training when validation score is not
       improving. If set to True, it will automatically set aside a stratified fraction of training
       data as validation and terminate training when validation score is not improving by at least
       tol for n\_iter\_no\_change consecutive epochs.
   \default{False}
 
-    \item \xmlNode{validation\_fraction}: \xmlDesc{float}, 
+    \item \xmlNode{validation\_fraction}: \xmlDesc{float},
       The proportion of training data to set aside as validation set for early stopping.
       Must be between 0 and 1. Only used if early\_stopping is True.
   \default{0.1}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
   \default{None}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to shuffle the training data, when shuffle is set to
       True. Pass an int for reproducible output across multiple function calls.
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{integer}, 
+    \item \xmlNode{verbose}: \xmlDesc{integer},
       The verbosity level
   \default{0}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
@@ -6365,27 +6365,27 @@
 
   The \xmlNode{Ridge} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{Ridge} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -6424,60 +6424,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -6490,24 +6490,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -6527,7 +6527,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -6538,66 +6538,66 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Regularization strength; must be a positive float. Regularization
       improves the conditioning of the problem and reduces the variance of the estimates.
       Larger values specify stronger regularization. Alpha corresponds to $1 / (2C)$ in other
       linear models such as LogisticRegression or LinearSVC.
   \default{1.0}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True, the
       regressors X will be normalized before regression by subtracting the mean and dividing
       by the l2-norm.
   \default{False}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Maximum number of iterations for conjugate gradient solver.
   \default{None}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Precision of the solution
   \default{0.001}
 
-    \item \xmlNode{solver}: \xmlDesc{[auto, svd, cholesky, lsqr, sparse\_cg, sag, saga]}, 
+    \item \xmlNode{solver}: \xmlDesc{[auto, svd, cholesky, lsqr, sparse\_cg, sag, saga]},
       Solver to use in the computational routines:
       \begin{itemize}                                                    \item auto, chooses the
       solver automatically based on the type of data.
@@ -6632,27 +6632,27 @@
 
   The \xmlNode{RidgeCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{RidgeCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -6691,60 +6691,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -6757,24 +6757,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -6794,7 +6794,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -6805,51 +6805,51 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True, the
       regressors X will be normalized before regression by subtracting the mean and dividing
       by the l2-norm.
   \default{False}
 
-    \item \xmlNode{gcv\_mode}: \xmlDesc{[auto, svd, eigen]}, 
+    \item \xmlNode{gcv\_mode}: \xmlDesc{[auto, svd, eigen]},
       Flag indicating which strategy to use when performing Leave-One-Out Cross-Validation.
       Options are:                                                  \begin{itemize}
       \item \textit{auto}, use ``svd'' if $n\_samples > n\_features$, otherwise use ``eigen''
@@ -6859,19 +6859,19 @@
       \end{itemize}
   \default{auto}
 
-    \item \xmlNode{alpha\_per\_target}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{alpha\_per\_target}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Flag indicating whether to optimize the alpha value for each target separately
       (for multi-output settings: multiple prediction targets). When set to True, after fitting,
       the alpha\_ attribute will contain a value for each target. When set to False, a single alpha
       is used for all targets. New in version 0.24. (not used)
   \default{False}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{None}
 
-    \item \xmlNode{alphas}: \xmlDesc{tuple of comma-separated float}, 
+    \item \xmlNode{alphas}: \xmlDesc{tuple of comma-separated float},
       Array of alpha values to try. Regularization strength; must be a positive float.
       Regularization                                                  improves the conditioning of
       the problem and reduces the variance of the estimates.
@@ -6879,12 +6879,12 @@
       linear models such as LogisticRegression or LinearSVC.
   \default{(0.1, 1.0, 10.0)}
 
-    \item \xmlNode{scoring}: \xmlDesc{string}, 
+    \item \xmlNode{scoring}: \xmlDesc{string},
       A string (see model evaluation documentation) or a scorer
       callable object / function with signature.
   \default{None}
 
-    \item \xmlNode{store\_cv\_values}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{store\_cv\_values}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Flag indicating if the cross-validation values corresponding
       to each alpha should be stored in the cv\_values\_ attribute (see below).
       This flag is only compatible with cv=None (i.e. using Leave-One-Out
@@ -6901,27 +6901,27 @@
 
   The \xmlNode{RidgeClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{RidgeClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -6960,60 +6960,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -7026,24 +7026,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -7063,7 +7063,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -7074,66 +7074,66 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Regularization strength; must be a positive float. Regularization
       improves the conditioning of the problem and reduces the variance of the estimates.
       Larger values specify stronger regularization. Alpha corresponds to $1 / (2C)$ in other
       linear models such as LogisticRegression or LinearSVC.
   \default{1.0}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True, the
       regressors X will be normalized before regression by subtracting the mean and dividing
       by the l2-norm.
   \default{False}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Maximum number of iterations for conjugate gradient solver.
   \default{None}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Precision of the solution
   \default{0.001}
 
-    \item \xmlNode{solver}: \xmlDesc{[auto, svd, cholesky, lsqr, sparse\_cg, sag, saga]}, 
+    \item \xmlNode{solver}: \xmlDesc{[auto, svd, cholesky, lsqr, sparse\_cg, sag, saga]},
       Solver to use in the computational routines:
       \begin{itemize}                                                    \item auto, chooses the
       solver automatically based on the type of data.
@@ -7156,13 +7156,13 @@
       sklearn.preprocessing.                                                  \end{itemize}
   \default{auto}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
   \default{None}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to shuffle the training data, when shuffle is set to
       True. Pass an int for reproducible output across multiple function calls.
   \default{None}
@@ -7179,27 +7179,27 @@
 
   The \xmlNode{RidgeClassifierCV} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{RidgeClassifierCV} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -7238,60 +7238,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -7304,24 +7304,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -7341,7 +7341,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -7352,56 +7352,56 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       This parameter is ignored when fit\_intercept is set to False. If True, the
       regressors X will be normalized before regression by subtracting the mean and dividing
       by the l2-norm.
   \default{False}
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       Determines the cross-validation splitting strategy.
       It specifies the number of folds..
   \default{None}
 
-    \item \xmlNode{alphas}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{alphas}: \xmlDesc{comma-separated floats},
       Array of alpha values to try. Regularization strength; must be a positive float.
       Regularization                                                  improves the conditioning of
       the problem and reduces the variance of the estimates.
@@ -7409,18 +7409,18 @@
       linear models such as LogisticRegression or LinearSVC.
   \default{[0.1, 1.0, 10.0]}
 
-    \item \xmlNode{scoring}: \xmlDesc{string}, 
+    \item \xmlNode{scoring}: \xmlDesc{string},
       A string (see model evaluation documentation) or a scorer
       callable object / function with signature.
   \default{None}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
   \default{None}
 
-    \item \xmlNode{store\_cv\_values}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{store\_cv\_values}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Flag indicating if the cross-validation values corresponding
       to each alpha should be stored in the cv\_values\_ attribute (see below).
       This flag is only compatible with cv=None (i.e. using Leave-One-Out
@@ -7446,27 +7446,27 @@
 
   The \xmlNode{SGDClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{SGDClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -7505,60 +7505,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -7571,24 +7571,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -7608,7 +7608,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -7619,40 +7619,40 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{loss}: \xmlDesc{[hinge, log, modified\_huber, squared\_hinge, perceptron, squared\_loss, huber, epsilon\_insensitive, squared\_epsilon\_insensitive]}, 
+    \item \xmlNode{loss}: \xmlDesc{[hinge, log, modified\_huber, squared\_hinge, perceptron, squared\_loss, huber, epsilon\_insensitive, squared\_epsilon\_insensitive]},
       The loss function to be used. Defaults to ``hinge'', which gives a linear SVM.The ``log'' loss
       gives logistic regression, a                                                  probabilistic
       classifier. ``modified\_huber'' is another smooth loss that brings tolerance to outliers as
@@ -7663,44 +7663,44 @@
       SGDRegressor for a description.
   \default{hinge}
 
-    \item \xmlNode{penalty}: \xmlDesc{[l2, l1, elasticnet]}, 
+    \item \xmlNode{penalty}: \xmlDesc{[l2, l1, elasticnet]},
       The penalty (aka regularization term) to be used. Defaults to ``l2'' which is the standard
       regularizer for linear SVM models.                                                  ``l1'' and
       ``elasticnet'' might bring sparsity to the model (feature selection) not achievable with
       ``l2''.
   \default{l2}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Constant that multiplies the regularization term. The higher the value, the stronger the
       regularization. Also used to compute                                                  the
       learning rate when set to learning\_rate is set to ``optimal''.
   \default{0.0001}
 
-    \item \xmlNode{l1\_ratio}: \xmlDesc{float}, 
+    \item \xmlNode{l1\_ratio}: \xmlDesc{float},
       The Elastic Net mixing parameter, with $0 <= l1\_ratio <= 1$. $l1\_ratio=0$ corresponds to L2
       penalty, $l1\_ratio=1$ to L1.                                                  Only used if
       penalty is ``elasticnet''.
   \default{0.15}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of passes over the training data (aka epochs).
   \default{1000}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       The stopping criterion. If it is not None, training will stop when $(loss > best\_loss - tol)$
       for $n\_iter\_no\_change$                                                  consecutive epochs.
   \default{0.001}
 
-    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       TWhether or not the training data should be shuffled after each epoch
   \default{True}
 
-    \item \xmlNode{epsilon}: \xmlDesc{float}, 
+    \item \xmlNode{epsilon}: \xmlDesc{float},
       Epsilon in the epsilon-insensitive loss functions; only if loss is ``huber'',
       ``epsilon\_insensitive'', or
       ``squared\_epsilon\_insensitive''. For ``huber'', determines the threshold at which it becomes
@@ -7710,7 +7710,7 @@
       threshold.
   \default{0.1}
 
-    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, optimal, invscaling, adaptive]}, 
+    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, optimal, invscaling, adaptive]},
       The learning rate schedule:                                                  \begin{itemize}
       \item constant: $eta = eta0$                                                   \item optimal:
       $eta = 1.0 / (alpha * (t + t0))$ where t0 is chosen by a heuristic proposed by Leon Bottou.
@@ -7722,53 +7722,53 @@
       learning rate is divided by 5.                                                  \end{itemize}
   \default{optimal}
 
-    \item \xmlNode{eta0}: \xmlDesc{float}, 
+    \item \xmlNode{eta0}: \xmlDesc{float},
       The initial learning rate for the ``constant'', ``invscaling'' or ``adaptive'' schedules. The
       default value is 0.0                                                  as eta0 is not used by
       the default schedule ``optimal''.
   \default{0.0}
 
-    \item \xmlNode{power\_t}: \xmlDesc{float}, 
+    \item \xmlNode{power\_t}: \xmlDesc{float},
       The exponent for inverse scaling learning rate.
   \default{0.5}
 
-    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       hether to use early stopping to terminate training when validation score is not
       improving. If set to True, it will automatically set aside a stratified fraction of training
       data as validation and terminate training when validation score is not improving by at least
       tol for n\_iter\_no\_change consecutive epochs.
   \default{False}
 
-    \item \xmlNode{validation\_fraction}: \xmlDesc{float}, 
+    \item \xmlNode{validation\_fraction}: \xmlDesc{float},
       The proportion of training data to set aside as validation set for early stopping.
       Must be between 0 and 1. Only used if early\_stopping is True.
   \default{0.1}
 
-    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer},
       Number of iterations with no improvement to wait before early stopping.
   \default{5}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to shuffle the training data, when shuffle is set to
       True. Pass an int for reproducible output across multiple function calls.
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{integer}, 
+    \item \xmlNode{verbose}: \xmlDesc{integer},
       The verbosity level
   \default{0}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
   \default{None}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
 
-    \item \xmlNode{average}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{average}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, computes the averaged SGD weights accross
       all updates and stores the result in the coef\_ attribute.
   \default{False}
@@ -7794,27 +7794,27 @@
 
   The \xmlNode{SGDRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{SGDRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -7853,60 +7853,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -7919,24 +7919,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -7956,7 +7956,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -7967,40 +7967,40 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{loss}: \xmlDesc{[squared\_loss, huber, epsilon\_insensitive, squared\_epsilon\_insensitive]}, 
+    \item \xmlNode{loss}: \xmlDesc{[squared\_loss, huber, epsilon\_insensitive, squared\_epsilon\_insensitive]},
       The loss function to be used.                                                  The
       ``squared\_loss'' refers to the ordinary least squares fit. ``huber'' modifies
       ``squared\_loss'' to focus less on getting outliers correct by
@@ -8010,44 +8010,44 @@
       becomes squared loss past a tolerance of epsilon.
   \default{squared\_loss}
 
-    \item \xmlNode{penalty}: \xmlDesc{[l2, l1, elasticnet]}, 
+    \item \xmlNode{penalty}: \xmlDesc{[l2, l1, elasticnet]},
       The penalty (aka regularization term) to be used. Defaults to ``l2'' which is the standard
       regularizer for linear SVM models.                                                  ``l1'' and
       ``elasticnet'' might bring sparsity to the model (feature selection) not achievable with
       ``l2''.
   \default{l2}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Constant that multiplies the regularization term. The higher the value, the stronger the
       regularization. Also used to compute                                                  the
       learning rate when set to learning\_rate is set to ``optimal''.
   \default{0.0001}
 
-    \item \xmlNode{l1\_ratio}: \xmlDesc{float}, 
+    \item \xmlNode{l1\_ratio}: \xmlDesc{float},
       The Elastic Net mixing parameter, with $0 <= l1\_ratio <= 1$. $l1\_ratio=0$ corresponds to L2
       penalty, $l1\_ratio=1$ to L1.                                                  Only used if
       penalty is ``elasticnet''.
   \default{0.15}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the intercept should be estimated or not. If False,
       the data is assumed to be already centered.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       The maximum number of passes over the training data (aka epochs).
   \default{1000}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       The stopping criterion. If it is not None, training will stop when $(loss > best\_loss - tol)$
       for $n\_iter\_no\_change$                                                  consecutive epochs.
   \default{0.001}
 
-    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       TWhether or not the training data should be shuffled after each epoch
   \default{True}
 
-    \item \xmlNode{epsilon}: \xmlDesc{float}, 
+    \item \xmlNode{epsilon}: \xmlDesc{float},
       Epsilon in the epsilon-insensitive loss functions; only if loss is ``huber'',
       ``epsilon\_insensitive'', or
       ``squared\_epsilon\_insensitive''. For ``huber'', determines the threshold at which it becomes
@@ -8057,7 +8057,7 @@
       threshold.
   \default{0.1}
 
-    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, optimal, invscaling, adaptive]}, 
+    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, optimal, invscaling, adaptive]},
       The learning rate schedule:                                                  \begin{itemize}
       \item constant: $eta = eta0$                                                   \item optimal:
       $eta = 1.0 / (alpha * (t + t0))$ where t0 is chosen by a heuristic proposed by Leon Bottou.
@@ -8069,47 +8069,47 @@
       learning rate is divided by 5.                                                  \end{itemize}
   \default{optimal}
 
-    \item \xmlNode{eta0}: \xmlDesc{float}, 
+    \item \xmlNode{eta0}: \xmlDesc{float},
       The initial learning rate for the ``constant'', ``invscaling'' or ``adaptive'' schedules. The
       default value is 0.0                                                  as eta0 is not used by
       the default schedule ``optimal''.
   \default{0.0}
 
-    \item \xmlNode{power\_t}: \xmlDesc{float}, 
+    \item \xmlNode{power\_t}: \xmlDesc{float},
       The exponent for inverse scaling learning rate.
   \default{0.5}
 
-    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       hether to use early stopping to terminate training when validation score is not
       improving. If set to True, it will automatically set aside a stratified fraction of training
       data as validation and terminate training when validation score is not improving by at least
       tol for n\_iter\_no\_change consecutive epochs.
   \default{False}
 
-    \item \xmlNode{validation\_fraction}: \xmlDesc{float}, 
+    \item \xmlNode{validation\_fraction}: \xmlDesc{float},
       The proportion of training data to set aside as validation set for early stopping.
       Must be between 0 and 1. Only used if early\_stopping is True.
   \default{0.1}
 
-    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer},
       Number of iterations with no improvement to wait before early stopping.
   \default{5}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to shuffle the training data, when shuffle is set to
       True. Pass an int for reproducible output across multiple function calls.
   \default{None}
 
-    \item \xmlNode{verbose}: \xmlDesc{integer}, 
+    \item \xmlNode{verbose}: \xmlDesc{integer},
       The verbosity level
   \default{0}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call
       to fit as initialization, otherwise, just erase the previous solution.
   \default{False}
 
-    \item \xmlNode{average}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{average}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, computes the averaged SGD weights accross
       all updates and stores the result in the coef\_ attribute.
   \default{False}
@@ -8124,27 +8124,27 @@
 
   The \xmlNode{ComplementNB} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{ComplementNB} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -8183,60 +8183,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -8249,24 +8249,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -8286,7 +8286,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -8297,54 +8297,54 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Additive (Laplace and Lidstone) smoothing parameter (0 for no smoothing).
   \default{1.0}
 
-    \item \xmlNode{norm}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{norm}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether or not a second normalization of the weights is performed.
   \default{False}
 
-    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats},
       Prior probabilities of the classes. If specified the priors are
       not adjusted according to the data. \nb the number of elements inputted here must
       match the number of classes in the data set used in the training stage.
   \default{None}
 
-    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to learn class prior probabilities or not. If false, a uniform
       prior will be used.
   \default{True}
@@ -8359,27 +8359,27 @@
 
   The \xmlNode{CategoricalNB} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{CategoricalNB} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -8418,60 +8418,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -8484,24 +8484,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -8521,7 +8521,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -8532,50 +8532,50 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Additive (Laplace and Lidstone) smoothing parameter (0 for no smoothing).
   \default{1.0}
 
-    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats},
       Prior probabilities of the classes. If specified the priors are
       not adjusted according to the data. \nb the number of elements inputted here must
       match the number of classes in the data set used in the training stage.
   \default{None}
 
-    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to learn class prior probabilities or not. If false, a uniform
       prior will be used.
   \default{True}
@@ -8603,27 +8603,27 @@
 
   The \xmlNode{BernoulliNB} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{BernoulliNB} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -8662,60 +8662,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -8728,24 +8728,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -8765,7 +8765,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -8776,55 +8776,55 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Additive (Laplace and Lidstone) smoothing parameter (0 for no smoothing).
   \default{1.0}
 
-    \item \xmlNode{binarize}: \xmlDesc{float}, 
+    \item \xmlNode{binarize}: \xmlDesc{float},
       Threshold for binarizing (mapping to booleans) of sample features. If None,
       input is presumed to already consist of binary vectors.
   \default{None}
 
-    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats},
       Prior probabilities of the classes. If specified the priors are
       not adjusted according to the data. \nb the number of elements inputted here must
       match the number of classes in the data set used in the training stage.
   \default{None}
 
-    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to learn class prior probabilities or not. If false, a uniform
       prior will be used.
   \default{True}
@@ -8854,27 +8854,27 @@
 
   The \xmlNode{MultinomialNB} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{MultinomialNB} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -8913,60 +8913,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -8979,24 +8979,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -9016,7 +9016,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -9027,50 +9027,50 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{class\_prior}: \xmlDesc{comma-separated floats},
       Prior probabilities of the classes. If specified the priors are
       not adjusted according to the data. \nb the number of elements inputted here must
       match the number of classes in the data set used in the training stage.
   \default{None}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Additive (Laplace and Lidstone) smoothing parameter (0 for no smoothing).
   \default{1.0}
 
-    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_prior}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to learn class prior probabilities or not. If false, a uniform
       prior will be used.
   \default{True}
@@ -9088,27 +9088,27 @@
 
   The \xmlNode{GaussianNB} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{GaussianNB} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -9147,60 +9147,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -9213,24 +9213,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -9250,7 +9250,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -9261,46 +9261,46 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{priors}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{priors}: \xmlDesc{comma-separated floats},
       Prior probabilities of the classes. If specified the priors are
       not adjusted according to the data. \nb the number of elements inputted here must
       match the number of classes in the data set used in the training stage.
   \default{None}
 
-    \item \xmlNode{var\_smoothing}: \xmlDesc{float}, 
+    \item \xmlNode{var\_smoothing}: \xmlDesc{float},
       Portion of the largest variance of all features that is added to variances for
       calculation stability.
   \default{1e-09}
@@ -9316,27 +9316,27 @@
 
   The \xmlNode{MLPClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{MLPClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -9375,60 +9375,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -9441,24 +9441,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -9478,7 +9478,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -9489,45 +9489,45 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{hidden\_layer\_sizes}: \xmlDesc{comma-separated integers}, 
+    \item \xmlNode{hidden\_layer\_sizes}: \xmlDesc{comma-separated integers},
       The ith element represents the number of neurons in the ith hidden layer.
       lenght = n\_layers - 2
   \default{(100,)}
 
-    \item \xmlNode{activation}: \xmlDesc{[identity, logistic, tanh, tanh]}, 
+    \item \xmlNode{activation}: \xmlDesc{[identity, logistic, tanh, tanh]},
       Activation function for the hidden layer:
       \begin{itemize}                                                   \item identity:  no-op
       activation, useful to implement linear bottleneck, returns $f(x) = x$
@@ -9537,7 +9537,7 @@
       \end{itemize}
   \default{relu}
 
-    \item \xmlNode{solver}: \xmlDesc{[lbfgs, sgd, adam]}, 
+    \item \xmlNode{solver}: \xmlDesc{[lbfgs, sgd, adam]},
       The solver for weight optimization:
       \begin{itemize}                                                   \item lbfgs: is an optimizer
       in the family of quasi-Newton methods.                                                   \item
@@ -9546,16 +9546,16 @@
       Jimmy Ba                                                  \end{itemize}
   \default{adam}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       L2 penalty (regularization term) parameter.
   \default{0.0001}
 
-    \item \xmlNode{batch\_size}: \xmlDesc{integer or string}, 
+    \item \xmlNode{batch\_size}: \xmlDesc{integer or string},
       Size of minibatches for stochastic optimizers. If the solver is `lbfgs',
       the classifier will not use minibatch. When set to ``auto", batch\_size=min(200, n\_samples)
   \default{auto}
 
-    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, invscaling, adaptive]}, 
+    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, invscaling, adaptive]},
       Learning rate schedule for weight updates.:
       \begin{itemize}                                                   \item constant: is a
       constant learning rate given by `learning\_rate\_init'.
@@ -9569,54 +9569,54 @@
       \end{itemize}
   \default{constant}
 
-    \item \xmlNode{learning\_rate\_init}: \xmlDesc{float}, 
+    \item \xmlNode{learning\_rate\_init}: \xmlDesc{float},
       The initial learning rate used. It controls the step-size in updating the weights.
       Only used when solver=`sgd' or `adam'.
   \default{0.001}
 
-    \item \xmlNode{power\_t}: \xmlDesc{float}, 
+    \item \xmlNode{power\_t}: \xmlDesc{float},
       The exponent for inverse scaling learning rate. It is used in updating effective
       learning rate when the learning\_rate is set to `invscaling'. Only used when solver=`sgd'.
   \default{0.5}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Maximum number of iterations. The solver iterates until convergence
       (determined by `tol') or this number of iterations. For stochastic solvers (`sgd', `adam'),
       note that this determines the number of epochs (how many times each data point will be used),
       not the number of gradient steps.
   \default{200}
 
-    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to shuffle samples in each iteration. Only used when solver=`sgd' or `adam'.
   \default{True}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Determines random number generation for weights and bias initialization,
       train-test split if early stopping is used, and batch sampling when solver=`sgd' or `adam'.
   \default{None}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for the optimization.
   \default{0.0001}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to print progress messages to stdout.
   \default{False}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call to fit as initialization, otherwise,
       just erase the previous solution.
   \default{False}
 
-    \item \xmlNode{momentum}: \xmlDesc{float}, 
+    \item \xmlNode{momentum}: \xmlDesc{float},
       Momentum for gradient descent update. Should be between 0 and 1. Only used when solver=`sgd'.
   \default{0.9}
 
-    \item \xmlNode{nesterovs\_momentum}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{nesterovs\_momentum}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use Nesterov's momentum. Only used when solver=`sgd' and momentum > 0.
   \default{True}
 
-    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use early stopping to terminate training when validation score is not improving.
       If set to true, it will automatically set aside ten-percent of training data as validation and
       terminate                                                  training when validation score is
@@ -9627,27 +9627,27 @@
       consecutive passes over the training set. Only effective when solver=`sgd' or `adam'.
   \default{False}
 
-    \item \xmlNode{validation\_fraction}: \xmlDesc{float}, 
+    \item \xmlNode{validation\_fraction}: \xmlDesc{float},
       The proportion of training data to set aside as validation set for early stopping. Must be
       between 0 and 1.                                                  Only used if early\_stopping
       is True
   \default{0.1}
 
-    \item \xmlNode{beta\_1}: \xmlDesc{float}, 
+    \item \xmlNode{beta\_1}: \xmlDesc{float},
       Exponential decay rate for estimates of first moment vector in adam, should be in $[0, 1)$.
       Only used when solver=`adam'.
   \default{0.9}
 
-    \item \xmlNode{beta\_2}: \xmlDesc{float}, 
+    \item \xmlNode{beta\_2}: \xmlDesc{float},
       Exponential decay rate for estimates of second moment vector in adam, should be in $[0, 1)$.
       Only used when solver=`adam'.
   \default{0.999}
 
-    \item \xmlNode{epsilon}: \xmlDesc{float}, 
+    \item \xmlNode{epsilon}: \xmlDesc{float},
       Value for numerical stability in adam. Only used when solver=`adam'.
   \default{1e-08}
 
-    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer},
       Maximum number of epochs to not meet tol improvement. Only effective when
       solver=`sgd' or `adam'
   \default{10}
@@ -9662,27 +9662,27 @@
 
   The \xmlNode{MLPRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{MLPRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -9721,60 +9721,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -9787,24 +9787,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -9824,7 +9824,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -9835,45 +9835,45 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{hidden\_layer\_sizes}: \xmlDesc{comma-separated integers}, 
+    \item \xmlNode{hidden\_layer\_sizes}: \xmlDesc{comma-separated integers},
       The ith element represents the number of neurons in the ith hidden layer.
       lenght = n\_layers - 2
   \default{(100,)}
 
-    \item \xmlNode{activation}: \xmlDesc{[identity, logistic, tanh, relu]}, 
+    \item \xmlNode{activation}: \xmlDesc{[identity, logistic, tanh, relu]},
       Activation function for the hidden layer:
       \begin{itemize}                                                    \item identity:  no-op
       activation, useful to implement linear bottleneck, returns $f(x) = x$
@@ -9883,7 +9883,7 @@
       \end{itemize}
   \default{relu}
 
-    \item \xmlNode{solver}: \xmlDesc{[lbfgs, sgd, adam]}, 
+    \item \xmlNode{solver}: \xmlDesc{[lbfgs, sgd, adam]},
       The solver for weight optimization:
       \begin{itemize}                                                    \item lbfgs: is an
       optimizer in the family of quasi-Newton methods.
@@ -9892,16 +9892,16 @@
       Jimmy Ba                                                  \end{itemize}
   \default{adam}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       L2 penalty (regularization term) parameter.
   \default{0.0001}
 
-    \item \xmlNode{batch\_size}: \xmlDesc{integer or string}, 
+    \item \xmlNode{batch\_size}: \xmlDesc{integer or string},
       Size of minibatches for stochastic optimizers. If the solver is `lbfgs',
       the classifier will not use minibatch. When set to ``auto", batch\_size=min(200, n\_samples)
   \default{auto}
 
-    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, invscaling, adaptive]}, 
+    \item \xmlNode{learning\_rate}: \xmlDesc{[constant, invscaling, adaptive]},
       Learning rate schedule for weight updates.:
       \begin{itemize}                                                   \item constant: is a
       constant learning rate given by `learning\_rate\_init'.
@@ -9915,54 +9915,54 @@
       \end{itemize}
   \default{constant}
 
-    \item \xmlNode{learning\_rate\_init}: \xmlDesc{float}, 
+    \item \xmlNode{learning\_rate\_init}: \xmlDesc{float},
       The initial learning rate used. It controls the step-size in updating the weights.
       Only used when solver=`sgd' or `adam'.
   \default{0.001}
 
-    \item \xmlNode{power\_t}: \xmlDesc{float}, 
+    \item \xmlNode{power\_t}: \xmlDesc{float},
       The exponent for inverse scaling learning rate. It is used in updating effective
       learning rate when the learning\_rate is set to `invscaling'. Only used when solver=`sgd'.
   \default{0.5}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Maximum number of iterations. The solver iterates until convergence
       (determined by `tol') or this number of iterations. For stochastic solvers (`sgd', `adam'),
       note that this determines the number of epochs (how many times each data point will be used),
       not the number of gradient steps.
   \default{200}
 
-    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shuffle}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to shuffle samples in each iteration. Only used when solver=`sgd' or `adam'.
   \default{True}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Determines random number generation for weights and bias initialization,
       train-test split if early stopping is used, and batch sampling when solver=`sgd' or `adam'.
   \default{None}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for the optimization.
   \default{0.0001}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to print progress messages to stdout.
   \default{False}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call to fit as initialization, otherwise,
       just erase the previous solution.
   \default{False}
 
-    \item \xmlNode{momentum}: \xmlDesc{float}, 
+    \item \xmlNode{momentum}: \xmlDesc{float},
       Momentum for gradient descent update. Should be between 0 and 1. Only used when solver=`sgd'.
   \default{0.9}
 
-    \item \xmlNode{nesterovs\_momentum}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{nesterovs\_momentum}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use Nesterov's momentum. Only used when solver=`sgd' and momentum > 0.
   \default{True}
 
-    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{early\_stopping}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use early stopping to terminate training when validation score is not improving.
       If set to true, it will automatically set aside ten-percent of training data as validation and
       terminate                                                  training when validation score is
@@ -9973,27 +9973,27 @@
       consecutive passes over the training set. Only effective when solver=`sgd' or `adam'.
   \default{False}
 
-    \item \xmlNode{validation\_fraction}: \xmlDesc{float}, 
+    \item \xmlNode{validation\_fraction}: \xmlDesc{float},
       The proportion of training data to set aside as validation set for early stopping. Must be
       between 0 and 1.                                                  Only used if early\_stopping
       is True
   \default{0.1}
 
-    \item \xmlNode{beta\_1}: \xmlDesc{float}, 
+    \item \xmlNode{beta\_1}: \xmlDesc{float},
       Exponential decay rate for estimates of first moment vector in adam, should be in $[0, 1)$.
       Only used when solver=`adam'.
   \default{0.9}
 
-    \item \xmlNode{beta\_2}: \xmlDesc{float}, 
+    \item \xmlNode{beta\_2}: \xmlDesc{float},
       Exponential decay rate for estimates of second moment vector in adam, should be in $[0, 1)$.
       Only used when solver=`adam'.
   \default{0.999}
 
-    \item \xmlNode{epsilon}: \xmlDesc{float}, 
+    \item \xmlNode{epsilon}: \xmlDesc{float},
       Value for numerical stability in adam. Only used when solver=`adam'.
   \default{1e-08}
 
-    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_iter\_no\_change}: \xmlDesc{integer},
       Maximum number of epochs to not meet tol improvement. Only effective when
       solver=`sgd' or `adam'
   \default{10}
@@ -10029,27 +10029,27 @@
 
   The \xmlNode{GaussianProcessClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{GaussianProcessClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -10088,60 +10088,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -10154,24 +10154,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -10191,7 +10191,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -10202,40 +10202,40 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{kernel}: \xmlDesc{[Constant, DotProduct, ExpSineSquared, Exponentiation, Matern, Pairwise, RBF, RationalQuadratic]}, 
+    \item \xmlNode{kernel}: \xmlDesc{[Constant, DotProduct, ExpSineSquared, Exponentiation, Matern, Pairwise, RBF, RationalQuadratic]},
       The kernel specifying the covariance function of the GP. If None is passed,
       the kernel $RBF$ is used as default. The kernel hyperparameters are optimized during fitting
       and consequentially the hyperparameters are
@@ -10315,7 +10315,7 @@
       \end{itemize}
   \default{RBF}
 
-    \item \xmlNode{n\_restarts\_optimizer}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_restarts\_optimizer}: \xmlDesc{integer},
       The number of restarts of the optimizer for finding the kernel's parameters which maximize the
       log-marginal likelihood. The first run of the optimizer is performed
       from the kernel's initial parameters, the remaining ones (if any) from thetas sampled log-
@@ -10323,13 +10323,13 @@
       0, all bounds must be finite.
   \default{0}
 
-    \item \xmlNode{max\_iter\_predict}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter\_predict}: \xmlDesc{integer},
       The maximum number of iterations in Newton’s method for approximating the posterior during
       predict. Smaller values will reduce computation time at
       the cost of worse results.
   \default{100}
 
-    \item \xmlNode{multi\_class}: \xmlDesc{[one\_vs\_rest, one\_vs\_one]}, 
+    \item \xmlNode{multi\_class}: \xmlDesc{[one\_vs\_rest, one\_vs\_one]},
       Specifies how multi-class classification problems are handled. Supported are ``one\_vs\_rest''
       and ``one\_vs\_one''.                                                         In
       ``one\_vs\_rest', one binary Gaussian process classifier is fitted for each class, which is
@@ -10340,11 +10340,11 @@
       multi-class predictions.
   \default{one\_vs\_rest}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Seed for the internal random number generator
   \default{None}
 
-    \item \xmlNode{optimizer}: \xmlDesc{[fmin\_l\_bfgs\_b]}, 
+    \item \xmlNode{optimizer}: \xmlDesc{[fmin\_l\_bfgs\_b]},
       Per default, the 'L-BGFS-B' algorithm from
       scipy.optimize.minimize is used. If None is passed, the kernel’s
       parameters are kept fixed.
@@ -10378,27 +10378,27 @@
 
   The \xmlNode{GaussianProcessRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{GaussianProcessRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -10437,60 +10437,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -10503,24 +10503,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -10540,7 +10540,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -10551,40 +10551,40 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{kernel}: \xmlDesc{[Constant, DotProduct, ExpSineSquared, WhiteNoise, Matern, PairwiseLinear, PairwiseAdditiveChi2, PairwiseChi2, PairwisePoly, PairwisePolynomial, PairwiseRBF, PairwiseLaplassian, PairwiseSigmoid, PairwiseCosine, RBF, RationalQuadratic, Custom]}, 
+    \item \xmlNode{kernel}: \xmlDesc{[Constant, DotProduct, ExpSineSquared, WhiteNoise, Matern, PairwiseLinear, PairwiseAdditiveChi2, PairwiseChi2, PairwisePoly, PairwisePolynomial, PairwiseRBF, PairwiseLaplassian, PairwiseSigmoid, PairwiseCosine, RBF, RationalQuadratic, Custom]},
       The kernel specifying the covariance function of the GP. If None is passed,
       the kernel $Constant$ is used as default. The kernel hyperparameters are optimized during
       fitting and consequentially the hyperparameters are
@@ -10666,14 +10666,14 @@
       Still under construction                                                  \end{itemize}.
   \default{None}
 
-    \item \xmlNode{alpha}: \xmlDesc{float}, 
+    \item \xmlNode{alpha}: \xmlDesc{float},
       Value added to the diagonal of the kernel matrix during fitting. This can prevent a potential
       numerical issue during fitting, by ensuring that the calculated
       values form a positive definite matrix. It can also be interpreted as the variance of
       additional Gaussian measurement noise on the training observations.
   \default{1e-10}
 
-    \item \xmlNode{n\_restarts\_optimizer}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_restarts\_optimizer}: \xmlDesc{integer},
       The number of restarts of the optimizer for finding the kernel's parameters which maximize the
       log-marginal likelihood. The first run of the optimizer is performed
       from the kernel's initial parameters, the remaining ones (if any) from thetas sampled log-
@@ -10681,33 +10681,33 @@
       0, all bounds must be finite.
   \default{0}
 
-    \item \xmlNode{normalize\_y}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{normalize\_y}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether the target values y are normalized, the mean and variance of the target values are set
       equal to 0 and 1 respectively. This is recommended for cases where zero-mean,
       unit-variance priors are used.
   \default{False}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Seed for the internal random number generator.
   \default{None}
 
-    \item \xmlNode{optimizer}: \xmlDesc{[fmin\_l\_bfgs\_b, None]}, 
+    \item \xmlNode{optimizer}: \xmlDesc{[fmin\_l\_bfgs\_b, None]},
       Per default, the 'L-BFGS-B' algorithm from
       scipy.optimize.minimize is used. If None is passed, the kernel’s
       parameters are kept fixed.
   \default{fmin\_l\_bfgs\_b}
 
-    \item \xmlNode{anisotropic}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{anisotropic}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Boolean that determines if unique length-scales are used for each
       axis of the input space (where applicable). The default is False.
   \default{False}
 
-    \item \xmlNode{custom\_kernel}: \xmlDesc{string}, 
+    \item \xmlNode{custom\_kernel}: \xmlDesc{string},
       Defines the custom kernel constructed by the available base kernels.
       Only applicable when 'kernel' is set to 'Custom'; therefore, the default is None.
   \default{None}
 
-    \item \xmlNode{multioutput}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{multioutput}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Determines whether model will track multiple targets through the
       multiouput regressor wrapper class. For most RAVEN applications, this is expected;
       therefore, the default is True.
@@ -10723,27 +10723,27 @@
 
   The \xmlNode{OneVsOneClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{OneVsOneClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -10782,60 +10782,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -10848,24 +10848,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -10885,7 +10885,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -10896,50 +10896,50 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{estimator}: \xmlDesc{string}, 
+    \item \xmlNode{estimator}: \xmlDesc{string},
       name of a ROM that can be used as an estimator
       The \xmlNode{estimator} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{n\_jobs}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_jobs}: \xmlDesc{integer},
       The number of jobs to use for the computation: the n\_classes * ( n\_classes - 1) / 2 OVO
       problems are computed in parallel. None means 1 unless in a joblib.parallel\_backend
       context. -1 means using all processors.
@@ -10959,27 +10959,27 @@
 
   The \xmlNode{OneVsRestClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{OneVsRestClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -11018,60 +11018,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -11084,24 +11084,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -11121,7 +11121,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -11132,50 +11132,50 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{estimator}: \xmlDesc{string}, 
+    \item \xmlNode{estimator}: \xmlDesc{string},
       name of a ROM that can be used as an estimator
       The \xmlNode{estimator} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{n\_jobs}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_jobs}: \xmlDesc{integer},
       TThe number of jobs to use for the computation: the n\_classes one-vs-rest
       problems are computed in parallel. None means 1 unless in a joblib.parallel\_backend
       context. -1 means using all processors.
@@ -11196,27 +11196,27 @@
 
   The \xmlNode{OutputCodeClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{OutputCodeClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -11255,60 +11255,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -11321,24 +11321,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -11358,7 +11358,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -11369,62 +11369,62 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{estimator}: \xmlDesc{string}, 
+    \item \xmlNode{estimator}: \xmlDesc{string},
       name of a ROM that can be used as an estimator
       The \xmlNode{estimator} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{code\_size}: \xmlDesc{float}, 
+    \item \xmlNode{code\_size}: \xmlDesc{float},
       Percentage of the number of classes to be used to create
       the code book. A number between 0 and 1 will require fewer classifiers
       than one-vs-the-rest. A number greater than 1 will require more classifiers
       than one-vs-the-rest.
   \default{1.5}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       The generator used to initialize the codebook. Pass an int
       for reproducible output across multiple function calls.
   \default{None}
 
-    \item \xmlNode{n\_jobs}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_jobs}: \xmlDesc{integer},
       TThe number of jobs to use for the computation: the n\_classes one-vs-rest
       problems are computed in parallel. None means 1 unless in a joblib.parallel\_backend
       context. -1 means using all processors. See Glossary for more details.
@@ -11445,27 +11445,27 @@
 
   The \xmlNode{KNeighborsClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{KNeighborsClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -11504,60 +11504,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -11570,24 +11570,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -11607,7 +11607,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -11618,67 +11618,67 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{n\_neighbors}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_neighbors}: \xmlDesc{integer},
       Number of neighbors to use by default for kneighbors queries.
   \default{5}
 
-    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]}, 
+    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]},
       weight function used in prediction. If ``uniform'', all points in each neighborhood
       are weighted equally. If ``distance'' weight points by the inverse of their distance. in this
       case,closer neighbors of a query point will have a greater influence than neighbors which are
       further away.
   \default{uniform}
 
-    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]}, 
+    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]},
       Algorithm used to compute the nearest neighbors
   \default{auto}
 
-    \item \xmlNode{leaf\_size}: \xmlDesc{integer}, 
+    \item \xmlNode{leaf\_size}: \xmlDesc{integer},
       Leaf size passed to BallTree or KDTree. This can affect the speed of the construction
       and query, as well as the memory required to store the tree. The optimal value depends on the
       nature of the problem.
   \default{30}
 
-    \item \xmlNode{p}: \xmlDesc{integer}, 
+    \item \xmlNode{p}: \xmlDesc{integer},
       Power parameter for the Minkowski metric. When $p = 1$, this is equivalent to using
       manhattan\_distance (l1), and euclidean\_distance (l2) for $p = 2$. For arbitrary $p$,
       minkowski\_distance                                                  (l\_p) is used.
   \default{2}
 
-    \item \xmlNode{metric}: \xmlDesc{[euclidean, manhattan, minkowski, chebyshev, hamming, braycurtis]}, 
+    \item \xmlNode{metric}: \xmlDesc{[euclidean, manhattan, minkowski, chebyshev, hamming, braycurtis]},
       the distance metric to use for the tree. The default metric is minkowski, and with
       $p=2$ is equivalent to the standard Euclidean metric.
       The available metrics are:                                                  \begin{itemize}
@@ -11707,27 +11707,27 @@
 
   The \xmlNode{NearestCentroid} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{NearestCentroid} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -11766,60 +11766,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -11832,24 +11832,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -11869,7 +11869,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -11880,44 +11880,44 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{shrink\_threshold}: \xmlDesc{float}, 
+    \item \xmlNode{shrink\_threshold}: \xmlDesc{float},
       Threshold for shrinking centroids to remove features.
   \default{None}
 
-    \item \xmlNode{metric}: \xmlDesc{[uniform, distance]}, 
+    \item \xmlNode{metric}: \xmlDesc{[uniform, distance]},
       The metric to use when calculating distance between instances in a feature array.
       The available metrics are allo the ones explained in the \xmlNode{Metrics} section (pairwise).
       The centroids for the samples corresponding to each class is the point from which the sum of
@@ -11941,27 +11941,27 @@
 
   The \xmlNode{RadiusNeighborsRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{RadiusNeighborsRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -12000,60 +12000,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -12066,24 +12066,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -12103,7 +12103,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -12114,67 +12114,67 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{radius}: \xmlDesc{float}, 
+    \item \xmlNode{radius}: \xmlDesc{float},
       Range of parameter space to use by default for radius neighbors queries.
   \default{1.0}
 
-    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]}, 
+    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]},
       weight function used in prediction. If ``uniform'', all points in each neighborhood
       are weighted equally. If ``distance'' weight points by the inverse of their distance. in this
       case,closer neighbors of a query point will have a greater influence than neighbors which are
       further away.
   \default{uniform}
 
-    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]}, 
+    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]},
       Algorithm used to compute the nearest neighbors
   \default{auto}
 
-    \item \xmlNode{leaf\_size}: \xmlDesc{integer}, 
+    \item \xmlNode{leaf\_size}: \xmlDesc{integer},
       Leaf size passed to BallTree or KDTree. This can affect the speed of the construction
       and query, as well as the memory required to store the tree. The optimal value depends on the
       nature of the problem.
   \default{30}
 
-    \item \xmlNode{p}: \xmlDesc{integer}, 
+    \item \xmlNode{p}: \xmlDesc{integer},
       Power parameter for the Minkowski metric. When $p = 1$, this is equivalent to using
       manhattan\_distance (l1), and euclidean\_distance (l2) for $p = 2$. For arbitrary $p$,
       minkowski\_distance                                                  (l\_p) is used.
   \default{2}
 
-    \item \xmlNode{metric}: \xmlDesc{[minkowski, euclidean, manhattan, chebyshev, hamming, canberra, braycurtis]}, 
+    \item \xmlNode{metric}: \xmlDesc{[minkowski, euclidean, manhattan, chebyshev, hamming, canberra, braycurtis]},
       the distance metric to use for the tree. The default metric is minkowski, and with
       $p=2$ is equivalent to the standard Euclidean metric.
       The available metrics are:                                                  \begin{itemize}
@@ -12201,27 +12201,27 @@
 
   The \xmlNode{KNeighborsRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{KNeighborsRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -12260,60 +12260,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -12326,24 +12326,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -12363,7 +12363,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -12374,67 +12374,67 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{n\_neighbors}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_neighbors}: \xmlDesc{integer},
       Number of neighbors to use by default for kneighbors queries.
   \default{5}
 
-    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]}, 
+    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]},
       weight function used in prediction. If ``uniform'', all points in each neighborhood
       are weighted equally. If ``distance'' weight points by the inverse of their distance. in this
       case,closer neighbors of a query point will have a greater influence than neighbors which are
       further away.
   \default{uniform}
 
-    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]}, 
+    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]},
       Algorithm used to compute the nearest neighbors
   \default{auto}
 
-    \item \xmlNode{leaf\_size}: \xmlDesc{integer}, 
+    \item \xmlNode{leaf\_size}: \xmlDesc{integer},
       Leaf size passed to BallTree or KDTree. This can affect the speed of the construction
       and query, as well as the memory required to store the tree. The optimal value depends on the
       nature of the problem.
   \default{30}
 
-    \item \xmlNode{p}: \xmlDesc{integer}, 
+    \item \xmlNode{p}: \xmlDesc{integer},
       Power parameter for the Minkowski metric. When $p = 1$, this is equivalent to using
       manhattan\_distance (l1), and euclidean\_distance (l2) for $p = 2$. For arbitrary $p$,
       minkowski\_distance                                                  (l\_p) is used.
   \default{2}
 
-    \item \xmlNode{metric}: \xmlDesc{[euclidean, manhattan, minkowski, chebyshev, hamming, braycurtis]}, 
+    \item \xmlNode{metric}: \xmlDesc{[euclidean, manhattan, minkowski, chebyshev, hamming, braycurtis]},
       the distance metric to use for the tree. The default metric is minkowski, and with
       $p=2$ is equivalent to the standard Euclidean metric.
       The available metrics are:                                                  \begin{itemize}
@@ -12463,27 +12463,27 @@
 
   The \xmlNode{RadiusNeighborsClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{RadiusNeighborsClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -12522,60 +12522,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -12588,24 +12588,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -12625,7 +12625,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -12636,67 +12636,67 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{radius}: \xmlDesc{float}, 
+    \item \xmlNode{radius}: \xmlDesc{float},
       Range of parameter space to use by default for radius neighbors queries.
   \default{1.0}
 
-    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]}, 
+    \item \xmlNode{weights}: \xmlDesc{[uniform, distance]},
       weight function used in prediction. If ``uniform'', all points in each neighborhood
       are weighted equally. If ``distance'' weight points by the inverse of their distance. in this
       case,closer neighbors of a query point will have a greater influence than neighbors which are
       further away.
   \default{uniform}
 
-    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]}, 
+    \item \xmlNode{algorithm}: \xmlDesc{[auto, ball\_tree, kd\_tree, brute]},
       Algorithm used to compute the nearest neighbors
   \default{auto}
 
-    \item \xmlNode{leaf\_size}: \xmlDesc{integer}, 
+    \item \xmlNode{leaf\_size}: \xmlDesc{integer},
       Leaf size passed to BallTree or KDTree. This can affect the speed of the construction
       and query, as well as the memory required to store the tree. The optimal value depends on the
       nature of the problem.
   \default{30}
 
-    \item \xmlNode{p}: \xmlDesc{integer}, 
+    \item \xmlNode{p}: \xmlDesc{integer},
       Power parameter for the Minkowski metric. When $p = 1$, this is equivalent to using
       manhattan\_distance (l1), and euclidean\_distance (l2) for $p = 2$. For arbitrary $p$,
       minkowski\_distance                                                  (l\_p) is used.
   \default{2}
 
-    \item \xmlNode{metric}: \xmlDesc{[minkowski, euclidean, manhattan, chebyshev, hamming, canberra, braycurtis]}, 
+    \item \xmlNode{metric}: \xmlDesc{[minkowski, euclidean, manhattan, chebyshev, hamming, canberra, braycurtis]},
       the distance metric to use for the tree. The default metric is minkowski, and with
       $p=2$ is equivalent to the standard Euclidean metric.
       The available metrics are:                                                  \begin{itemize}
@@ -12710,7 +12710,7 @@
       \end{itemize}
   \default{minkowski}
 
-    \item \xmlNode{outlier\_label}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{outlier\_label}: \xmlDesc{comma-separated strings},
       label for outlier samples (samples with no neighbors in given radius).
       The available options are:                                                  \begin{itemize}
       \item manual label: strings or int labels. list of manual labels if multi-output is used.
@@ -12731,27 +12731,27 @@
 
   The \xmlNode{LinearSVC} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LinearSVC} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -12790,60 +12790,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -12856,24 +12856,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -12893,7 +12893,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -12904,66 +12904,66 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{penalty}: \xmlDesc{[l1, l2]}, 
+    \item \xmlNode{penalty}: \xmlDesc{[l1, l2]},
       Specifies the norm used in the penalization. The ``l2'' penalty is the standard used in SVC.
       The ``l1' leads to coefficients vectors that are sparse.
   \default{l2}
 
-    \item \xmlNode{loss}: \xmlDesc{[hinge, squared\_hinge]}, 
+    \item \xmlNode{loss}: \xmlDesc{[hinge, squared\_hinge]},
       Specifies the loss function. ``hinge'' is the standard SVM loss (used e.g. by the SVC class)
       while ``squared\_hinge'' is the square of the hinge loss. The combination of penalty=``l1' and
       loss=``hinge''                                                  is not supported.
   \default{squared\_hinge}
 
-    \item \xmlNode{dual}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{dual}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Select the algorithm to either solve the dual or primal optimization problem.
       Prefer dual=False when $n\_samples > n\_features$.
   \default{True}
 
-    \item \xmlNode{C}: \xmlDesc{float}, 
+    \item \xmlNode{C}: \xmlDesc{float},
       Regularization parameter. The strength of the regularization is inversely
       proportional to C.                                                            Must be strictly
       positive. The penalty is a squared l2 penalty..
   \default{1.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{multi\_class}: \xmlDesc{[crammer\_singer, ovr]}, 
+    \item \xmlNode{multi\_class}: \xmlDesc{[crammer\_singer, ovr]},
       Determines the multi-class strategy if y contains more than two classes. ``ovr'' trains
       $n\_classes$ one-vs-rest classifiers, while ``crammer\_singer'' optimizes a joint objective over
       all classes.                                                  While crammer\_singer is
@@ -12973,12 +12973,12 @@
       loss, penalty and dual will be ignored.
   \default{ovr}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to calculate the intercept for this model. If set to false, no
       intercept will be used in calculations (i.e. data is expected to be already centered).
   \default{True}
 
-    \item \xmlNode{intercept\_scaling}: \xmlDesc{float}, 
+    \item \xmlNode{intercept\_scaling}: \xmlDesc{float},
       When fit\_intercept is True, instance vector x becomes $[x, intercept\_scaling]$,
       i.e. a “synthetic” feature with constant value equals to intercept\_scaling is appended
       to the instance vector. The intercept becomes $intercept\_scaling * synthetic feature weight$
@@ -12988,17 +12988,17 @@
       increased.
   \default{1.0}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Hard limit on iterations within solver.``-1'' for no limit
   \default{1000}
 
-    \item \xmlNode{verbose}: \xmlDesc{integer}, 
+    \item \xmlNode{verbose}: \xmlDesc{integer},
       Enable verbose output. Note that this setting takes advantage
       of a per-process runtime setting in liblinear that, if enabled, may not
       work properly in a multithreaded context.
   \default{0}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Controls the pseudo random number generation for shuffling
       the data for the dual coordinate descent (if dual=True). When dual=False
       the underlying implementation of LinearSVC is not random and
@@ -13006,7 +13006,7 @@
       output across multiple function calls.
   \default{None}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
@@ -13024,27 +13024,27 @@
 
   The \xmlNode{LinearSVR} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{LinearSVR} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -13083,60 +13083,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -13149,24 +13149,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -13186,7 +13186,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -13197,60 +13197,60 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{epsilon}: \xmlDesc{float}, 
+    \item \xmlNode{epsilon}: \xmlDesc{float},
       Epsilon parameter in the epsilon-insensitive loss function. The value of
       this parameter depends on the scale of the target variable y. If unsure, set $epsilon=0.$
   \default{0.0}
 
-    \item \xmlNode{loss}: \xmlDesc{[epsilon\_insensitive’, squared\_epsilon\_insensitive]}, 
+    \item \xmlNode{loss}: \xmlDesc{[epsilon\_insensitive’, squared\_epsilon\_insensitive]},
       Specifies the loss function. The epsilon-insensitive loss (standard SVR)
       is the L1 loss, while the squared epsilon-insensitive loss (``squared\_epsilon\_insensitive'')
       is the L2 loss.
   \default{squared\_epsilon\_insensitive}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.0001}
 
-    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{fit\_intercept}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to calculate the intercept for this model. If set to false, no
       intercept will be used in calculations (i.e. data is expected to be already centered).
   \default{True}
 
-    \item \xmlNode{intercept\_scaling}: \xmlDesc{float}, 
+    \item \xmlNode{intercept\_scaling}: \xmlDesc{float},
       When fit\_intercept is True, instance vector x becomes $[x, intercept\_scaling]$,
       i.e. a “synthetic” feature with constant value equals to intercept\_scaling is appended
       to the instance vector. The intercept becomes $intercept\_scaling * synthetic feature weight$
@@ -13260,12 +13260,12 @@
       increased.
   \default{1.0}
 
-    \item \xmlNode{dual}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{dual}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Select the algorithm to either solve the dual or primal optimization problem.
       Prefer dual=False when $n\_samples > n\_features$.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Hard limit on iterations within solver.``-1'' for no limit
   \default{-1}
   \end{itemize}
@@ -13280,27 +13280,27 @@
 
   The \xmlNode{NuSVC} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{NuSVC} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -13339,60 +13339,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -13405,24 +13405,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -13442,7 +13442,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -13453,79 +13453,79 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{nu}: \xmlDesc{float}, 
+    \item \xmlNode{nu}: \xmlDesc{float},
       An upper bound on the fraction of margin errors and
       a lower bound of the fraction of support vectors. Should be in the interval $(0, 1]$.
   \default{0.5}
 
-    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]}, 
+    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]},
       Specifies the kernel type to be used in the algorithm. It must be one of
       ``linear'', ``poly'', ``rbf'' or ``sigmoid''.
   \default{rbf}
 
-    \item \xmlNode{degree}: \xmlDesc{integer}, 
+    \item \xmlNode{degree}: \xmlDesc{integer},
       Degree of the polynomial kernel function ('poly').Ignored by all other kernels.
   \default{3}
 
-    \item \xmlNode{gamma}: \xmlDesc{float}, 
+    \item \xmlNode{gamma}: \xmlDesc{float},
       Kernel coefficient for ``poly'', ``rbf'' or ``sigmoid''. If not input, then it uses
       $1 / (n\_features * X.var())$ as value of gamma
   \default{scale}
 
-    \item \xmlNode{coef0}: \xmlDesc{float}, 
+    \item \xmlNode{coef0}: \xmlDesc{float},
       Independent term in kernel function
   \default{0.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.001}
 
-    \item \xmlNode{cache\_size}: \xmlDesc{float}, 
+    \item \xmlNode{cache\_size}: \xmlDesc{float},
       Size of the kernel cache (in MB)
   \default{200.0}
 
-    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use the shrinking heuristic.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Hard limit on iterations within solver.``-1'' for no limit
   \default{-1}
 
-    \item \xmlNode{decision\_function\_shape}: \xmlDesc{[ovo, ovr]}, 
+    \item \xmlNode{decision\_function\_shape}: \xmlDesc{[ovo, ovr]},
       Whether to return a one-vs-rest (``ovr'') decision function of shape $(n\_samples, n\_classes)$
       as                                                            all other classifiers, or the
       original one-vs-one (``ovo'') decision function of libsvm which has
@@ -13534,23 +13534,23 @@
       parameter is ignored for binary classification.
   \default{ovr}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Enable verbose output. Note that this setting takes advantage
       of a per-process runtime setting in libsvm that, if enabled, may not
       work properly in a multithreaded context.
   \default{False}
 
-    \item \xmlNode{probability}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{probability}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to enable probability estimates.
   \default{False}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
   \default{None}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Controls the pseudo random number generation for shuffling
       the data for probability estimates. Ignored when probability is False.
       Pass an int for reproducible output across multiple function calls.
@@ -13567,27 +13567,27 @@
 
   The \xmlNode{NuSVR} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{NuSVR} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -13626,60 +13626,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -13692,24 +13692,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -13729,7 +13729,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -13740,81 +13740,81 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{nu}: \xmlDesc{float}, 
+    \item \xmlNode{nu}: \xmlDesc{float},
       An upper bound on the fraction of margin errors and
       a lower bound of the fraction of support vectors. Should be in the interval $(0, 1]$.
   \default{0.5}
 
-    \item \xmlNode{C}: \xmlDesc{float}, 
+    \item \xmlNode{C}: \xmlDesc{float},
       Regularization parameter. The strength of the regularization is inversely
       proportional to C.                                                           Must be strictly
       positive. The penalty is a squared l2 penalty.
   \default{1.0}
 
-    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]}, 
+    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]},
       Specifies the kernel type to be used in the algorithm. It must be one of
       ``linear'', ``poly'', ``rbf'' or ``sigmoid''.
   \default{rbf}
 
-    \item \xmlNode{degree}: \xmlDesc{integer}, 
+    \item \xmlNode{degree}: \xmlDesc{integer},
       Degree of the polynomial kernel function ('poly').Ignored by all other kernels.
   \default{3}
 
-    \item \xmlNode{gamma}: \xmlDesc{float}, 
+    \item \xmlNode{gamma}: \xmlDesc{float},
       Kernel coefficient for ``poly'', ``rbf'' or ``sigmoid''. If not input, then it uses
       $1 / (n\_features * X.var())$ as value of gamma
   \default{scale}
 
-    \item \xmlNode{coef0}: \xmlDesc{float}, 
+    \item \xmlNode{coef0}: \xmlDesc{float},
       Independent term in kernel function
   \default{0.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.001}
 
-    \item \xmlNode{cache\_size}: \xmlDesc{float}, 
+    \item \xmlNode{cache\_size}: \xmlDesc{float},
       Size of the kernel cache (in MB)
   \default{200.0}
 
-    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use the shrinking heuristic.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Hard limit on iterations within solver.``-1'' for no limit
   \default{-1}
   \end{itemize}
@@ -13830,27 +13830,27 @@
 
   The \xmlNode{SVC} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{SVC} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -13889,60 +13889,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -13955,24 +13955,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -13992,7 +13992,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -14003,80 +14003,80 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{C}: \xmlDesc{float}, 
+    \item \xmlNode{C}: \xmlDesc{float},
       Regularization parameter. The strength of the regularization is inversely
       proportional to C.                                                            Must be strictly
       positive. The penalty is a squared l2 penalty..
   \default{1.0}
 
-    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]}, 
+    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]},
       Specifies the kernel type to be used in the algorithm. It must be one of
       ``linear'', ``poly'', ``rbf'' or ``sigmoid''.
   \default{rbf}
 
-    \item \xmlNode{degree}: \xmlDesc{integer}, 
+    \item \xmlNode{degree}: \xmlDesc{integer},
       Degree of the polynomial kernel function ('poly').Ignored by all other kernels.
   \default{3}
 
-    \item \xmlNode{gamma}: \xmlDesc{float}, 
+    \item \xmlNode{gamma}: \xmlDesc{float},
       Kernel coefficient for ``poly'', ``rbf'' or ``sigmoid''. If not input, then it uses
       $1 / (n\_features * X.var())$ as value of gamma
   \default{scale}
 
-    \item \xmlNode{coef0}: \xmlDesc{float}, 
+    \item \xmlNode{coef0}: \xmlDesc{float},
       Independent term in kernel function
   \default{0.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.001}
 
-    \item \xmlNode{cache\_size}: \xmlDesc{float}, 
+    \item \xmlNode{cache\_size}: \xmlDesc{float},
       Size of the kernel cache (in MB)
   \default{200.0}
 
-    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use the shrinking heuristic.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Hard limit on iterations within solver.``-1'' for no limit
   \default{-1}
 
-    \item \xmlNode{decision\_function\_shape}: \xmlDesc{[ovo, ovr]}, 
+    \item \xmlNode{decision\_function\_shape}: \xmlDesc{[ovo, ovr]},
       Whether to return a one-vs-rest (``ovr'') decision function of shape $(n\_samples, n\_classes)$
       as                                                            all other classifiers, or the
       original one-vs-one (``ovo'') decision function of libsvm which has
@@ -14085,23 +14085,23 @@
       parameter is ignored for binary classification.
   \default{ovr}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Enable verbose output. Note that this setting takes advantage
       of a per-process runtime setting in libsvm that, if enabled, may not
       work properly in a multithreaded context.
   \default{False}
 
-    \item \xmlNode{probability}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{probability}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to enable probability estimates.
   \default{False}
 
-    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]}, 
+    \item \xmlNode{class\_weight}: \xmlDesc{[balanced]},
       If not given, all classes are supposed to have weight one.
       The “balanced” mode uses the values of y to automatically adjust weights
       inversely proportional to class frequencies in the input data
   \default{None}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Controls the pseudo random number generation for shuffling
       the data for probability estimates. Ignored when probability is False.
       Pass an int for reproducible output across multiple function calls.
@@ -14119,27 +14119,27 @@
 
   The \xmlNode{SVR} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{SVR} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -14178,60 +14178,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -14244,24 +14244,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -14281,7 +14281,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -14292,87 +14292,87 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{C}: \xmlDesc{float}, 
+    \item \xmlNode{C}: \xmlDesc{float},
       Regularization parameter. The strength of the regularization is inversely
       proportional to C.                                                            Must be strictly
       positive. The penalty is a squared l2 penalty..
   \default{1.0}
 
-    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]}, 
+    \item \xmlNode{kernel}: \xmlDesc{[linear, poly, rbf, sigmoid]},
       Specifies the kernel type to be used in the algorithm. It must be one of
       ``linear'', ``poly'', ``rbf'' or ``sigmoid''.
   \default{rbf}
 
-    \item \xmlNode{degree}: \xmlDesc{integer}, 
+    \item \xmlNode{degree}: \xmlDesc{integer},
       Degree of the polynomial kernel function ('poly').Ignored by all other kernels.
   \default{3}
 
-    \item \xmlNode{gamma}: \xmlDesc{float}, 
+    \item \xmlNode{gamma}: \xmlDesc{float},
       Kernel coefficient for ``poly'', ``rbf'' or ``sigmoid''. If not input, then it uses
       $1 / (n\_features * X.var())$ as value of gamma
   \default{scale}
 
-    \item \xmlNode{coef0}: \xmlDesc{float}, 
+    \item \xmlNode{coef0}: \xmlDesc{float},
       Independent term in kernel function
   \default{0.0}
 
-    \item \xmlNode{tol}: \xmlDesc{float}, 
+    \item \xmlNode{tol}: \xmlDesc{float},
       Tolerance for stopping criterion
   \default{0.001}
 
-    \item \xmlNode{cache\_size}: \xmlDesc{float}, 
+    \item \xmlNode{cache\_size}: \xmlDesc{float},
       Size of the kernel cache (in MB)
   \default{200.0}
 
-    \item \xmlNode{epsilon}: \xmlDesc{float}, 
+    \item \xmlNode{epsilon}: \xmlDesc{float},
       Epsilon in the epsilon-SVR model. It specifies the epsilon-tube
       within which no penalty is associated in the training loss function
       with points predicted within a distance epsilon from the actual
       value.
   \default{0.1}
 
-    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{shrinking}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use the shrinking heuristic.
   \default{True}
 
-    \item \xmlNode{max\_iter}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_iter}: \xmlDesc{integer},
       Hard limit on iterations within solver.``-1'' for no limit
   \default{-1}
 
-    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{verbose}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Enable verbose output. Note that this setting takes advantage
       of a per-process runtime setting in libsvm that, if enabled, may not
       work properly in a multithreaded context.
@@ -14386,27 +14386,27 @@
 
   The \xmlNode{DecisionTreeClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{DecisionTreeClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -14445,60 +14445,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -14511,24 +14511,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -14548,7 +14548,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -14559,59 +14559,59 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{criterion}: \xmlDesc{[gini, entropy]}, 
+    \item \xmlNode{criterion}: \xmlDesc{[gini, entropy]},
       The function to measure the quality of a split. Supported criteria are ``gini'' for the
       Gini impurity and ``entropy'' for the information gain.
   \default{gini}
 
-    \item \xmlNode{splitter}: \xmlDesc{[best, random]}, 
+    \item \xmlNode{splitter}: \xmlDesc{[best, random]},
       The strategy used to choose the split at each node. Supported strategies are ``best''
       to choose the best split and ``random'' to choose the best random split.
   \default{best}
 
-    \item \xmlNode{max\_depth}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_depth}: \xmlDesc{integer},
       The maximum depth of the tree. If None, then nodes are expanded until all leaves are pure
       or until all leaves contain less than min\_samples\_split samples.
   \default{None}
 
-    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer},
       The minimum number of samples required to split an internal node
   \default{2}
 
-    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer},
       The minimum number of samples required to be at a leaf node. A split point at any
       depth will only be considered if it leaves at least min\_samples\_leaf training samples in
       each                                                  of the left and right branches. This may
@@ -14619,12 +14619,12 @@
       in regression.
   \default{1}
 
-    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float}, 
+    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float},
       The minimum weighted fraction of the sum total of weights (of all the input samples)
       required to be at a leaf node. Samples have equal weight when sample\_weight is not provided.
   \default{0.0}
 
-    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]}, 
+    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]},
       The strategy to compute the number of features to consider when looking for the best split:
       \begin{itemize}                                                     \item sqrt:
       $max\_features=sqrt(n\_features)$                                                     \item
@@ -14635,13 +14635,13 @@
       samples is found, even if it requires to effectively inspect more than max\_features features.
   \default{None}
 
-    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer},
       Grow a tree with max\_leaf\_nodes in best-first fashion. Best nodes are defined as relative
       reduction                                                  in impurity. If None then unlimited
       number of leaf nodes.
   \default{None}
 
-    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float}, 
+    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float},
       A node will be split if this split induces a decrease of the impurity greater than or equal to
       this value.                                                  The weighted impurity decrease
       equation is the following:                                                  $N\_t / N *
@@ -14653,7 +14653,7 @@
       passed.
   \default{0.0}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Controls the randomness of the estimator. The features are
       always randomly permuted at each split, even if splitter is set to
       "best". When max\_features < n\_features, the algorithm will select
@@ -14673,27 +14673,27 @@
 
   The \xmlNode{DecisionTreeRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{DecisionTreeRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -14732,60 +14732,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -14798,24 +14798,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -14835,7 +14835,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -14846,40 +14846,40 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{criterion}: \xmlDesc{[mse, friedman\_mse, mae, poisson]}, 
+    \item \xmlNode{criterion}: \xmlDesc{[mse, friedman\_mse, mae, poisson]},
       The function to measure the quality of a split. Supported criteria are ``mse'' for the mean
       squared error,                                                  which is equal to variance
       reduction as feature selection criterion and minimizes the L2 loss using the mean of each
@@ -14890,21 +14890,21 @@
       deviance to find splits.
   \default{mse}
 
-    \item \xmlNode{splitter}: \xmlDesc{[best, random]}, 
+    \item \xmlNode{splitter}: \xmlDesc{[best, random]},
       The strategy used to choose the split at each node. Supported strategies are ``best''
       to choose the best split and ``random'' to choose the best random split.
   \default{best}
 
-    \item \xmlNode{max\_depth}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_depth}: \xmlDesc{integer},
       The maximum depth of the tree. If None, then nodes are expanded until all leaves are pure
       or until all leaves contain less than min\_samples\_split samples.
   \default{None}
 
-    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer},
       The minimum number of samples required to split an internal node
   \default{2}
 
-    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer},
       The minimum number of samples required to be at a leaf node. A split point at any
       depth will only be considered if it leaves at least min\_samples\_leaf training samples in
       each                                                  of the left and right branches. This may
@@ -14912,12 +14912,12 @@
       in regression.
   \default{1}
 
-    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float}, 
+    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float},
       The minimum weighted fraction of the sum total of weights (of all the input samples)
       required to be at a leaf node. Samples have equal weight when sample\_weight is not provided.
   \default{0.0}
 
-    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]}, 
+    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]},
       The strategy to compute the number of features to consider when looking for the best split:
       \begin{itemize}                                                     \item sqrt:
       $max\_features=sqrt(n\_features)$                                                     \item
@@ -14929,13 +14929,13 @@
       samples is found, even if it requires to effectively inspect more than max\_features features.
   \default{None}
 
-    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer},
       Grow a tree with max\_leaf\_nodes in best-first fashion. Best nodes are defined as relative
       reduction                                                  in impurity. If None then unlimited
       number of leaf nodes.
   \default{None}
 
-    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float}, 
+    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float},
       A node will be split if this split induces a decrease of the impurity greater than or equal to
       this value.                                                  The weighted impurity decrease
       equation is the following:                                                  $N\_t / N *
@@ -14947,7 +14947,7 @@
       passed.
   \default{0.0}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Controls the randomness of the estimator. The features are
       always randomly permuted at each split, even if splitter is set to
       "best". When max\_features < n\_features, the algorithm will select
@@ -14972,27 +14972,27 @@
 
   The \xmlNode{ExtraTreeClassifier} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{ExtraTreeClassifier} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -15031,60 +15031,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -15097,24 +15097,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -15134,7 +15134,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -15145,59 +15145,59 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{criterion}: \xmlDesc{[gini, entropy]}, 
+    \item \xmlNode{criterion}: \xmlDesc{[gini, entropy]},
       The function to measure the quality of a split. Supported criteria are ``gini'' for the
       Gini impurity and ``entropy'' for the information gain.
   \default{gini}
 
-    \item \xmlNode{splitter}: \xmlDesc{[best, random]}, 
+    \item \xmlNode{splitter}: \xmlDesc{[best, random]},
       The strategy used to choose the split at each node. Supported strategies are ``best''
       to choose the best split and ``random'' to choose the best random split.
   \default{best}
 
-    \item \xmlNode{max\_depth}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_depth}: \xmlDesc{integer},
       The maximum depth of the tree. If None, then nodes are expanded until all leaves are pure
       or until all leaves contain less than min\_samples\_split samples.
   \default{None}
 
-    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer},
       The minimum number of samples required to split an internal node
   \default{2}
 
-    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer},
       The minimum number of samples required to be at a leaf node. A split point at any
       depth will only be considered if it leaves at least min\_samples\_leaf training samples in
       each                                                  of the left and right branches. This may
@@ -15205,12 +15205,12 @@
       in regression.
   \default{1}
 
-    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float}, 
+    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float},
       The minimum weighted fraction of the sum total of weights (of all the input samples)
       required to be at a leaf node. Samples have equal weight when sample\_weight is not provided.
   \default{0.0}
 
-    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]}, 
+    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]},
       The strategy to compute the number of features to consider when looking for the best split:
       \begin{itemize}                                                     \item sqrt:
       $max\_features=sqrt(n\_features)$                                                     \item
@@ -15222,13 +15222,13 @@
       samples is found, even if it requires to effectively inspect more than max\_features features.
   \default{None}
 
-    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer},
       Grow a tree with max\_leaf\_nodes in best-first fashion. Best nodes are defined as relative
       reduction                                                  in impurity. If None then unlimited
       number of leaf nodes.
   \default{None}
 
-    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float}, 
+    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float},
       A node will be split if this split induces a decrease of the impurity greater than or equal to
       this value.                                                  The weighted impurity decrease
       equation is the following:                                                  $N\_t / N *
@@ -15240,7 +15240,7 @@
       passed.
   \default{0.0}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to pick randomly the max\_features used at each split.
   \default{None}
   \end{itemize}
@@ -15257,27 +15257,27 @@
 
   The \xmlNode{ExtraTreeRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{ExtraTreeRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -15316,60 +15316,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -15382,24 +15382,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -15419,7 +15419,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -15430,40 +15430,40 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{criterion}: \xmlDesc{[mse, friedman\_mse, mae]}, 
+    \item \xmlNode{criterion}: \xmlDesc{[mse, friedman\_mse, mae]},
       The function to measure the quality of a split. Supported criteria are ``mse'' for the mean
       squared error,                                                  which is equal to variance
       reduction as feature selection criterion and minimizes the L2 loss using the mean of each
@@ -15472,21 +15472,21 @@
       mean absolute error, which minimizes the L1 loss using the median of each terminal node.
   \default{mse}
 
-    \item \xmlNode{splitter}: \xmlDesc{[best, random]}, 
+    \item \xmlNode{splitter}: \xmlDesc{[best, random]},
       The strategy used to choose the split at each node. Supported strategies are ``best''
       to choose the best split and ``random'' to choose the best random split.
   \default{best}
 
-    \item \xmlNode{max\_depth}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_depth}: \xmlDesc{integer},
       The maximum depth of the tree. If None, then nodes are expanded until all leaves are pure
       or until all leaves contain less than min\_samples\_split samples.
   \default{None}
 
-    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_split}: \xmlDesc{integer},
       The minimum number of samples required to split an internal node
   \default{2}
 
-    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer}, 
+    \item \xmlNode{min\_samples\_leaf}: \xmlDesc{integer},
       The minimum number of samples required to be at a leaf node. A split point at any
       depth will only be considered if it leaves at least min\_samples\_leaf training samples in
       each                                                  of the left and right branches. This may
@@ -15494,12 +15494,12 @@
       in regression.
   \default{1}
 
-    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float}, 
+    \item \xmlNode{min\_weight\_fraction\_leaf}: \xmlDesc{float},
       The minimum weighted fraction of the sum total of weights (of all the input samples)
       required to be at a leaf node. Samples have equal weight when sample\_weight is not provided.
   \default{0.0}
 
-    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]}, 
+    \item \xmlNode{max\_features}: \xmlDesc{[auto, sqrt, log2]},
       The strategy to compute the number of features to consider when looking for the best split:
       \begin{itemize}                                                     \item sqrt:
       $max\_features=sqrt(n\_features)$                                                     \item
@@ -15510,13 +15510,13 @@
       samples is found, even if it requires to effectively inspect more than max\_features features.
   \default{None}
 
-    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer}, 
+    \item \xmlNode{max\_leaf\_nodes}: \xmlDesc{integer},
       Grow a tree with max\_leaf\_nodes in best-first fashion. Best nodes are defined as relative
       reduction                                                  in impurity. If None then unlimited
       number of leaf nodes.
   \default{None}
 
-    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float}, 
+    \item \xmlNode{min\_impurity\_decrease}: \xmlDesc{float},
       A node will be split if this split induces a decrease of the impurity greater than or equal to
       this value.                                                  The weighted impurity decrease
       equation is the following:                                                  $N\_t / N *
@@ -15528,13 +15528,13 @@
       passed.
   \default{0.0}
 
-    \item \xmlNode{ccp\_alpha}: \xmlDesc{float}, 
+    \item \xmlNode{ccp\_alpha}: \xmlDesc{float},
       Complexity parameter used for Minimal Cost-Complexity Pruning. The subtree with the largest
       cost                                                  complexity that is smaller than
       ccp\_alpha will be chosen. By default, no pruning is performed.
   \default{0.0}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Used to pick randomly the max\_features used at each split.
   \default{None}
   \end{itemize}
@@ -15547,27 +15547,27 @@
 
   The \xmlNode{VotingRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{VotingRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -15606,60 +15606,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -15672,24 +15672,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -15709,7 +15709,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -15720,50 +15720,50 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{estimator}: \xmlDesc{string}, 
+    \item \xmlNode{estimator}: \xmlDesc{string},
       name of a ROM that can be used as an estimator
       The \xmlNode{estimator} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{weights}: \xmlDesc{comma-separated floats}, 
+    \item \xmlNode{weights}: \xmlDesc{comma-separated floats},
       Sequence of weights (float or int) to weight the occurrences of predicted
       values before averaging. Uses uniform weights if None.
   \default{None}
@@ -15781,27 +15781,27 @@
 
   The \xmlNode{BaggingRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{BaggingRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -15840,60 +15840,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -15906,24 +15906,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -15943,7 +15943,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -15954,81 +15954,81 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{estimator}: \xmlDesc{string}, 
+    \item \xmlNode{estimator}: \xmlDesc{string},
       name of a ROM that can be used as an estimator
       The \xmlNode{estimator} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{n\_estimators}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_estimators}: \xmlDesc{integer},
       The number of base estimators in the ensemble.
   \default{10}
 
-    \item \xmlNode{max\_samples}: \xmlDesc{float}, 
+    \item \xmlNode{max\_samples}: \xmlDesc{float},
       The number of samples to draw from X to train each base estimator
   \default{1.0}
 
-    \item \xmlNode{max\_features}: \xmlDesc{float}, 
+    \item \xmlNode{max\_features}: \xmlDesc{float},
       The number of features to draw from X to train each base estimator
   \default{1.0}
 
-    \item \xmlNode{bootstrap}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{bootstrap}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether samples are drawn with replacement. If False, sampling without
       replacement is performed.
   \default{True}
 
-    \item \xmlNode{bootstrap\_features}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{bootstrap\_features}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether features are drawn with replacement.
   \default{False}
 
-    \item \xmlNode{oob\_score}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{oob\_score}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       Whether to use out-of-bag samples to estimate the generalization error.
       Only available if bootstrap=True.
   \default{False}
 
-    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{warm\_start}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When set to True, reuse the solution of the previous call to fit and add more
       estimators to the ensemble, otherwise, just fit a whole new ensemble.
   \default{False}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Controls the random resampling of the original dataset (sample wise and feature wise).
   \default{None}
   \end{itemize}
@@ -16042,27 +16042,27 @@
 
   The \xmlNode{AdaBoostRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{AdaBoostRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -16101,60 +16101,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -16167,24 +16167,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -16204,7 +16204,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -16215,68 +16215,68 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{estimator}: \xmlDesc{string}, 
+    \item \xmlNode{estimator}: \xmlDesc{string},
       name of a ROM that can be used as an estimator
       The \xmlNode{estimator} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{n\_estimators}: \xmlDesc{integer}, 
+    \item \xmlNode{n\_estimators}: \xmlDesc{integer},
       The maximum number of estimators at which boosting is
       terminated. In case of perfect fit, the learning procedure is
       stopped early.
   \default{50}
 
-    \item \xmlNode{learning\_rate}: \xmlDesc{float}, 
+    \item \xmlNode{learning\_rate}: \xmlDesc{float},
       Weight applied to each regressor at each boosting iteration.
       A higher learning rate increases the contribution of each regressor.
       There is a trade-off between the learning\_rate and n\_estimators
       parameters.
   \default{1.0}
 
-    \item \xmlNode{loss}: \xmlDesc{[linear, square, exponential]}, 
+    \item \xmlNode{loss}: \xmlDesc{[linear, square, exponential]},
       The loss function to use when updating the weights after each
       boosting iteration.
   \default{linear}
 
-    \item \xmlNode{random\_state}: \xmlDesc{integer}, 
+    \item \xmlNode{random\_state}: \xmlDesc{integer},
       Controls the random seed given at each estimator at each
       boosting iteration.
   \default{None}
@@ -16290,27 +16290,27 @@
 
   The \xmlNode{StackingRegressor} node recognizes the following parameters:
     \begin{itemize}
-      \item \xmlAttr{name}: \xmlDesc{string, required}, 
+      \item \xmlAttr{name}: \xmlDesc{string, required},
         User-defined name to designate this entity in the RAVEN input file.
-      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+      \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
         Desired verbosity of messages coming from this entity
-      \item \xmlAttr{subType}: \xmlDesc{string, required}, 
+      \item \xmlAttr{subType}: \xmlDesc{string, required},
         specify the type of ROM that will be used
   \end{itemize}
 
   The \xmlNode{StackingRegressor} node recognizes the following subnodes:
   \begin{itemize}
-    \item \xmlNode{Features}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Features}: \xmlDesc{comma-separated strings},
       specifies the names of the features of this ROM.         \nb These parameters are going to be
       requested for the training of this object         (see Section~\ref{subsec:stepRomTrainer})
 
-    \item \xmlNode{Target}: \xmlDesc{comma-separated strings}, 
+    \item \xmlNode{Target}: \xmlDesc{comma-separated strings},
       contains a comma separated list of the targets of this ROM. These parameters         are the
       Figures of Merit (FOMs) this ROM is supposed to predict.         \nb These parameters are
       going to be requested for the training of this         object (see Section
       \ref{subsec:stepRomTrainer}).
 
-    \item \xmlNode{pivotParameter}: \xmlDesc{string}, 
+    \item \xmlNode{pivotParameter}: \xmlDesc{string},
       If a time-dependent ROM is requested, please specifies the pivot         variable (e.g. time,
       etc) used in the input HistorySet.
   \default{time}
@@ -16349,60 +16349,60 @@
           the subsequential search.
           The \xmlNode{RFE} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{RFE} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer}, 
+            \item \xmlNode{nFeaturesToSelect}: \xmlDesc{integer},
               Exact Number of features to select. If not inputted, ``nFeaturesToSelect'' will be set
               to $1/2$ of the features in the training dataset.
   \default{None}
 
-            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer}, 
+            \item \xmlNode{maxNumberFeatures}: \xmlDesc{integer},
               Maximum Number of features to select, the algorithm will automatically determine the
               feature list to minimize a total score.
   \default{None}
 
-            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{onlyOutputScore}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               If maxNumberFeatures is on, only output score should beconsidered? Or, in case of
               particular models (e.g. DMDC), state variable space score should be considered as
               well.
   \default{False}
 
-            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyClusteringFiltering}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               Applying clustering correlation before RFE search? If true, an hierarchal clustering
               is applied on the feature         space aimed to remove features that are correlated
               before the actual RFE search is performed. This approach can stabilize and
               accelerate the process in case of large feature spaces (e.g > 500 features).
   \default{False}
 
-            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+            \item \xmlNode{applyCrossCorrelation}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
               In case of subgroupping, should a cross correleation analysis should be performed
               cross sub-groups?         If it is activated, a cross correleation analysis is used to
               additionally filter the features selected for each         sub-groupping search.
   \default{False}
 
-            \item \xmlNode{step}: \xmlDesc{float}, 
+            \item \xmlNode{step}: \xmlDesc{float},
               If greater than or equal to 1, then step corresponds to the (integer) number
               of features to remove at each iteration. If within (0.0, 1.0), then step
               corresponds to the percentage (rounded down) of features to remove at         each
               iteration.
   \default{1}
 
-            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats}, 
+            \item \xmlNode{subGroup}: \xmlDesc{comma-separated strings, integers, and floats},
               Subgroup of output variables on which to perform the search. Multiple nodes of this
               type can be inputted. The RFE search will be then performed in each ``subgroup''
               separately and then the the union of the different feature sets are used for the final
@@ -16415,24 +16415,24 @@
           desired outputs. The variance threshold can be set by the user.
           The \xmlNode{VarianceThreshold} node recognizes the following parameters:
             \begin{itemize}
-              \item \xmlAttr{name}: \xmlDesc{string, required}, 
+              \item \xmlAttr{name}: \xmlDesc{string, required},
                 User-defined name to designate this entity in the RAVEN input file.
-              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional}, 
+              \item \xmlAttr{verbosity}: \xmlDesc{[silent, quiet, all, debug], optional},
                 Desired verbosity of messages coming from this entity
           \end{itemize}
 
           The \xmlNode{VarianceThreshold} node recognizes the following subnodes:
           \begin{itemize}
-            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+            \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
               List of IDs of features/variables to include in the search.
   \default{None}
 
-            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+            \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
               Which space to search? Target or Feature (this is temporary till DataSet training is
               implemented)
   \default{feature}
 
-            \item \xmlNode{threshold}: \xmlDesc{float}, 
+            \item \xmlNode{threshold}: \xmlDesc{float},
               Features with a training-set variance lower than this threshold                   will
               be removed. The default is to keep all features with non-zero
               variance, i.e. remove the features that have the same value in all
@@ -16452,7 +16452,7 @@
 
       The \xmlNode{featureSpaceTransformation} node recognizes the following subnodes:
       \begin{itemize}
-        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]}, 
+        \item \xmlNode{transformationMethod}: \xmlDesc{[PCA, KernelLinearPCA, KernelPolyPCA, KernelRbfPCA, KernelSigmoidPCA, KernelCosinePCA, ICA]},
           Transformation method to use. Eight options (5 Kernel PCAs) are available:
           \begin{itemize}                     \item \textit{PCA}, Principal Component Analysis;
           \item \textit{KernelLinearPCA}, Kernel (Linear) Principal component analysis;
@@ -16463,57 +16463,57 @@
           \item \textit{ICA}, Independent component analysis;                    \end{itemize}
   \default{PCA}
 
-        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings}, 
+        \item \xmlNode{parametersToInclude}: \xmlDesc{comma-separated strings},
           List of IDs of features/variables to include in the transformation process.
   \default{None}
 
-        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]}, 
+        \item \xmlNode{whichSpace}: \xmlDesc{[Feature, feature, Target, target]},
           Which space to search? Target or Feature?
   \default{Feature}
       \end{itemize}
 
-    \item \xmlNode{CV}: \xmlDesc{string}, 
+    \item \xmlNode{CV}: \xmlDesc{string},
       The text portion of this node needs to contain the name of the \xmlNode{PostProcessor} with
       \xmlAttr{subType}         ``CrossValidation``.
       The \xmlNode{CV} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{class}: \xmlDesc{string, optional},
             should be set to \xmlString{Model}
-          \item \xmlAttr{type}: \xmlDesc{string, optional}, 
+          \item \xmlAttr{type}: \xmlDesc{string, optional},
             should be set to \xmlString{PostProcessor}
       \end{itemize}
 
-    \item \xmlNode{alias}: \xmlDesc{string}, 
+    \item \xmlNode{alias}: \xmlDesc{string},
       specifies alias for         any variable of interest in the input or output space. These
       aliases can be used anywhere in the RAVEN input to         refer to the variables. In the body
       of this node the user specifies the name of the variable that the model is going to use
       (during its execution).
       The \xmlNode{alias} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{variable}: \xmlDesc{string, required}, 
+          \item \xmlAttr{variable}: \xmlDesc{string, required},
             define the actual alias, usable throughout the RAVEN input
-          \item \xmlAttr{type}: \xmlDesc{[input, output], required}, 
+          \item \xmlAttr{type}: \xmlDesc{[input, output], required},
             either ``input'' or ``output''.
       \end{itemize}
 
-    \item \xmlNode{estimator}: \xmlDesc{string}, 
+    \item \xmlNode{estimator}: \xmlDesc{string},
       name of a ROM that can be used as an estimator
       The \xmlNode{estimator} node recognizes the following parameters:
         \begin{itemize}
-          \item \xmlAttr{class}: \xmlDesc{string, required}, 
+          \item \xmlAttr{class}: \xmlDesc{string, required},
             RAVEN class for this entity (e.g. Samplers, Models, DataObjects)
-          \item \xmlAttr{type}: \xmlDesc{string, required}, 
+          \item \xmlAttr{type}: \xmlDesc{string, required},
             RAVEN type for this entity; a subtype of the class (e.g. MonteCarlo, Code, PointSet)
       \end{itemize}
 
-    \item \xmlNode{final\_estimator}: \xmlDesc{string}, 
+    \item \xmlNode{final\_estimator}: \xmlDesc{string},
       The name of estimator which will be used to combine the base estimators.
 
-    \item \xmlNode{cv}: \xmlDesc{integer}, 
+    \item \xmlNode{cv}: \xmlDesc{integer},
       specify the number of folds in a (Stratified) KFold,
   \default{5}
 
-    \item \xmlNode{passthrough}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]}, 
+    \item \xmlNode{passthrough}: \xmlDesc{[True, Yes, 1, False, No, 0, t, y, 1, f, n, 0]},
       When False, only the predictions of estimators will be used as training
       data for final\_estimator. When True, the final\_estimator is trained on the predictions
       as well as the original training data.

--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -840,3 +840,11 @@ def wrapText(text, indent, width=100):
   msg = textwrap.dedent(text)
   msg = textwrap.fill(msg, width=width, initial_indent=indent, subsequent_indent=indent)
   return msg
+
+def removeTrailingWhitespace(text):
+  """
+    Utility to remove whitespace at end of lines.
+    @ In, text, text to clean
+    @ Out, msg, str, modified text
+  """
+  return re.sub("[ \t]*\n", "\n", text)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Close #2452

##### What are the significant changes in functionality due to this change request?
First of all, this changes doc/user_manual/generated/generateOptimizerDoc.py and doc/user_manual/generated/generateRomDoc.py to not generate trailing whitespace. (With the help of a new helper function in ravenframework/utils/InputData.py
Next, it reruns ./generate_docs.sh and commits the new version without whitespace.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

