### PR TITLE
Adding checking for a just me conda install.

### DIFF
--- a/scripts/establish_conda_env.sh
+++ b/scripts/establish_conda_env.sh
@@ -59,7 +59,17 @@ function find_conda_defs ()
       # default location of conda definitions, windows is unsurprisingly an exception
       if [[ "$OSOPTION" = "--os windows" ]];
       then
-        CONDA_DEFS="/c/ProgramData/Miniconda3/etc/profile.d/conda.sh";
+	  if test -e "/c/ProgramData/Miniconda3/etc/profile.d/conda.sh"
+	  then
+              CONDA_DEFS="/c/ProgramData/Miniconda3/etc/profile.d/conda.sh";
+	  elif test -e "$HOME/AppData/Local/miniconda3/etc/profile.d/conda.sh"
+	  then
+	      CONDA_DEFS="$HOME/AppData/Local/miniconda3/etc/profile.d/conda.sh
+"
+	  else
+	      echo Failed to find Conda at /c/ProgramData/Miniconda3/etc/profile.d/conda.sh and $HOME/AppData/Local/miniconda3/etc/profile.d/conda.sh
+
+	  fi
       elif test -e "$HOME/miniconda3/etc/profile.d/conda.sh";
       then
         CONDA_DEFS="$HOME/miniconda3/etc/profile.d/conda.sh";


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
Closes #2517

##### What are the significant changes in functionality due to this change request?
This adds a check for a windows just me conda install (for users who install conda in their home directory).

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

