### PR TITLE
Chansoo/ensemble jobhandler event wait

### DIFF
--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -157,7 +157,35 @@ class JobHandler(BaseType):
     # something from the main thread can remove them.
     self.__finished = []
 
-    # End block of __queueLock protected variables
+    # ---------- Per-job completion events (lock-free signaling) ----------
+    # Maps job identifier (str) -> threading.Event.
+    #
+    # Motivation:
+    #   EnsembleModel (parallelStrategy==2) runs N evaluation threads that
+    #   each call isThisJobFinished() in a busy-wait loop.  Every call
+    #   acquires __queueLock, and when N is large (e.g. 100) the resulting
+    #   lock contention can starve the single polling thread in startLoop(),
+    #   preventing it from running cleanJobQueue().  Jobs then never
+    #   transition from __running to __finished, causing a permanent hang.
+    #
+    # Solution:
+    #   Each job gets a threading.Event created in reAddJob().  Waiting
+    #   threads call event.wait() instead of polling isThisJobFinished(),
+    #   eliminating lock acquisition entirely on the wait path.  The
+    #   polling thread calls event.set() inside cleanJobQueue() when it
+    #   moves a job to __finished.
+    #
+    # Impact:
+    #   - Backward-compatible: isThisJobFinished() is unchanged and still
+    #     available for callers that do not use event-based waiting.
+    #   - Negligible overhead: one dict entry and one Event object per job.
+    #   - Cleaned up in getFinished() (on collection), terminateAll(),
+    #     terminateJobs(), and startingNewStep().
+    #
+    # See also: EnsembleModel.__advanceModel(), which is the consumer.
+    self.__jobEvents = {}
+
+    # End block of __queueLock protected variables (including __jobEvents)
     ############################################################################
 
     self.__queueLock = threading.RLock()
@@ -182,6 +210,9 @@ class JobHandler(BaseType):
     """
     state = copy.copy(self.__dict__)
     state.pop('_JobHandler__queueLock')
+    # threading.Event objects cannot be pickled; exclude them.
+    # They will be re-created as empty dict in __setstate__.
+    state.pop('_JobHandler__jobEvents', None)
     #This will be reinitialized from a schedulerFile.
     if self._parallelLib == ParallelLibEnum.dask and '_server' in state:
       state.pop('_server')
@@ -195,6 +226,9 @@ class JobHandler(BaseType):
     """
     self.__dict__.update(d)
     self.__queueLock = threading.RLock()
+    # Reinitialize the per-job event registry (lost during pickling).
+    # New events will be created when jobs are submitted via reAddJob().
+    self.__jobEvents = {}
     if '_server' not in self.__dict__:
       if self._parallelLib == ParallelLibEnum.dask and self.daskSchedulerFile is not None:
         self._server = dask.distributed.Client(scheduler_file=self.daskSchedulerFile)
@@ -780,6 +814,11 @@ class JobHandler(BaseType):
       @ Out, None
     """
     with self.__queueLock:
+      # Create a per-job Event so that waiting threads (e.g. in
+      # EnsembleModel.__advanceModel) can block on event.wait() instead
+      # of polling isThisJobFinished().  Created inside the lock to
+      # guarantee the event exists before cleanJobQueue() could set it.
+      self.__jobEvents[runner.identifier] = threading.Event()
       if not runner.clientRunner:
         self.__queue.append(runner)
       else:
@@ -940,6 +979,33 @@ class JobHandler(BaseType):
     # problems.
     self.raiseAnError(RuntimeError,"Job "+identifier+" is unknown!")
 
+  def getJobEvent(self, identifier):
+    """
+      Return the threading.Event associated with a job identifier.
+
+      The returned Event is set (event.set()) by cleanJobQueue() when the
+      job transitions to the __finished state.  Callers can use
+      event.wait() to block efficiently without acquiring __queueLock,
+      which eliminates the lock contention that causes hangs when many
+      threads poll isThisJobFinished() concurrently.
+
+      If the job has already finished before this method is called, the
+      Event will already be in the set state, so event.wait() returns
+      immediately.
+
+      Returns None if the identifier is not found (e.g. job was never
+      submitted through reAddJob, or was already collected and cleaned up).
+
+      @ In, identifier, string, job identifier
+      @ Out, event, threading.Event or None, the completion event
+    """
+    identifier = identifier.strip()
+    with self.__queueLock:
+      event = self.__jobEvents.get(identifier)
+      if event is None:
+        self.raiseADebug(f'getJobEvent: no Event found for "{identifier}"')
+      return event
+
   def areTheseJobsFinished(self, uniqueHandler="any"):
     """
       Method to check if all the runs in the queue are finished
@@ -1041,6 +1107,10 @@ class JobHandler(BaseType):
       if removeFinished:
         for i in reversed(runsToBeRemoved):
           self.__finished[i].trackTime('collected')
+          # Remove the per-job Event to prevent memory leaks.  At this
+          # point the waiting thread has already been woken up (the Event
+          # was set in cleanJobQueue), so this is pure cleanup.
+          self.__jobEvents.pop(self.__finished[i].identifier, None)
           del self.__finished[i]
 
       # end with self.__queueLock
@@ -1201,6 +1271,14 @@ class JobHandler(BaseType):
             self.__finished.append(run)
             self.__finished[-1].trackTime('jobHandler_finished')
             runList[i] = None
+            # Wake up any thread waiting for this specific job to finish.
+            # This is the counterpart to event.wait() in
+            # EnsembleModel.__advanceModel().  The call is safe even when
+            # no thread is waiting (set() on an unwaited Event is a no-op
+            # that simply flips the internal flag).
+            event = self.__jobEvents.get(run.identifier)
+            if event is not None:
+              event.set()
 
   def setProfileJobs(self,profile=False):
     """
@@ -1218,6 +1296,9 @@ class JobHandler(BaseType):
     """
     with self.__queueLock:
       self.__submittedJobs = []
+      # Clear stale Events from the previous step.  Any new step will
+      # create fresh Events via reAddJob() as jobs are submitted.
+      self.__jobEvents.clear()
 
   def shutdown(self):
     """
@@ -1244,6 +1325,12 @@ class JobHandler(BaseType):
         for run in unfinishedRuns:
           run.kill()
 
+      # Discard all pending Events.  This is called by
+      # createCloneJobHandler() after deep-copying, so the cloned
+      # handler starts with a clean event registry.  It is also called
+      # on explicit termination to release resources.
+      self.__jobEvents.clear()
+
   def terminateJobs(self, ids):
     """
       Kills running jobs that match the given ids.
@@ -1262,6 +1349,12 @@ class JobHandler(BaseType):
             ids.remove(job.identifier)
             toRemove.append(job)
         for job in toRemove:
+          # Clean up the per-job completion Event for the terminated job.
+          # If a thread is waiting on this Event, it holds its own
+          # reference and will not crash; however, the Event will never
+          # be set, so the thread will eventually time out.  This is the
+          # expected behavior for a forcibly killed job.
+          self.__jobEvents.pop(job.identifier, None)
           # for fixed-spot queues, need to replace job with None not remove
           if isinstance(queue,list):
             job.kill()

--- a/ravenframework/MessageHandler.py
+++ b/ravenframework/MessageHandler.py
@@ -117,6 +117,8 @@ class MessageHandler(object):
   def printWarnings(self):
     """
       Prints a summary of warnings collected during the run.
+      After printing, clears the warning list so they are not re-printed
+      on subsequent calls (e.g. when error() triggers printWarnings()).
       @ In, None
       @ Out, None
     """
@@ -133,6 +135,9 @@ class MessageHandler(object):
         print('-'*50)
       else:
         print(f'There were {sum(self.warningCount)} warnings during the simulation run.')
+      # Clear after printing to prevent re-dumping on next error() call
+      self.warnings.clear()
+      self.warningCount.clear()
 
   def paint(self, string, color):
     """

--- a/ravenframework/Models/EnsembleModel.py
+++ b/ravenframework/Models/EnsembleModel.py
@@ -532,7 +532,10 @@ class EnsembleModel(Dummy):
     Input = self.createNewInput(myInput[0], samplerType, **kwargsToKeep)
 
     ## Unpack the specifics for this class, namely just the jobHandler
-    returnValue = (Input,self._externalRun(Input, jobHandler))
+    evaluation = self._externalRun(Input, jobHandler)
+    if evaluation is None:
+      return None
+    returnValue = (Input,evaluation)
     return returnValue
 
   def submit(self,myInput,samplerType,jobHandler,**kwargs):
@@ -716,10 +719,13 @@ class EnsembleModel(Dummy):
         ##if self.runInfoDict and 'Code' == self.modelsDictionary[modelIn]['Instance'].type:
         ##  inputKwargs[modelIn].update(self.runInfoDict)
 
-        retDict, gotOuts, evaluation = self.__advanceModel(identifier, self.modelsDictionary[modelIn],
-                                                        originalInput[modelIn], inputKwargs[modelIn],
-                                                        inRunTargetEvaluations[modelIn], samplerType,
-                                                        iterationCount, jobHandler)
+        evaluationInfo = self.__advanceModel(identifier, self.modelsDictionary[modelIn],
+                                             originalInput[modelIn], inputKwargs[modelIn],
+                                             inRunTargetEvaluations[modelIn], samplerType,
+                                             iterationCount, jobHandler)
+        if evaluationInfo is None:
+          return None
+        retDict, gotOuts, evaluation = evaluationInfo
 
         returnDict[modelIn] = retDict
         typeOutputs[modelCnt] = inRunTargetEvaluations[modelIn].type
@@ -781,6 +787,7 @@ class EnsembleModel(Dummy):
       suffix = f"{utils.returnIdSeparator()}{inputKwargs['batchRun']}"
     self.raiseADebug('Submitting model',modelToExecute['Instance'].name)
     localIdentifier = f"{modelToExecute['Instance'].name}{utils.returnIdSeparator()}{identifier}{suffix}"
+    excType, excValue, excTrace = RuntimeError, RuntimeError("Model returned no evaluation"), None
     if self.parallelStrategy == 1:
       # we evaluate the model directly
       try:
@@ -794,9 +801,46 @@ class EnsembleModel(Dummy):
         # run the model
         inputKwargs.pop("jobHandler", None)
         modelToExecute['Instance'].submit(origInputList, samplerType, jobHandler, **inputKwargs)
-        ## wait until the model finishes, in order to get ready to run the subsequential one
-        while not jobHandler.isThisJobFinished(localIdentifier):
-          time.sleep(1.e-3)
+        ## Wait for the sub-model job to finish.
+        #
+        # Historical context (lock contention bug):
+        #   The original implementation polled isThisJobFinished() in a
+        #   while/sleep loop.  Each call acquires JobHandler.__queueLock.
+        #   With N evaluation threads (e.g. 100 GA populations) all
+        #   polling concurrently, the resulting N lock-requests/sec can
+        #   starve the single polling thread in JobHandler.startLoop(),
+        #   which also needs the lock to run fillJobQueue() and
+        #   cleanJobQueue().  When the polling thread is starved, jobs
+        #   that have already finished at the OS level never transition
+        #   from __running to __finished, causing a permanent hang.
+        #
+        # Fix:
+        #   Use a per-job threading.Event (created in reAddJob, set in
+        #   cleanJobQueue) so that waiting threads block on event.wait()
+        #   instead of acquiring the lock.  This eliminates contention
+        #   entirely on the wait path.
+        #
+        # The timeout on event.wait() serves two purposes:
+        #   1. Python's Event.wait(None) is not interruptible by Ctrl+C
+        #      or POSIX signals (CPython limitation); a finite timeout
+        #      ensures the thread periodically regains control.
+        #   2. Acts as a safety net in case the Event is somehow missed
+        #      (should not happen in normal operation).
+        #
+        # Backward compatibility:
+        #   If getJobEvent() returns None (unexpected), we fall back to
+        #   the original polling loop so that non-standard JobHandler
+        #   subclasses or configurations still work.
+        jobEvent = jobHandler.getJobEvent(localIdentifier)
+        if jobEvent is not None:
+          while not jobEvent.wait(timeout=30.0):
+            pass
+        else:
+          # Fallback: original polling (should not be reached in normal use)
+          self.raiseAWarning(f'No Event found for job "{localIdentifier}", '
+                             f'falling back to polling-based wait')
+          while not jobHandler.isThisJobFinished(localIdentifier):
+            time.sleep(1.0)
         moveOn = True
       # get job that just finished to gather the results
       finishedRun = jobHandler.getFinished(jobIdentifier = localIdentifier, uniqueHandler=f"{self.name}{identifier}{suffix}")
@@ -808,23 +852,35 @@ class EnsembleModel(Dummy):
           # the failure happened at the input creation stage
           excType, excValue, excTrace = IOError, IOError("Failure happened at the input creation stage. See trace above"), None
         evaluation = None
-        # the model failed
-        for modelToRemove in list(set(self.orderList) - set([modelToExecute['Instance'].name])):
-          jobHandler.getFinished(jobIdentifier = f"{modelToRemove}{utils.returnIdSeparator()}{identifier}{suffix}",
-                                 uniqueHandler = f"{self.name}{identifier}{suffix}")
+        # the model failed — clean up only models that were submitted
+        # BEFORE the failed model (they may be running or finished).
+        # Models AFTER the failed one in orderList were never submitted,
+        # so calling getFinished for them would block indefinitely.
+        failedModelIdx = self.orderList.index(modelToExecute['Instance'].name)
+        for modelToRemove in self.orderList[:failedModelIdx]:
+          try:
+            jobHandler.getFinished(jobIdentifier = f"{modelToRemove}{utils.returnIdSeparator()}{identifier}{suffix}",
+                                   uniqueHandler = f"{self.name}{identifier}{suffix}")
+          except Exception:
+            pass  # best-effort cleanup
 
       else:
         # collect the target evaluation
         modelToExecute['Instance'].collectOutput(finishedRun[0],inRunTargetEvaluations)
 
-    if not evaluation:
-      # the model failed
+    if evaluation is None:
+      # A failed sub-model should make the enclosing EnsembleModel job fail the
+      # same way a standalone Code model fails: return no evaluation and let the
+      # JobHandler/MultiRun failure-handling path manage retries or failed runs.
+      # Raising here bypasses that generic path and can leave nested ensemble
+      # runs stuck with unclaimed internal jobs.
       import traceback
       msg = io.StringIO()
       traceback.print_exception(excType, excValue, excTrace, limit=10, file=msg)
       msg = msg.getvalue().replace('\n', '\n        ')
-      self.raiseAnError(RuntimeError, f'The Model "{modelToExecute["Instance"].name}" id "{localIdentifier}" '+
-                        f'failed! Trace:\n{"*"*72}\n{msg}\n{"*"*72}')
+      self.raiseAWarning(f'The Model "{modelToExecute["Instance"].name}" id "{localIdentifier}" '+
+                         f'failed! Trace:\n{"*"*72}\n{msg}\n{"*"*72}')
+      return None
     else:
       if self.parallelStrategy == 1:
         inRunTargetEvaluations.addRealization(evaluation)

--- a/ravenframework/Models/EnsembleModel.py
+++ b/ravenframework/Models/EnsembleModel.py
@@ -89,6 +89,7 @@ class EnsembleModel(Dummy):
     self.printTag               = 'EnsembleModel MODEL' # print tag
     self.parallelStrategy = 1                           # parallel strategy [1=MPI like (internalParallel), 2=threads]
     self.runInfoDict = None                             # dictionary containing run info in case of parallelStrategy=2
+    self.pollingInterval = 0.1                          # polling interval for fallback polling
     # assembler objects to be requested
     self.addAssemblerObject('Model', InputData.Quantity.one_to_infinity)
     self.addAssemblerObject('TargetEvaluation', InputData.Quantity.one_to_infinity)
@@ -170,6 +171,8 @@ class EnsembleModel(Dummy):
               self.initialConditions[var.tag] = float(values[0]) if len(values) == 1 else np.asarray([float(varValue) for varValue in values])
             except:
               self.raiseAnError(IOError,"unable to read text from XML node "+var.tag)
+      elif child.tag == 'pollingInterval':
+        self.pollingInterval = float(child.text)
 
   def __findMatchingModel(self,what,subWhat):
     """
@@ -834,7 +837,7 @@ class EnsembleModel(Dummy):
           self.raiseAWarning(f'No Event found for job "{localIdentifier}", '
                              f'falling back to polling-based wait')
           while not jobHandler.isThisJobFinished(localIdentifier):
-            time.sleep(0.1)
+            time.sleep(self.pollingInterval)
         moveOn = True
       # get job that just finished to gather the results
       finishedRun = jobHandler.getFinished(jobIdentifier = localIdentifier, uniqueHandler=f"{self.name}{identifier}{suffix}")

--- a/ravenframework/Models/EnsembleModel.py
+++ b/ravenframework/Models/EnsembleModel.py
@@ -820,27 +820,21 @@ class EnsembleModel(Dummy):
         #   instead of acquiring the lock.  This eliminates contention
         #   entirely on the wait path.
         #
-        # The timeout on event.wait() serves two purposes:
-        #   1. Python's Event.wait(None) is not interruptible by Ctrl+C
-        #      or POSIX signals (CPython limitation); a finite timeout
-        #      ensures the thread periodically regains control.
-        #   2. Acts as a safety net in case the Event is somehow missed
-        #      (should not happen in normal operation).
-        #
         # Backward compatibility:
         #   If getJobEvent() returns None (unexpected), we fall back to
         #   the original polling loop so that non-standard JobHandler
         #   subclasses or configurations still work.
         jobEvent = jobHandler.getJobEvent(localIdentifier)
         if jobEvent is not None:
-          while not jobEvent.wait(timeout=30.0):
-            pass
+          jobEvent.wait()
         else:
-          # Fallback: original polling (should not be reached in normal use)
+          # Fallback: polling (should not be reached in normal use).  Use
+          # a moderate interval since this path still takes the JobHandler
+          # queue lock.
           self.raiseAWarning(f'No Event found for job "{localIdentifier}", '
                              f'falling back to polling-based wait')
           while not jobHandler.isThisJobFinished(localIdentifier):
-            time.sleep(1.0)
+            time.sleep(0.1)
         moveOn = True
       # get job that just finished to gather the results
       finishedRun = jobHandler.getFinished(jobIdentifier = localIdentifier, uniqueHandler=f"{self.name}{identifier}{suffix}")
@@ -852,17 +846,10 @@ class EnsembleModel(Dummy):
           # the failure happened at the input creation stage
           excType, excValue, excTrace = IOError, IOError("Failure happened at the input creation stage. See trace above"), None
         evaluation = None
-        # the model failed — clean up only models that were submitted
-        # BEFORE the failed model (they may be running or finished).
-        # Models AFTER the failed one in orderList were never submitted,
-        # so calling getFinished for them would block indefinitely.
-        failedModelIdx = self.orderList.index(modelToExecute['Instance'].name)
-        for modelToRemove in self.orderList[:failedModelIdx]:
-          try:
-            jobHandler.getFinished(jobIdentifier = f"{modelToRemove}{utils.returnIdSeparator()}{identifier}{suffix}",
-                                   uniqueHandler = f"{self.name}{identifier}{suffix}")
-          except Exception:
-            pass  # best-effort cleanup
+        # No additional sub-model cleanup is needed for this ensemble
+        # evaluation: previous sub-models were already collected, the
+        # failed sub-model was just collected above, and downstream
+        # sub-models have not been submitted yet.
 
       else:
         # collect the target evaluation

--- a/tests/framework/unit_tests/JobHandler/testJobHandlerEvents.py
+++ b/tests/framework/unit_tests/JobHandler/testJobHandlerEvents.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Battelle Energy Alliance, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+  Unit tests for JobHandler per-job completion events.
+"""
+
+from __future__ import division, print_function, unicode_literals, absolute_import
+
+import os
+import sys
+
+ravenDir = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), os.pardir, os.pardir, os.pardir, os.pardir))
+frameworkDir = os.path.join(ravenDir, 'framework')
+sys.path.append(ravenDir)
+
+from ravenframework import JobHandler
+from ravenframework.utils import utils
+
+utils.find_crow(frameworkDir)
+
+results = {"pass": 0, "fail": 0}
+
+
+def checkTrue(comment, value):
+  """
+    Check that a condition is true.
+    @ In, comment, str, description of the check
+    @ In, value, bool, condition value
+    @ Out, None
+  """
+  if value:
+    results["pass"] += 1
+  else:
+    print("checking answer", comment, "is not True")
+    results["fail"] += 1
+
+
+def checkEqual(comment, value, expected):
+  """
+    Check that two values are equal.
+    @ In, comment, str, description of the check
+    @ In, value, object, actual value
+    @ In, expected, object, expected value
+    @ Out, None
+  """
+  if value == expected:
+    results["pass"] += 1
+  else:
+    print("checking answer", comment, value, "!=", expected)
+    results["fail"] += 1
+
+
+class FinishedRunner:
+  """
+    Minimal runner that becomes done immediately after start.
+  """
+  def __init__(self, identifier):
+    """
+      Constructor.
+      @ In, identifier, str, runner identifier
+      @ Out, None
+    """
+    self.identifier = identifier
+    self.uniqueHandler = "any"
+    self.groupId = None
+    self.clientRunner = False
+    self.args = []
+    self.started = False
+    self.times = []
+
+  def start(self):
+    """
+      Mark the runner as started.
+      @ In, None
+      @ Out, None
+    """
+    self.started = True
+
+  def isDone(self):
+    """
+      Report completion status.
+      @ In, None
+      @ Out, bool, True once started
+    """
+    return self.started
+
+  def trackTime(self, event):
+    """
+      Record timing labels requested by JobHandler.
+      @ In, event, str, timing event
+      @ Out, None
+    """
+    self.times.append(event)
+
+  def getReturnCode(self):
+    """
+      Return successful execution.
+      @ In, None
+      @ Out, int, zero return code
+    """
+    return 0
+
+  def getMetadata(self):
+    """
+      Return no metadata.
+      @ In, None
+      @ Out, None
+    """
+    return None
+
+  def kill(self):
+    """
+      Runner kill hook.
+      @ In, None
+      @ Out, None
+    """
+    pass
+
+
+runInfo = {
+  "maxQueueSize": 1,
+  "batchSize": 1,
+  "parallelMethod": None,
+  "internalParallel": False,
+  "Nodes": [],
+}
+
+handler = JobHandler.JobHandler()
+handler.applyRunInfo(runInfo)
+handler.initialize()
+
+runner = FinishedRunner("job_event_test")
+handler.reAddJob(runner)
+
+event = handler.getJobEvent("job_event_test")
+checkTrue("event created by reAddJob", event is not None)
+checkTrue("event initially unset", not event.is_set())
+
+handler.fillJobQueue()
+checkTrue("runner started by fillJobQueue", runner.started)
+checkTrue("event still unset while runner has not been cleaned", not event.is_set())
+
+handler.cleanJobQueue()
+checkTrue("event set by cleanJobQueue", event.is_set())
+checkTrue("isThisJobFinished sees finished runner", handler.isThisJobFinished("job_event_test"))
+
+finished = handler.getFinished(jobIdentifier="job_event_test")
+checkEqual("one finished runner returned", len(finished), 1)
+checkTrue("finished runner is original runner", finished[0] is runner)
+checkTrue("event removed after getFinished cleanup", handler.getJobEvent("job_event_test") is None)
+
+print(results)
+sys.exit(results["fail"])

--- a/tests/framework/unit_tests/JobHandler/tests
+++ b/tests/framework/unit_tests/JobHandler/tests
@@ -1,0 +1,6 @@
+[Tests]
+ [./jobHandlerEvents]
+  type = 'RavenPython'
+  input = 'testJobHandlerEvents.py'
+ [../]
+[]


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#2567 

##### What are the significant changes in functionality due to this change request?
This change stabilizes EnsembleModel job completion when using the threaded parallel strategy. Previously, each ensemble evaluation thread repeatedly polled `JobHandler.isThisJobFinished()`, which acquired the shared JobHandler queue lock. With many concurrent ensemble evaluations, this polling could create enough lock contention to prevent the JobHandler polling loop from promptly moving completed jobs into the finished queue, producing hangs even after subprocesses had completed.

The JobHandler now creates a per-job `threading.Event` when a job is submitted, sets that event when the job is moved to the finished queue, and exposes `getJobEvent()` so EnsembleModel can wait on job completion without repeatedly acquiring the queue lock. The previous polling path remains as a fallback if no event is available.

This PR also improves failed sub-model handling in EnsembleModel. Failed evaluations now return no evaluation and allow the existing failed-run handling path to process the failure, instead of raising immediately and potentially leaving nested ensemble jobs unclaimed. Cleanup is limited to models that were actually submitted before the failed model, avoiding waits on downstream models that were never launched.

Additionally, `MessageHandler.printWarnings()` now clears stored warnings after printing so warnings are not reprinted later by subsequent error handling. A focused JobHandler unit test was added to verify event creation, event signaling on completion, and event cleanup after finished-job collection.

  ##### Tests performed

The following checks were run in `/home/leec3/projects/raven_idaholab_issue2567`:

  - `python -m py_compile ravenframework/JobHandler.py ravenframework/MessageHandler.py ravenframework/Models/EnsembleModel.py tests/framework/unit_tests/JobHandler/testJobHandlerEvents.py`
  - `python -m py_compile ravenframework/CustomModes/PBSSimulationMode.py ravenframework/CustomModes/MPILegacySimulationMode.py`
  - `./run_tests --test-dir tests/framework/unit_tests/JobHandler`
  - `./run_tests --test-dir tests/framework/ensembleModelTests --re 'testEnsembleModelLinearThread|testEnsembleModelLinearExpectedFailure|testEnsembleModelWithCode' -j 3`
  - `git diff --check`

  Cluster/qsub validation was also run through Slurm:

  - Slurm job `1873408`
  - Command path: `./run_tests --raven --test-dir tests/cluster_tests/InternalParallel --re 'test_parallel_ensemble_linear' --run-types qsub -j 1`
  - Result: `COMPLETED`, exit code `0:0`
  - ROOK result: `PASSED: 1`, `FAILED: 0`
  - Final run_tests result: `Tested sets: RAVEN PluginAPI`, `... tests passed!`

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [x] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [x] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [x] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [x] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [x] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

