### PR TITLE
Switching a lot over to pip.

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -37,31 +37,31 @@ Note all install methods after "main" take
 -->
 <dependencies>
   <main>
-    <h5py/>
-    <numpy>1.26</numpy>
-    <scipy>1.12</scipy>
-    <scikit-learn>1.1</scikit-learn>
-    <pandas/>
+    <h5py source="pip"/>
+    <numpy source="pip">1.26</numpy>
+    <scipy source="pip">1.12</scipy>
+    <scikit-learn source="pip">1.1</scikit-learn>
+    <pandas source="pip"/>
     <!-- Note most versions of xarray work, but some (such as 0.20) don't -->
-    <xarray/>
+    <xarray source="pip"/>
     <netcdf4 source="pip">1.6</netcdf4>
-    <matplotlib>3.6</matplotlib>
-    <statsmodels>0.13</statsmodels>
-    <cloudpickle/>
+    <matplotlib source="pip">3.6</matplotlib>
+    <statsmodels source="pip">0.13</statsmodels>
+    <cloudpickle source="pip"/>
     <tensorflow source="pip">2.14</tensorflow>
     <grpcio source="pip" />
     <!-- conda is really slow on windows if the version is not specified.-->
     <python skip_check='True' os='windows'>3.11</python>
-    <python skip_check='True' os='mac,linux'>3</python>
+    <python skip_check='True' os='mac,linux'>3.11</python>
     <hdf5 skip_check='True'/>
     <swig skip_check='True'/>
     <pylint/>
     <coverage/>
-    <lxml/>
-    <psutil/>
+    <lxml source="pip"/>
+    <psutil source="pip"/>
     <pip/>
     <pyDOE3 source="pip"/>
-    <importlib_metadata/>
+    <importlib_metadata source="pip"/>
     <pyside2 optional='True'/>
     <nomkl os='linux' skip_check='True'/>
     <cmake skip_check='True' optional='True'/>
@@ -72,8 +72,8 @@ Note all install methods after "main" take
     <imageio source="pip">2.22</imageio>
     <line_profiler optional='True'/>
     <!-- <ete3 optional='True'/> -->
-    <statsforecast/>
-    <pywavelets>1.4</pywavelets>
+    <statsforecast source="pip"/>
+    <pywavelets source="pip">1.4</pywavelets>
     <python-sensors source="pip"/>
     <numdifftools source="pip">0.9</numdifftools>
     <fmpy optional='True'/>
@@ -83,7 +83,7 @@ Note all install methods after "main" take
     <ipopt skip_check='True' optional='True'/>
     <cyipopt optional='True'/>
     <pyomo-extensions source="pyomo" skip_check='True' optional='True'/>
-    <setuptools />
+    <setuptools source="pip"/>
     <!-- source="mamba" are the ones installed when mamba is installed -->
     <mamba source='mamba' skip_check='True'/>
     <pydmd source="pip"/>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?
Switches to using pip for most dependencies.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

