### PR TITLE
TSA filter options and domain bounding transformation

### DIFF
--- a/ravenframework/TSA/TSAUser.py
+++ b/ravenframework/TSA/TSAUser.py
@@ -20,6 +20,7 @@ Contains a utility base class for accessing commonly-used TSA functions.
 import numpy as np
 import copy
 from inspect import isabstract
+from collections import defaultdict
 
 from ..utils import xmlUtils, InputData, InputTypes
 
@@ -43,6 +44,9 @@ class TSAUser:
     spec.addSub(InputData.parameterInputFactory('pivotParameter', contentType=InputTypes.StringType,
         descr=r"""If a time-dependent ROM is requested, please specifies the pivot
         variable (e.g. time, etc) used in the input HistorySet.""", default='time'))
+    spec.addSub(InputData.parameterInputFactory('saveResiduals', contentType=InputTypes.BoolType,
+        descr=r"""If the residual of each algorithm in the SyntheticHistory model should be saved in the ROM
+        metadata. This can significantly inflate the size of the metadata file, if saved.""", default=False))
     for typ in factory.knownTypes():
       c = factory.returnClass(typ)
       if subset == 'characterize' and not c.canCharacterize():
@@ -71,6 +75,9 @@ class TSAUser:
     self._paramNames = None          # cached list of parameter names
     self._paramRealization = None    # cached dict of param variables mapped to values
     self._tsaTargets = None          # cached list of targets
+    self._saveResiduals = False      # switch for saving algorithm residuals at train time
+    self._residuals = {}             # residuals by algorithm and target
+    self._globalResiduals = {}       # residuals by algorithm and target for global algorithms
     self.target = None
 
   def readTSAInput(self, spec, hasClusters=False):
@@ -82,6 +89,9 @@ class TSAUser:
     """
     if self.pivotParameterID is None: # might be handled by parent
       self.pivotParameterID = spec.findFirst('pivotParameter').value
+    # Have we been asked to save the algorithm residuals in the ROM metadata?
+    self._saveResiduals = saveResidsSub.value if (saveResidsSub := spec.findFirst('saveResiduals')) else False
+    # Grab the provided TSA algorithms in order to create a pipeline of models and transformations
     for sub in spec.subparts:
       if sub.name in factory.knownTypes():
         algo = factory.returnInstance(sub.name)
@@ -146,6 +156,8 @@ class TSAUser:
     self._paramNames = None          # cached list of parameter names
     self._paramRealization = None    # cached dict of param variables mapped to values
     self._tsaTargets = None          # cached list of targets
+    self._residuals = {}             # algorithm training residuals
+    self._globalResiduals = {}       # global algorithm training residuals
 
   def getTargets(self):
     """
@@ -217,6 +229,7 @@ class TSAUser:
 
     # if NOT training globally, deep-ish copy, so we don't mod originals
     residual = targetVals if trainGlobal else targetVals[:, :, :]
+    savedResiduals = self._globalResiduals if trainGlobal else self._residuals
     # check if training globally, if so we only train global algos
     algorithms = self._tsaGlobalAlgorithms if trainGlobal else self._tsaAlgorithms
 
@@ -238,8 +251,10 @@ class TSAUser:
       # residual signal is not altered.
       if algo.canTransform():
         algoResidual = algo.getResidual(signal, params, pivots, settings)
-        residual[0, :, indices] = algoResidual.T # transpose, again because of indices
-      # TODO meta store signal, residual?
+        residual[0, :, indices] = algoResidual.T  # transpose, again because of indices
+      # Save the residuals if requested
+      if self._saveResiduals:
+        savedResiduals[algo.name] = {target: np.copy(resid) for target, resid in zip(self.target, residual[0].T)}
 
   def evaluateTSASequential(self, evalGlobal=False, evaluation=None, slicer=None):
     """
@@ -315,6 +330,23 @@ class TSAUser:
       algoNode = xmlUtils.newNode(algo.name)
       algo.writeXML(algoNode, self._tsaTrainedParams[algo])
       root.append(algoNode)
+    if self._saveResiduals:
+      self._writeResidualsToXML(root)
+
+  def _writeResidualsToXML(self, tsaNode):
+    """"
+      Write the signal residuals to the ROM XML
+      @ In, tsaNode, xml.etree.ElementTree.Element, the TSA model XML node
+      @ Out, None
+    """
+    residsNode = xmlUtils.newNode('residuals')
+    tsaNode.append(residsNode)
+    residsToWrite = self._residuals or self._globalResiduals  # Write global residuals if there's nothing in self._residuals. Depends on the global algorithms always being fitted, then written first.
+    for algo, residuals in residsToWrite.items():
+      algoNode = xmlUtils.newNode(algo)
+      for target, resids in residuals.items():
+        algoNode.append(xmlUtils.newNode(target, text=np.array2string(resids, separator=',').strip('[]')))
+      residsNode.append(algoNode)
 
   def getTSApointwiseData(self):
     """

--- a/ravenframework/TSA/Transformers/FunctionTransformers.py
+++ b/ravenframework/TSA/Transformers/FunctionTransformers.py
@@ -23,7 +23,7 @@ import scipy.special as sps
 import sklearn.preprocessing as skl
 
 from .ScikitLearnBase import SKLTransformer
-from ...utils import InputTypes
+from ...utils import InputTypes, InputData
 
 
 class LogTransformer(SKLTransformer):
@@ -158,4 +158,61 @@ class OutTruncation(SKLTransformer):
       self.templateTransformer.set_params(inverse_func=np.abs)
     else:  # negative
       self.templateTransformer.set_params(inverse_func=lambda x: -np.abs(x))
+    return settings
+
+
+class BoundDomain(SKLTransformer):
+  """ Restrict the domain of a signal to some upper and lower bounds. """
+  templateTransformer = skl.FunctionTransformer()
+
+  @classmethod
+  def getInputSpecification(cls):
+    """
+      Method to get a reference to a class that specifies the input data for
+      class cls.
+      @ In, None
+      @ Out, specs, InputData.ParameterInput, class to use for
+        specifying input of cls.
+    """
+    specs = super().getInputSpecification()
+    specs.name = 'bounddomain'
+    specs.description = r"""applies the transformation function
+      $$ f(x) = \begin{cases}
+            L & x < L \\
+            x & L \leq x leq U \\
+            U & x > U
+         \end{cases} $$
+    for both the forward and inverse transformations to limit the training
+    signal and samples to the interval $\[L, U\]$."""
+    specs.addSub(InputData.parameterInputFactory('lowerBound', contentType=InputTypes.FloatType, default=-np.inf,
+                                                 descr=r"""Bounding interval lower bound $L$"""))
+    specs.addSub(InputData.parameterInputFactory('upperBound', contentType=InputTypes.FloatType, default=np.inf,
+                                                 descr=r"""Bounding interval upper bound $U$"""))
+    return specs
+
+  def handleInput(self, spec):
+    """
+      Reads user inputs into this object.
+      @ In, spec, InputData.InputParams, input specifications
+      @ Out, settings, dict, initialization settings for this algorithm
+    """
+    settings = super().handleInput(spec)
+
+    bounds, _ = spec.findNodesAndExtractValues(['lowerBound', 'upperBound'])
+    settings |= bounds
+
+    # define a bounding function to enforce those bounds
+    def boundingFunc(x):
+      """
+        Bounds the signal domain to between lowerBound and upperBound
+        @ In, x, np.ndarray, values to bound
+        @ Out, x, np.ndarray, bounded signal
+      """
+      x[x > bounds['upperBound']] = bounds['upperBound']
+      x[x < bounds['lowerBound']] = bounds['lowerBound']
+      return x
+
+    # use both the forward and inverse transformation functions to apply those bounds
+    self.templateTransformer.set_params(func=boundingFunc, inverse_func=boundingFunc, check_inverse=False)
+
     return settings

--- a/ravenframework/TSA/Transformers/__init__.py
+++ b/ravenframework/TSA/Transformers/__init__.py
@@ -22,7 +22,8 @@ Created May 25, 2023
 """
 
 from .Filters import ZeroFilter
-from .FunctionTransformers import LogTransformer, ArcsinhTransformer, TanhTransformer, SigmoidTransformer, OutTruncation
+from .FunctionTransformers import (LogTransformer, ArcsinhTransformer, TanhTransformer, SigmoidTransformer,
+                                   OutTruncation, BoundDomain)
 from .Normalizers import MaxAbsScaler, MinMaxScaler, StandardScaler, RobustScaler
 from .Distributions import Gaussianize, QuantileTransformer, PreserveCDF
 from .Differencing import Differencing

--- a/ravenframework/TSA/__init__.py
+++ b/ravenframework/TSA/__init__.py
@@ -31,7 +31,7 @@ from .STL import STL
 from .Transformers import MaxAbsScaler, MinMaxScaler, StandardScaler, RobustScaler, \
                           LogTransformer, ArcsinhTransformer, TanhTransformer, SigmoidTransformer, \
                           QuantileTransformer, OutTruncation, ZeroFilter, PreserveCDF, Gaussianize, \
-                          Differencing, FilterBankDWT
+                          Differencing, FilterBankDWT, BoundDomain
 
 from .Factory import factory
 

--- a/tests/framework/unit_tests/TSA/testBoundDomain.py
+++ b/tests/framework/unit_tests/TSA/testBoundDomain.py
@@ -1,0 +1,99 @@
+# Copyright 2017 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+  This Module performs Unit Tests for the TSA.BoundDomain class.
+  It cannot be considered part of the active code but of the regression test system
+"""
+import os
+import sys
+import unittest
+import numpy as np
+from numpy.testing import assert_array_equal
+
+# add RAVEN to path
+ravenDir =  os.path.abspath(os.path.join(*([os.path.dirname(__file__)] + [os.pardir]*4)))
+frameworkDir = os.path.join(ravenDir, 'framework')
+if ravenDir not in sys.path:
+  sys.path.append(ravenDir)
+
+from ravenframework.utils import xmlUtils
+from ravenframework.TSA import BoundDomain
+
+print('Modules undergoing testing:')
+print(BoundDomain)
+print('')
+
+
+class TestBoundDomain(unittest.TestCase):
+  """ Tests for the BoundDomain TSA transformer class """
+
+  def setUp(self):
+    """
+      Sets up transformer object and input/output test data
+      @ In, None
+      @ Out, None
+    """
+    self.targets = ["signal"]
+    self.signal = np.array([-np.inf, np.inf, np.nan, -1, 0, 1, 10]).reshape(-1, 1)
+    self.lowerBound = -5.0
+    self.upperBound = 5.0
+    self.boundedSignal = np.array([-5, 5, np.nan, -1, 0, 1, 5]).reshape(-1, 1)
+    self.pivots = np.arange(self.signal.shape[0])
+
+    self.transformer = BoundDomain()
+    xml = xmlUtils.newNode("bounddomain", attrib={"target": ",".join(self.targets)})
+    xml.append(xmlUtils.newNode("lowerBound", text=str(self.lowerBound)))
+    xml.append(xmlUtils.newNode("upperBound", text=str(self.upperBound)))
+    spec = self.transformer.getInputSpecification()()
+    spec.parseNode(xml)
+    self.settings = self.transformer.handleInput(spec)
+
+  def testSettings(self):
+    """
+      Test that settings are correctly read from XML
+      @ In, None
+      @ Out, None
+    """
+    self.assertDictContainsSubset({"lowerBound": self.lowerBound, "upperBound": self.upperBound}, self.settings)
+
+  def testFit(self):
+    """
+      Test the `fit` method
+      @ In, None
+      @ Out, None
+    """
+    params = self.transformer.fit(self.signal, self.pivots, self.targets, self.settings)
+    # params should have an entry for each fitted target
+    for target in self.targets:
+      self.assertIn(target, params)
+
+  def testGetResidual(self):
+    """
+      Test the `getResidual` method
+      @ In, None
+      @ Out, None
+    """
+    params = self.transformer.fit(self.signal, self.pivots, self.targets, self.settings)
+    residual = self.transformer.getResidual(self.signal, params, self.pivots, self.settings)
+    assert_array_equal(residual, self.boundedSignal)
+
+  def testGetComposite(self):
+    """
+      Test the `getComposite` method
+      @ In, None
+      @ Out, None
+    """
+    params = self.transformer.fit(self.signal, self.pivots, self.targets, self.settings)
+    composite = self.transformer.getComposite(self.signal, params, self.pivots, self.settings)
+    assert_array_equal(composite, self.boundedSignal)

--- a/tests/framework/unit_tests/TSA/tests
+++ b/tests/framework/unit_tests/TSA/tests
@@ -40,4 +40,8 @@
     type = 'RavenPython'
     input = 'testSTL.py'
   [../]
+  [./BoundDomain]
+    type = 'Unittest'
+    input = 'testBoundDomain.py'
+  [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2471 

##### What are the significant changes in functionality due to this change request?
- Adds an option to the ZeroFilter class to specify absolute tolerance for ZeroFilter transformation, such that any value |x|<tol is masked, rather than relying on the default tolerance in `np.isclose`. The default tolerance from `np.isclose` is retained in the new option.
- Adds an option to the ZeroFilter class to specify the fill value for masked values, defaulting to the previous use of `np.nan`.
- Creates a `BoundDomain` transformation which applies the transformation function $f(x) = L$ for $x < L$ and $f(x) = U$ for $x > U$, with $f(x) = x$ otherwise, for both the forward and inverse transformations. This limits the domain of the training signal and synthetic samples to the interval $[L, U]$. If either bound is not specified, the bound defaults to the corresponding +/- infinity values.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

