### PR TITLE
Parallel decorator simplification

### DIFF
--- a/ravenframework/Decorators/Parallelization.py
+++ b/ravenframework/Decorators/Parallelization.py
@@ -39,12 +39,9 @@ class Parallel(object):
     i.e. :
     - if ray is available and needs to be used,
       the decorated function (or class) will need to be called as following:
-      functionName.remote(*args, **kwargs)
-    - if ray is available and direct call to the function is needed,
-      the original function (or class) will need to be called as following:
-      functionName.original_function(*args, **kwargs)
-    - if ray is not available,
-      the original function (or class) will need to be called as following:
+      functionName.ray_function.remote(*args, **kwargs)
+    - if a direct call to the function is needed,
+      the original function (or class) can still be called as usual:
       functionName(*args, **kwargs)
   """
   def __init__(self):
@@ -61,15 +58,11 @@ class Parallel(object):
       @ In, func, FunctionType or Class, the function or class to decorate
       @ Out, decorated, FunctionType, or Class, the decorated function or class
     """
-    if self.decorator is None:
-      # Return the function decorated with a wrapper
-      # this is basically not decarate but we keep the same
-      # approach for accessing to the original underlying function
-      # in case of multi-threading
-      decorated = Object()
-    else:
+    if self.decorator is not None:
       # decorate the function
-      decorated = self.decorator(func)
-    decorated.__dict__['original_function'] = func
-    return decorated
+      func.__dict__['ray_function'] = self.decorator(func)
+
+    func.__dict__['parallel_function'] = True
+
+    return func
 

--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -726,11 +726,11 @@ class JobHandler(BaseType):
         clientQueue
       @ Out, None
     """
-    assert "original_function" in dir(functionToRun), "to parallelize a function, it must be" \
+    assert "parallel_function" in dir(functionToRun), "to parallelize a function, it must be" \
            " decorated with RAVEN Parallel decorator"
     if self._server is None or forceUseThreads:
       internalJob = Runners.factory.returnInstance('SharedMemoryRunner', args,
-                                                   functionToRun.original_function,
+                                                   functionToRun,
                                                    identifier=identifier,
                                                    metadata=metadata,
                                                    uniqueHandler=uniqueHandler,
@@ -742,7 +742,7 @@ class JobHandler(BaseType):
         arguments = args
       if self._parallelLib == ParallelLibEnum.dask:
         internalJob = Runners.factory.returnInstance('DaskRunner', arguments,
-                                                     functionToRun.original_function,
+                                                     functionToRun,
                                                      identifier=identifier,
                                                      metadata=metadata,
                                                      uniqueHandler=uniqueHandler,
@@ -750,7 +750,7 @@ class JobHandler(BaseType):
 
       elif self._parallelLib == ParallelLibEnum.ray:
         internalJob = Runners.factory.returnInstance('RayRunner', arguments,
-                                                     functionToRun.remote,
+                                                     functionToRun.ray_function.remote,
                                                      identifier=identifier,
                                                      metadata=metadata,
                                                      uniqueHandler=uniqueHandler,

--- a/ravenframework/Models/Code.py
+++ b/ravenframework/Models/Code.py
@@ -880,7 +880,10 @@ class Code(Model):
     """
     evaluation = finishedJob.getEvaluation()
     if not hasattr(evaluation, 'pop'):
-      self.raiseAWarning("No pop in evaluation " + repr(evaluation) + " for job " + str(finishedJob.identifier) + ":" + repr(finishedJob) + " with return code "+ repr(finishedJob.getReturnCode()))
+      self.raiseAWarning("No pop in evaluation " + repr(evaluation) + " of type " + str(type(evaluation)) + " for job " + str(finishedJob.identifier) + ":" + repr(finishedJob) + " with return code "+ repr(finishedJob.getReturnCode()))
+      if isinstance(evaluation, BaseException):
+        import traceback
+        traceback.print_exception(evaluation)
 
 
     self._replaceVariablesNamesWithAliasSystem(evaluation, 'input',True)

--- a/ravenframework/Models/EnsembleModel.py
+++ b/ravenframework/Models/EnsembleModel.py
@@ -784,7 +784,7 @@ class EnsembleModel(Dummy):
     if self.parallelStrategy == 1:
       # we evaluate the model directly
       try:
-        evaluation = modelToExecute['Instance'].evaluateSample.original_function(modelToExecute['Instance'], origInputList, samplerType, inputKwargs)
+        evaluation = modelToExecute['Instance'].evaluateSample(origInputList, samplerType, inputKwargs)
       except Exception:
         excType, excValue, excTrace = sys.exc_info()
         evaluation = None

--- a/ravenframework/Quadratures.py
+++ b/ravenframework/Quadratures.py
@@ -401,7 +401,7 @@ class TensorGrid(SparseGrid):
         largest[i] = max(idx[i],largest[i])
     #construct tensor grid using largest in each dimension
     quadSizes = self.quadRule(largest)+1 #TODO give user access to this +1 rule
-    points,weights = self.tensorGrid.original_function(self, quadSizes)
+    points,weights = self.tensorGrid(quadSizes)
     for i,pt in enumerate(points):
       self.SG[pt] = weights[i]
 
@@ -452,7 +452,7 @@ class SmolyakSparseGrid(SparseGrid):
       for j,cof in enumerate(self.c):
         idx = self.indexSet[j]
         m = self.quadRule(idx)+1
-        new =   self.tensorGrid.original_function(self, m)
+        new =   self.tensorGrid(m)
         for i in range(len(new[0])):
           newpt=tuple(new[0][i])
           newwt=new[1][i]*cof
@@ -491,7 +491,7 @@ class SmolyakSparseGrid(SparseGrid):
           cof=self.c[j]
           idx = self.indexSet[j]
           m=self.quadRule(idx)+1
-          handler.addJob((self, m,),self.tensorGrid,prefix+str(cof))
+          handler.addJob((m,),self.tensorGrid,prefix+str(cof))
       else:
         if handler.isFinished() and len(handler.getFinishedNoPop())==0:
           break #FIXME this is significantly the second-most expensive line in this method

--- a/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
+++ b/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
@@ -387,8 +387,8 @@ class RFE(FeatureSelectionBase):
           outputSpace = self.subGroups[g]
           self.raiseAMessage("Sub-groupping with targets: {}".format(",".join(outputSpace)))
         # apply RFE
-        supportParallel_, indexToKeepParallel = self._rfe.original_function(self.estimator,
-                                                                            X, y, g, outputSpace, supportDataRFE)
+        supportParallel_, indexToKeepParallel = self._rfe(self.estimator,
+                                                          X, y, g, outputSpace, supportDataRFE)
 
         if nGroups > 1:
           # store candidates in case of sub-groupping
@@ -500,8 +500,8 @@ class RFE(FeatureSelectionBase):
           #Looping over all possible combinations: from initialNumbOfFeatures choose k
           for it, combo in enumerate(itertools.combinations(featuresForRanking,k)):
             # train and get score
-            score, survivors, _ = self._scoring.original_function(copy.deepcopy(self.estimator),
-                                                                  X, y, combo,supportData)
+            score, survivors, _ = self._scoring(copy.deepcopy(self.estimator),
+                                                X, y, combo,supportData)
             updateBestScore(it, k, score, combo, survivors)
       idxx = np.argmin(scoreCollection)
       support_ = copy.copy(originalSupport)

--- a/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
+++ b/ravenframework/SupervisedLearning/FeatureSelection/RFE.py
@@ -351,7 +351,7 @@ class RFE(FeatureSelectionBase):
           if g > 0:
             supportDataRFE['firstStep'] = setStep
           jhandler.addJob((estimatorRef, XRef, yRef, g, outputSpace, supportDataRFE,),
-                          self._rfe, prefix, uniqueHandler='RFE_subgroup')
+                          self.__class__._rfe, prefix, uniqueHandler='RFE_subgroup')
           g += 1
 
         finishedJobs = jhandler.getFinished(uniqueHandler='RFE_subgroup')
@@ -387,7 +387,7 @@ class RFE(FeatureSelectionBase):
           outputSpace = self.subGroups[g]
           self.raiseAMessage("Sub-groupping with targets: {}".format(",".join(outputSpace)))
         # apply RFE
-        supportParallel_, indexToKeepParallel = self._rfe(self.estimator,
+        supportParallel_, indexToKeepParallel = self.__class__._rfe(self.estimator,
                                                           X, y, g, outputSpace, supportDataRFE)
 
         if nGroups > 1:
@@ -478,7 +478,7 @@ class RFE(FeatureSelectionBase):
             if jhandler.availability() > 0:
               prefix = f'{k}_{it+1}'
               jhandler.addJob((estimatorRef, XRef, yRef, combinations[it], supportDataRef,),
-                              self._scoring, prefix, uniqueHandler='RFE_scoring')
+                              self.__class__._scoring, prefix, uniqueHandler='RFE_scoring')
               it += 1
             finishedJobs = jhandler.getFinished(uniqueHandler='RFE_scoring')
             if not finishedJobs:
@@ -500,7 +500,7 @@ class RFE(FeatureSelectionBase):
           #Looping over all possible combinations: from initialNumbOfFeatures choose k
           for it, combo in enumerate(itertools.combinations(featuresForRanking,k)):
             # train and get score
-            score, survivors, _ = self._scoring(copy.deepcopy(self.estimator),
+            score, survivors, _ = self.__class__._scoring(copy.deepcopy(self.estimator),
                                                 X, y, combo,supportData)
             updateBestScore(it, k, score, combo, survivors)
       idxx = np.argmin(scoreCollection)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? 
Close #2491 

##### What are the significant changes in functionality due to this change request?
This changes how the `@Parallel` decorator works, and just leaves the function as is, but adds a `ray_function` for ray.
This also adds showing the stack trace when a code returns an Exception.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

