### PR TITLE
Input data pickle

### DIFF
--- a/ravenframework/Models/ROM.py
+++ b/ravenframework/Models/ROM.py
@@ -791,3 +791,6 @@ if __name__ == '__main__':
       concreteModel.pprint()
 """
     return template
+
+#magic to allow ROM to be pickled
+ROM.getInputSpecification()

--- a/ravenframework/Models/ROM.py
+++ b/ravenframework/Models/ROM.py
@@ -792,5 +792,5 @@ if __name__ == '__main__':
 """
     return template
 
-#magic to allow ROM to be pickled
+#magic to allow ROM to be pickled, see utils.InputData.parameterInputFactory
 ROM.getInputSpecification()

--- a/ravenframework/Runners/DaskRunner.py
+++ b/ravenframework/Runners/DaskRunner.py
@@ -121,7 +121,7 @@ class DaskRunner(InternalRunner):
       try:
         self._collectRunnerResponse()
       except Exception as ae:
-        self.raiseAWarning(self.__class__.__name__ + " job "+self.identifier+" failed with error:"+ str(ae) +" !",'ExceptedError')
+        self.raiseAWarning(self.__class__.__name__ + " job "+self.identifier+" failed with error:"+ str(ae) +" !",'ExceptedErrorInGetReturnCode')
         self.returnCode = -1
 
     return self.returnCode
@@ -143,7 +143,7 @@ class DaskRunner(InternalRunner):
             self.runReturn = None
             self.hasBeenAdded = True
             self.returnCode = -1
-            self.raiseAWarning(self.__class__.__name__ + " job "+self.identifier+" failed with error:"+ str(ae) +" !",'ExceptedError')
+            self.raiseAWarning(self.__class__.__name__ + " job "+self.identifier+" failed with error:"+ str(ae) +" !",'ExceptedErrorInCollect')
             raise ae
         else:
           self.runReturn = None
@@ -168,7 +168,7 @@ class DaskRunner(InternalRunner):
       #exc_type, exc_value, exc_traceback = sys.exc_info()
       #import traceback
       #traceback.print_exception(exc_type, exc_value, exc_traceback)
-      self.raiseAWarning(self.__class__.__name__ + " job "+self.identifier+" failed with error:"+ str(ae) +" !",'ExceptedError')
+      self.raiseAWarning(self.__class__.__name__ + " job "+self.identifier+" failed with error:"+ str(ae) +" !",'ExceptedErrorInStart')
       self.returnCode = -1
 
   def kill(self):

--- a/ravenframework/SupervisedLearning/DMD/DMDBase.py
+++ b/ravenframework/SupervisedLearning/DMD/DMDBase.py
@@ -474,5 +474,5 @@ class DMDBase(SupervisedLearning):
     return self.__returnInitialParametersLocal__()
 
 
-#magic to allow DMDBase to be pickled
+#magic to allow DMDBase to be pickled, see utils.InputData.parameterInputFactory
 DMDBase.getInputSpecification()

--- a/ravenframework/SupervisedLearning/DMD/DMDBase.py
+++ b/ravenframework/SupervisedLearning/DMD/DMDBase.py
@@ -472,3 +472,7 @@ class DMDBase(SupervisedLearning):
       @ Out, params, dict, the dict of the SM settings
     """
     return self.__returnInitialParametersLocal__()
+
+
+#magic to allow DMDBase to be pickled
+DMDBase.getInputSpecification()

--- a/ravenframework/SupervisedLearning/DMD/DynamicModeDecompositionControl.py
+++ b/ravenframework/SupervisedLearning/DMD/DynamicModeDecompositionControl.py
@@ -664,3 +664,6 @@ class DMDC(DMD):
     B = beta.dot(uTruc[n:, :].T)
     C = Y1.dot(scipy.linalg.pinv(X1))
     return A, B, C
+
+#magic to allow ROM to be pickled
+DMDC.getInputSpecification()

--- a/ravenframework/SupervisedLearning/DMD/DynamicModeDecompositionControl.py
+++ b/ravenframework/SupervisedLearning/DMD/DynamicModeDecompositionControl.py
@@ -665,5 +665,5 @@ class DMDC(DMD):
     C = Y1.dot(scipy.linalg.pinv(X1))
     return A, B, C
 
-#magic to allow ROM to be pickled
+#magic to allow DMDC to be pickled, see utils.InputData.parameterInputFactory
 DMDC.getInputSpecification()

--- a/ravenframework/SupervisedLearning/DMD/HODMD.py
+++ b/ravenframework/SupervisedLearning/DMD/HODMD.py
@@ -191,5 +191,5 @@ class HODMD(DMDBase):
     # intialize the model
     self.initializeModel(self.dmdParams)
 
-#magic to allow HODMD to be pickled
+#magic to allow HODMD to be pickled, see utils.InputData.parameterInputFactory
 HODMD.getInputSpecification()

--- a/ravenframework/SupervisedLearning/DMD/HODMD.py
+++ b/ravenframework/SupervisedLearning/DMD/HODMD.py
@@ -190,3 +190,6 @@ class HODMD(DMDBase):
     self._dmdBase = HODMD
     # intialize the model
     self.initializeModel(self.dmdParams)
+
+#magic to allow HODMD to be pickled
+HODMD.getInputSpecification()

--- a/ravenframework/SupervisedLearning/ROMCollection.py
+++ b/ravenframework/SupervisedLearning/ROMCollection.py
@@ -2204,3 +2204,8 @@ class Decomposition(SupervisedLearning):
         associated with the corresponding points in featureVals
     """
     pass
+
+
+#magic to allow ROMCollection to be pickled
+Collection.getInputSpecification()
+Interpolated.getInputSpecification()

--- a/ravenframework/SupervisedLearning/ROMCollection.py
+++ b/ravenframework/SupervisedLearning/ROMCollection.py
@@ -2206,6 +2206,9 @@ class Decomposition(SupervisedLearning):
     pass
 
 
-#magic to allow ROMCollection to be pickled
+#magic to allow ROMCollection to be pickled, see utils.InputData.parameterInputFactory
 Collection.getInputSpecification()
+Segments.getInputSpecification()
+Clusters.getInputSpecification()
 Interpolated.getInputSpecification()
+Decomposition.getInputSpecification()

--- a/ravenframework/SupervisedLearning/SupervisedLearning.py
+++ b/ravenframework/SupervisedLearning/SupervisedLearning.py
@@ -873,5 +873,5 @@ class SupervisedLearning(BaseInterface):
     """
 
 
-#magic to allow SupervisedLearning to be pickled
+#magic to allow SupervisedLearning to be pickled, see utils.InputData.parameterInputFactory
 SupervisedLearning.getInputSpecification()

--- a/ravenframework/SupervisedLearning/SupervisedLearning.py
+++ b/ravenframework/SupervisedLearning/SupervisedLearning.py
@@ -871,3 +871,7 @@ class SupervisedLearning(BaseInterface):
       @ In, None
       @ Out, params, dict, dictionary of parameter names and current values
     """
+
+
+#magic to allow SupervisedLearning to be pickled
+SupervisedLearning.getInputSpecification()

--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -741,11 +741,28 @@ class ParameterInput(object):
     msg += '\n{i}\\end{{itemize}}\n'.format(i=doDent(recDepth))
     return msg
 
+#Note: if you get an error like:
+"""
+  File ".../site-packages/distributed/protocol/pickle.py", line 90, in loads
+    return pickle.loads(x, buffers=buffers)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: Can't get attribute 'DMDCSpecInputDataUser' on <module 'ravenframework.utils.InputData' from '.../raven/ravenframework/utils/InputData.py'>
+"""
+#the solution is to do something like:
+"""
+#magic to allow ROM to be pickled, see utils.InputData.parameterInputFactory
+DMDC.getInputSpecification()
+"""
+#Basically, the type function in parameterInputFactory needs to be run
+# to get the attribute in the InputData namespace.
+#Note, that this is only needed if the ParamterInput class needs to be
+#unpickled before the class ever has getInputSpecification called.
 
 
 def parameterInputFactory(name, *paramList, **paramDict):
   """
     Creates a new ParameterInput class with the same parameters as ParameterInput.createClass
+    @ In, name, string, The name of the node.
     @ In, same parameters as ParameterInput.createClass
     @ Out, newClass, ParameterInput, the newly created class.
   """

--- a/ravenframework/utils/InputData.py
+++ b/ravenframework/utils/InputData.py
@@ -19,6 +19,8 @@ Created on 2016-Jan-26
 This a library for defining the data used and for reading it in.
 """
 import re
+import traceback
+import os
 from collections import OrderedDict
 from enum import Enum
 import xml.etree.ElementTree as ET
@@ -172,8 +174,9 @@ class ParameterInput(object):
       @ Out, None
     """
 
-    ## Rename the class to something understandable by a developer
-    cls.__name__ = str(name+'Spec')
+    ## Rename the class to something other than ParameterInput if needed
+    if cls.__name__ == "ParameterInput":
+      cls.__name__ = str(name+'Spec')
     # register class name to module (necessary for pickling)
     globals()[cls.__name__] = cls
 
@@ -740,17 +743,27 @@ class ParameterInput(object):
 
 
 
-def parameterInputFactory(*paramList, **paramDict):
+def parameterInputFactory(name, *paramList, **paramDict):
   """
     Creates a new ParameterInput class with the same parameters as ParameterInput.createClass
     @ In, same parameters as ParameterInput.createClass
     @ Out, newClass, ParameterInput, the newly created class.
   """
-  class newClass(ParameterInput):
-    """
-      The new class to be created by the factory
-    """
-  newClass.createClass(*paramList, **paramDict)
+  #We need a unique name, but unfortuneately, people used the same
+  # name in different classes, which causes depickling problems
+  # so we use the stack trace to find which class is calling us
+  uniquifier = ""
+  tb = traceback.extract_stack()
+  i = -1
+  while i >= -len(tb) and tb[i].name != 'getInputSpecification' and i > -5:
+    #print(tb[i].filename,tb[i].lineno)
+    i -= 1
+  if i >= -len(tb):
+    #print(tb[i].filename,tb[i].lineno)
+    uniquifier += os.path.basename(tb[i].filename[:-3])
+  #print("for",name+'Spec'+uniquifier)
+  newClass = type(name+'Spec'+uniquifier, (ParameterInput,), {})
+  newClass.createClass(name, *paramList, **paramDict)
   return newClass
 
 def assemblyInputFactory(*paramList, **paramDict):


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2482 

##### What are the significant changes in functionality due to this change request?
* gives different error messages for different locations in DaskRunner
* gives each parameterInputFactory class a different name
* uses 3 parameter `type` function, instead of just creating a local class

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

