### PR TITLE
Work on improving usefulness of RavenRunsRaven test

### DIFF
--- a/ravenframework/Models/Code.py
+++ b/ravenframework/Models/Code.py
@@ -799,7 +799,10 @@ class Code(Model):
     """
     evaluation = finishedJob.getEvaluation()
     if not hasattr(evaluation, 'pop'):
-      self.raiseAWarning("No pop in evaluation " + repr(evaluation) + " for job " + str(finishedJob.identifier) + ":" + repr(finishedJob) + " with return code "+ repr(finishedJob.getReturnCode()))
+      self.raiseAWarning("No pop in evaluation " + repr(evaluation) + " of type " + str(type(evaluation)) + " for job " + str(finishedJob.identifier) + ":" + repr(finishedJob) + " with return code "+ repr(finishedJob.getReturnCode()))
+      if isinstance(evaluation, BaseException):
+        import traceback
+        traceback.print_exception(evaluation)
 
 
     self._replaceVariablesNamesWithAliasSystem(evaluation, 'input',True)

--- a/tests/cluster_tests/RavenRunsRaven/CodeDask/Inner/Simple.py
+++ b/tests/cluster_tests/RavenRunsRaven/CodeDask/Inner/Simple.py
@@ -44,6 +44,7 @@ def readInput(infile):
     @ In, infile, string, filename
     @ Out, (a, b, x, y, out), tuple, required inputs
   """
+  print("Reading",infile)
   config = configparser.ConfigParser()
   config.read(infile)
   a = float(config['FromOuter']['a'])
@@ -59,6 +60,8 @@ def run(*args):
     @ In, args, list, list of things to sum up
     @ Out, run, float, sum of entries in list
   """
+  for i in range(100000):
+    a = 2**2**2**2**2
   return sum(args)
 
 def write(a, b, c, x, y, out):

--- a/tests/cluster_tests/RavenRunsRaven/code_dask.xml
+++ b/tests/cluster_tests/RavenRunsRaven/code_dask.xml
@@ -23,6 +23,7 @@
     <Sequence>sample, print</Sequence>
     <batchSize>8</batchSize>
     <NumMPI>8</NumMPI>
+    <NumThreads>1</NumThreads>
     <expectedTime>0:10:0</expectedTime>
     <NodeParameter>--hostfile</NodeParameter>
     <RemoteRunCommand>raven_ec_qsub_command.sh</RemoteRunCommand>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

