### PR TITLE
Register PRLO as an opt-in plugin submodule (update = none) (#2581)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,12 @@
 [submodule "plugins/DOVE"]
 	path = plugins/DOVE
 	url = https://github.com/idaholab/DOVE.git
+[submodule "plugins/PRLO"]
+	path = plugins/PRLO
+	url = https://github.inl.gov/congjian-wang/PRLO.git
+	# PRLO is access-controlled (INL-internal). `update = none` keeps it opt-in:
+	# `git clone --recursive` and a blanket `git submodule update --init` skip it,
+	# so the public clone/CI experience is unaffected for users without access.
+	# Licensed users fetch it explicitly: `git submodule update --init plugins/PRLO`
+	# (or `scripts/install_plugins.py PRLO`).
+	update = none


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address?
Closes #2581 
Registers the PRLO plugin (Plant Reload Process Optimization) as a RAVEN plugin
submodule so it can be discovered/installed through the standard plugin tooling.

##### What are the significant changes in functionality due to this change request?
- Adds `plugins/PRLO` to `.gitmodules`, pinned to PRLO `main` (a66c897).
- PRLO is INL-internal (access-controlled on github.inl.gov). The entry is marked
  `update = none`, so it is OPT-IN: a plain or `--recursive` clone and a blanket
  `git submodule update --init` skip it, leaving the public clone and CI experience
  unaffected for users without access. Licensed users fetch it explicitly:
  `git submodule update --init plugins/PRLO`  (or `scripts/install_plugins.py PRLO`).
- Only the submodule URL, path, and pinned commit are published; repository contents
  remain protected by github.inl.gov access control.

----------------
For Change Control Board: Change Request Review
----------------
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax... *(N/A — no input syntax change.)*
- [ ] 3. Make sure the Python code and commenting standards are respected... *(N/A — config only.)*
- [ ] 4. Regression tests have to complete successfully.  *(Please confirm idaholab CI
        submodule init respects `update = none` and does not attempt to fetch PRLO.)*
- [ ] 5. If significant functionality is added, there must be tests added... *(N/A.)*
- [ ] 6. The merge request must reference an issue.
