### PR TITLE
Have pylint check the whitespace.

### DIFF
--- a/developer_tools/pylint_check
+++ b/developer_tools/pylint_check
@@ -12,7 +12,7 @@ cd $SCRIPT_DIR/..
 source $SCRIPT_DIR/../scripts/establish_conda_env.sh --load --quiet
 
 echo Framework
-pylint --disable=all --enable=missing-docstring --enable=multiple-statements ravenframework/ scripts/TestHarness/testers/*.py
+pylint --disable=all --enable=missing-docstring --enable=multiple-statements ravenframework/ scripts/TestHarness/testers/*.py --enable=trailing-whitespace
 
 echo Rook
 pylint --disable=consider-iterating-dictionary,unspecified-encoding,consider-using-f-string,fixme,too-few-public-methods,len-as-condition,too-many-locals,too-many-return-statements,too-many-branches,too-many-statements,too-many-instance-attributes,too-many-arguments,similarities,broad-except,consider-using-enumerate,no-member,import-error,not-an-iterable,unexpected-keyword-arg,too-many-public-methods,wrong-import-position,consider-using-with --const-rgx '(([A-Za-z_][A-Za-z0-9_]*)|(__.*__))$' --module-rgx '(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$' --indent-string "  " rook/*.py

--- a/ravenframework/contrib/melcorTools/melcorTools.py
+++ b/ravenframework/contrib/melcorTools/melcorTools.py
@@ -1,8 +1,8 @@
 """
-  DISCLAIMER: 
+  DISCLAIMER:
     THIS MODULE IS AN EXTERNAL MODULE NOT MAINTAINED BY RAVEN TEAM.
     ORIGINAL MODULE AVAILABLE AT: https://github.com/mattdon/MELCOR_pyPlot
-  
+
   MELCOR FORMAT SUPPORT MODULE
   Created on March 28, 2017
   Last update on October 14, 2022


### PR DESCRIPTION
This makes it easier to check the whitespace issues locally.

--------
Pull Request Description
--------
##### What issue does this change request address? 
Closes #2496 

##### What are the significant changes in functionality due to this change request?
This adds checking whitespace to the pylint check, so it is easier to check whitespace locally.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

