### PR TITLE
update Slurm with noSplitNode

### DIFF
--- a/ravenframework/CustomModes/SlurmSimulationMode.py
+++ b/ravenframework/CustomModes/SlurmSimulationMode.py
@@ -18,6 +18,7 @@ Module that contains a SimulationMode for Slurm and mpiexec
 import os
 import math
 import string
+import subprocess
 from ravenframework import Simulation
 from ravenframework.utils import InputData, InputTypes
 
@@ -46,7 +47,89 @@ class SlurmSimulationMode(Simulation.SimulationMode):
     self.__partition = None #If not none, use this for partition=
     self.__mpiparams = [] #Paramaters to give to mpi
     self.__createPrecommand = True #If true, do create precommand.
+    self.__runSbatch = False
+    self.__noSplitNode = False #If true, keep all MPI ranks for each batch on one physical node
+    self.__maxOnNode = None #Used with __noSplitNode to limit ranks used on one node
+    self.__noOverlap = False #Used with __noSplitNode to prevent multiple batches from sharing one node
+    self.__restrictScheduler = False #If true, add Slurm placement restrictions for noSplitNode at sbatch time
+    self.__exclusive = False #If true with __restrictScheduler, request exclusive nodes
     self.printTag = 'SLURM SIMULATION MODE'
+
+  def __generateSlurmNodeFile(self, nodeFile):
+    """
+      Generate a node file containing one hostname entry per allocated Slurm task.
+      @ In, nodeFile, str, node file path to create
+      @ Out, None
+    """
+    command = ["srun", "--overlap"]
+    slurmTasks = os.environ.get("SLURM_NTASKS", os.environ.get("SLURM_NPROCS", None))
+    if slurmTasks is not None:
+      command.extend(["-n", slurmTasks])
+    command.append("hostname")
+    with open(nodeFile, "w") as output:
+      subprocess.check_call(command, stdout=output)
+
+  def __writeSubNodeFile(self, workingDir, index, group):
+    """
+      Write one per-batch node file.
+      @ In, workingDir, str, base working directory
+      @ In, index, int, batch index
+      @ In, group, list(str), hostnames to write
+      @ Out, None
+    """
+    with open(os.path.join(workingDir, "node_" + str(index)), "w") as subNodeFile:
+      for node in group:
+        subNodeFile.write(node.strip() + "\n")
+
+  def __buildNoSplitNodeGroups(self, lines, numMPI):
+    """
+      Build groups of hostnames with each group entirely on one physical node.
+      @ In, lines, list(str), lines from the Slurm node file
+      @ In, numMPI, int, number of MPI ranks needed for each RAVEN batch member
+      @ Out, groups, list(list(str)), full no-split groups
+    """
+    nodes = [line.strip() for line in lines if line.strip()]
+    nodes.sort()
+    groups = []
+
+    def addGroupsForNode(node, slots):
+      """
+        Add as many full NumMPI groups as possible from a single node.
+        @ In, node, str, node name
+        @ In, slots, list(str), all available slots for this node
+        @ Out, None
+      """
+      if node is None or len(slots) == 0:
+        return
+      originalSlots = len(slots)
+      if self.__maxOnNode is not None:
+        slots = slots[:self.__maxOnNode]
+      fullGroups = len(slots) // numMPI
+      if self.__noOverlap and fullGroups > 0:
+        fullGroups = 1
+      for groupIndex in range(fullGroups):
+        start = groupIndex * numMPI
+        groups.append(slots[start:start+numMPI])
+      usedSlots = fullGroups * numMPI
+      if fullGroups == 0:
+        self.raiseAWarning("not using node " + str(node) + " because it only provides " + str(len(slots)) + " available processor(s), fewer than NumMPI " + str(numMPI))
+      elif not self.__noOverlap and len(slots) > usedSlots:
+        self.raiseAWarning("not using part of node " + str(node) + " because of partial group: " + str(slots[usedSlots:]))
+      elif self.__noOverlap and len(slots) > numMPI:
+        self.raiseADebug("not using extra processors on node " + str(node) + " because noOverlap is True")
+      if self.__maxOnNode is not None and originalSlots > len(slots):
+        self.raiseADebug("not using " + str(originalSlots - len(slots)) + " processor(s) on node " + str(node) + " because maxOnNode is " + str(self.__maxOnNode))
+
+    currentNode = None
+    currentSlots = []
+    for node in nodes:
+      if node != currentNode:
+        addGroupsForNode(currentNode, currentSlots)
+        currentNode = node
+        currentSlots = []
+      currentSlots.append(node)
+    addGroupsForNode(currentNode, currentSlots)
+    return groups
 
   def modifyInfo(self, runInfoDict):
     """
@@ -62,36 +145,51 @@ class SlurmSimulationMode(Simulation.SimulationMode):
       if not self.__nodeFile:
         self.__nodeFile = os.path.join(workingDir,"slurmNodeFile_"+str(os.getpid()))
         #generate nodeFile
-        os.system("srun --overlap -- hostname > "+self.__nodeFile)
+        self.__generateSlurmNodeFile(self.__nodeFile)
       self.raiseADebug('Setting up remote nodes based on "{}"'.format(self.__nodeFile))
       lines = open(self.__nodeFile,"r").readlines()
       #XXX This is an undocumented way to pass information back
       newRunInfo['Nodes'] = list(lines)
       numMPI = runInfoDict['NumMPI']
       oldBatchsize = runInfoDict['batchSize']
-      #the batchsize is just the number of nodes of which there is one
-      # per line in the nodeFile divided by the numMPI (which is per run)
-      # and the floor and int and max make sure that the numbers are reasonable
-      maxBatchsize = max(int(math.floor(len(lines) / numMPI)), 1)
-
-      if maxBatchsize < oldBatchsize:
-        newRunInfo['batchSize'] = maxBatchsize
-        self.raiseAWarning("changing batchsize from "+str(oldBatchsize)+" to "+str(maxBatchsize)+" to fit on "+str(len(lines))+" processors")
-      newBatchsize = newRunInfo['batchSize']
-      self.raiseADebug('Batch size is "{}"'.format(newBatchsize))
-      if newBatchsize > 1:
-        #need to split node lines so that numMPI nodes are available per run
-        workingDir = runInfoDict['WorkingDir']
-        for i in range(newBatchsize):
-          subNodeFile = open(os.path.join(workingDir, f"node_{i}"), "w")
-          for line in lines[i*numMPI : (i+1) * numMPI]:
-            subNodeFile.write(line)
-          subNodeFile.close()
-        #then give each index a separate file.
-        nodeCommand = runInfoDict["NodeParameter"]+" %BASE_WORKING_DIR%/node_%INDEX% "
+      if self.__noSplitNode:
+        groups = self.__buildNoSplitNodeGroups(lines, numMPI)
+        maxBatchsize = len(groups)
+        if maxBatchsize == 0:
+          self.raiseAnError(IOError, "Cannot run with given parameters because no Slurm nodes have NumMPI " + str(numMPI) + " available and noSplitNode is True")
+        if maxBatchsize < oldBatchsize:
+          newRunInfo['batchSize'] = maxBatchsize
+          self.raiseAWarning("changing batchsize from " + str(oldBatchsize) + " to " + str(maxBatchsize) + " because noSplitNode is True and only " + str(maxBatchsize) + " full node group(s) are available")
+        newBatchsize = newRunInfo['batchSize']
+        self.raiseADebug('Batch size is "{}"'.format(newBatchsize))
+        for i, group in enumerate(groups[:newBatchsize]):
+          self.__writeSubNodeFile(workingDir, i, group)
+        if newBatchsize > 1:
+          #then give each index a separate file.
+          nodeCommand = runInfoDict["NodeParameter"]+" %BASE_WORKING_DIR%/node_%INDEX% "
+        else:
+          #For true noSplitNode, even a single batch must use the selected single-node file.
+          nodeCommand = runInfoDict["NodeParameter"]+" "+os.path.join(workingDir, "node_0")
       else:
-        #If only one batch just use original node file
-        nodeCommand = runInfoDict["NodeParameter"]+" "+self.__nodeFile
+        #the batchsize is just the number of nodes of which there is one
+        # per line in the nodeFile divided by the numMPI (which is per run)
+        # and the floor and int and max make sure that the numbers are reasonable
+        maxBatchsize = max(int(math.floor(len(lines) / numMPI)), 1)
+        if maxBatchsize < oldBatchsize:
+          newRunInfo['batchSize'] = maxBatchsize
+          self.raiseAWarning("changing batchsize from "+str(oldBatchsize)+" to "+str(maxBatchsize)+" to fit on "+str(len(lines))+" processors")
+        newBatchsize = newRunInfo['batchSize']
+        self.raiseADebug('Batch size is "{}"'.format(newBatchsize))
+        if newBatchsize > 1:
+          #need to split node lines so that numMPI nodes are available per run
+          workingDir = runInfoDict['WorkingDir']
+          for i in range(newBatchsize):
+            self.__writeSubNodeFile(workingDir, i, lines[i*numMPI : (i+1) * numMPI])
+          #then give each index a separate file.
+          nodeCommand = runInfoDict["NodeParameter"]+" %BASE_WORKING_DIR%/node_%INDEX% "
+        else:
+          #If only one batch just use original node file
+          nodeCommand = runInfoDict["NodeParameter"]+" "+self.__nodeFile
 
     else:
       #Not in PBS, so can't look at PBS_NODEFILE and none supplied in input
@@ -117,6 +215,52 @@ class SlurmSimulationMode(Simulation.SimulationMode):
       newRunInfo['postcommand'] =" {} {}".format(newRunInfo['threadParameter'],runInfoDict['postcommand'])
     self.raiseAMessage("precommand: "+newRunInfo['precommand']+", postcommand: "+newRunInfo.get('postcommand',runInfoDict['postcommand']))
     return newRunInfo
+
+  def __getClusterParameterNames(self, clusterParameters):
+    """
+      Extract Slurm option names from the user-provided cluster parameters.
+      @ In, clusterParameters, list(str), Slurm options supplied by the user
+      @ Out, names, set(str), normalized option names
+    """
+    names = set()
+    for param in clusterParameters:
+      if not isinstance(param, str):
+        continue
+      if param.startswith("--"):
+        names.add(param.split("=", 1)[0])
+      elif param in ("-N", "-n", "-c"):
+        names.add(param)
+    return names
+
+  def __getNoSplitSchedulerParameters(self, runInfoDict, coresNeeded):
+    """
+      Build strict Slurm scheduler-side placement parameters for noSplitNode.
+      This uses one RAVEN batch member per physical node.
+      @ In, runInfoDict, dict, dictionary of run info
+      @ In, coresNeeded, int, requested Slurm task count
+      @ Out, schedulerParameters, list(str), extra sbatch parameters
+    """
+    if not (self.__noSplitNode and self.__restrictScheduler):
+      return []
+
+    batchSize = runInfoDict['batchSize']
+    numMPI = runInfoDict['NumMPI']
+    expectedTasks = batchSize * numMPI
+    if coresNeeded != expectedTasks:
+      self.raiseAnError(IOError, "When noSplitNode restrictScheduler is enabled, coresneeded must be omitted or equal to batchSize*NumMPI. Received coresneeded " + str(coresNeeded) + " but expected " + str(expectedTasks))
+
+    userParameterNames = self.__getClusterParameterNames(runInfoDict["clusterParameters"])
+    conflictingNames = sorted(userParameterNames.intersection(set(["--nodes", "-N", "--ntasks-per-node"])))
+    if len(conflictingNames) > 0:
+      self.raiseAWarning("clusterParameters already contains Slurm placement option(s) " + str(conflictingNames) + "; noSplitNode restrictScheduler will add strict placement options after them")
+
+    schedulerParameters = [
+      "--nodes=" + str(batchSize) + "-" + str(batchSize),
+      "--ntasks-per-node=" + str(numMPI)
+    ]
+    if self.__exclusive:
+      schedulerParameters.append("--exclusive")
+    return schedulerParameters
 
   def __createAndRunSbatch(self, runInfoDict):
     """
@@ -156,9 +300,11 @@ class SlurmSimulationMode(Simulation.SimulationMode):
     command_env.update(os.environ)
     command_env["COMMAND"] = raven + " " + " ".join(runInfoDict["SimulationFiles"])
     command_env["RAVEN_FRAMEWORK_DIR"] = frameworkDir
+    schedulerParameters = self.__getNoSplitSchedulerParameters(runInfoDict, coresNeeded)
     ## generate the command, which will be passed into "args" of subprocess.call
     command = ["sbatch","--job-name="+jobName]+\
               runInfoDict["clusterParameters"]+\
+              schedulerParameters+\
               ["--ntasks="+str(coresNeeded),
                "--cpus-per-task="+str(ncpus)]+\
                ([memString] if memString is not None else [])+\
@@ -203,11 +349,20 @@ class SlurmSimulationMode(Simulation.SimulationMode):
     """
     inputSpecification = InputData.parameterInputFactory("mode", ordered=False, contentType=InputTypes.StringType)
     inputSpecification.addSub(InputData.parameterInputFactory("runSbatch"))
+    inputSpecification.addSub(InputData.parameterInputFactory("nodefile", contentType=InputTypes.StringType))
     inputSpecification.addSub(InputData.parameterInputFactory("memory", contentType=InputTypes.StringType))
     inputSpecification.addSub(InputData.parameterInputFactory("coresneeded", contentType=InputTypes.IntegerType))
     inputSpecification.addSub(InputData.parameterInputFactory("partition", contentType=InputTypes.StringType))
     inputSpecification.addSub(InputData.parameterInputFactory("MPIParam", contentType=InputTypes.StringType))
+    for noSplitNodeName in ("noSplitNode", "nosplitnode"):
+      noSplitNodeInput = InputData.parameterInputFactory(noSplitNodeName)
+      noSplitNodeInput.addParam("maxOnNode", param_type=InputTypes.IntegerType)
+      noSplitNodeInput.addParam("noOverlap", param_type=InputTypes.BoolType)
+      noSplitNodeInput.addParam("restrictScheduler", param_type=InputTypes.BoolType)
+      noSplitNodeInput.addParam("exclusive", param_type=InputTypes.BoolType)
+      inputSpecification.addSub(noSplitNodeInput)
     inputSpecification.addSub(InputData.parameterInputFactory("noprecommand"))
+    inputSpecification.addSub(InputData.parameterInputFactory("noPrecommand"))
     return inputSpecification
 
   def handleInput(self, paramInput):
@@ -217,17 +372,24 @@ class SlurmSimulationMode(Simulation.SimulationMode):
       @ Out, None
     """
     for child in paramInput.subparts:
-      if child.getName() == "nodefile":
+      childName = child.getName().lower()
+      if childName == "nodefile":
         self.__nodeFile = child.value.strip()
-      elif child.getName() == "memory":
+      elif childName == "memory":
         self.__memNeeded = child.value.strip()
-      elif child.getName() == "coresneeded":
+      elif childName == "coresneeded":
         self.__coresNeeded = child.value
-      elif child.getName() == "partition":
+      elif childName == "partition":
         self.__partition = child.value.strip()
-      elif child.getName() == "runSbatch":
+      elif childName == "runsbatch":
         self.__runSbatch = True
-      elif child.getName() == "MPIParam":
+      elif childName == "mpiparam":
         self.__mpiparams.append(child.value.strip())
-      elif child.getName() == "noPrecommand":
+      elif childName == "nosplitnode":
+        self.__noSplitNode = True
+        self.__maxOnNode = child.parameterValues.get("maxOnNode", None)
+        self.__noOverlap = child.parameterValues.get("noOverlap", False)
+        self.__restrictScheduler = child.parameterValues.get("restrictScheduler", False)
+        self.__exclusive = child.parameterValues.get("exclusive", False)
+      elif childName == "noprecommand":
         self.__createPrecommand = False


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?


----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

