### PR TITLE
Closes #2578 -  Spam in Generic Parser

### DIFF
--- a/ravenframework/CodeInterfaceClasses/Generic/GenericParser.py
+++ b/ravenframework/CodeInterfaceClasses/Generic/GenericParser.py
@@ -94,9 +94,11 @@ class GenericParser():
               varformat = var[min(optionalPos[1]+1,len(var)):len(var)] if optionalPos[0] < optionalPos[1] else var[optionalPos[1]+1:min(optionalPos[0],len(var))]
               var = var[0:min(optionalPos)]
               if var in self.defaults.keys() and optionalPos[0] != sys.maxsize:
-                print('multiple default values given for variable',var)
+                if self.defaults[var][infileName] != defval:
+                  print('multiple default values given for variable',var)
               if var in self.formats.keys() and optionalPos[1] != sys.maxsize:
-                print('multiple format values given for variable',var)
+                if self.formats[var][infileName] != varformat:
+                  print('multiple format values given for variable',var)
               #TODO allow the user to specify take-last or take-first?
               if var not in self.defaults.keys() and optionalPos[0] != sys.maxsize:
                 self.defaults[var] = {}


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)

Closes  #2578

##### What are the significant changes in functionality due to this change request?

Simply added a check on the if statement for default values in the Generic Parser

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

